### PR TITLE
Fix v1.2.1 manifest checksum and automate future updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,23 @@ jobs:
         with:
           files: /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip
           generate_release_notes: true
+
+      - name: Update manifest checksum
+        run: |
+          CHECKSUM=$(md5sum /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip | awk '{print $1}')
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
+          # Use jq to update the checksum for the matching version entry
+          jq --arg ver "${VERSION}.0" --arg cs "$CHECKSUM" \
+            '.[0].versions |= map(if .version == $ver then .checksum = $cs else . end)' \
+            manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+
+      - name: Commit manifest update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git diff --cached --quiet && exit 0
+          git commit -m "Update manifest checksum for ${{ github.ref_name }}"
+          git push origin HEAD:main

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         "changelog": "Fix sync history persistence across version upgrades",
         "targetAbi": "10.11.0.0",
         "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.2.1/jellyfin-plugin-letterboxd-v1.2.1.zip",
-        "checksum": "7098365419ed33169dcdea7bd0daa0c2",
+        "checksum": "4a9dc0f75d90c945b1aa30e1b353ad63",
         "timestamp": "2026-03-26T01:00:00Z"
       },
       {


### PR DESCRIPTION
## Summary
- Fix incorrect MD5 checksum for v1.2.1 in manifest.json (`7098365419ed33169dcdea7bd0daa0c2` → `4a9dc0f75d90c945b1aa30e1b353ad63`)
- Automate checksum updates in the release workflow so the manifest is always correct after tagging a release

## What happened
The v1.2.1 checksum was manually entered in the manifest and didn't match the actual zip file, preventing users from installing the plugin.

## Changes
- **manifest.json**: Corrected the v1.2.1 checksum to match the actual release artifact
- **.github/workflows/release.yml**: Added steps to automatically compute the MD5 checksum after packaging and commit the updated manifest back to main

Closes #1