### PR TITLE
Add real-time playback sync and auto re-auth

### DIFF
--- a/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
+++ b/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/LetterboxdSync.Tests/PlaybackHandlerTests.cs
+++ b/LetterboxdSync.Tests/PlaybackHandlerTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using LetterboxdSync;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class ServiceRegistratorTests
+{
+    [Fact]
+    public void RegisterServices_AddsPlaybackHandlerAsHostedService()
+    {
+        var services = new ServiceCollection();
+        var registrator = new ServiceRegistrator();
+
+        registrator.RegisterServices(services, null!);
+
+        var descriptor = Assert.Single(services);
+        Assert.Equal(typeof(Microsoft.Extensions.Hosting.IHostedService), descriptor.ServiceType);
+        Assert.Equal(typeof(PlaybackHandler), descriptor.ImplementationType);
+    }
+}
+
+public class ReauthTests
+{
+    private static readonly Uri BaseUri = new("https://letterboxd.com/");
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task MarkAsWatched_401ThenSuccess_ReauthenticatesAndRetries()
+    {
+        int logEntryCallCount = 0;
+        bool didLogin = false;
+
+        var handler = new MockHandler((request, client) =>
+        {
+            var path = request.RequestUri?.PathAndQuery ?? "";
+
+            // CSRF refresh — inject cookie into the container
+            if (request.Method == HttpMethod.Get && path == "/")
+            {
+                client._cookieContainer.Add(BaseUri, new Cookie("com.xk72.webparts.csrf", "testtoken"));
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            // Login page
+            if (request.Method == HttpMethod.Get && path.StartsWith("/sign-in"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "<input type=\"hidden\" name=\"__csrf\" value=\"formtoken\" />")
+                };
+            }
+
+            // Login POST
+            if (request.Method == HttpMethod.Post && path.Contains("login.do"))
+            {
+                didLogin = true;
+                client._cookieContainer.Add(BaseUri, new Cookie("letterboxd.user.CURRENT", "newSession"));
+                client._cookieContainer.Add(BaseUri, new Cookie("com.xk72.webparts.csrf", "newcsrf"));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"result\":\"success\"}")
+                };
+            }
+
+            // production-log-entries — first call returns 401, second returns 200
+            if (request.Method == HttpMethod.Post && path.Contains("production-log-entries"))
+            {
+                logEntryCallCount++;
+                if (logEntryCallCount == 1)
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"result\":\"success\"}")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = handler.CreateClient(TestLogger);
+
+        // Set stale cookies so HasAuthenticatedSession() returns true initially
+        client.SetRawCookies("letterboxd.user.CURRENT=staleSession; com.xk72.webparts.csrf=stalecsrf");
+        await client.AuthenticateAsync("testuser", "testpass");
+
+        // Should succeed after auto re-auth
+        await client.MarkAsWatchedAsync("test-film", "12345", DateTime.Now, false, "PROD1");
+
+        Assert.True(logEntryCallCount >= 2, $"Expected at least 2 calls to production-log-entries, got {logEntryCallCount}");
+        Assert.True(didLogin, "Expected a fresh login after 401");
+    }
+
+    [Fact]
+    public async Task ForceReauthenticate_ClearsSessionAndLogs()
+    {
+        int loginCount = 0;
+
+        var handler = new MockHandler((request, client) =>
+        {
+            var path = request.RequestUri?.PathAndQuery ?? "";
+
+            if (request.Method == HttpMethod.Get && path == "/")
+            {
+                client._cookieContainer.Add(BaseUri, new Cookie("com.xk72.webparts.csrf", "testtoken"));
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            if (request.Method == HttpMethod.Get && path.StartsWith("/sign-in"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "<input type=\"hidden\" name=\"__csrf\" value=\"formtoken\" />")
+                };
+            }
+
+            if (request.Method == HttpMethod.Post && path.Contains("login.do"))
+            {
+                loginCount++;
+                client._cookieContainer.Add(BaseUri, new Cookie("letterboxd.user.CURRENT", "freshSession"));
+                client._cookieContainer.Add(BaseUri, new Cookie("com.xk72.webparts.csrf", "freshcsrf"));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"result\":\"success\"}")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = handler.CreateClient(TestLogger);
+        client.SetRawCookies("letterboxd.user.CURRENT=staleSession; com.xk72.webparts.csrf=stalecsrf");
+
+        await client.AuthenticateAsync("testuser", "testpass");
+
+        // First auth should reuse session (no login call)
+        Assert.Equal(0, loginCount);
+
+        // Force re-auth should do a fresh login
+        await client.ForceReauthenticateAsync("testuser", "testpass");
+
+        Assert.Equal(1, loginCount);
+    }
+
+    /// <summary>
+    /// Mock handler that receives the LetterboxdClient so it can manipulate cookies directly.
+    /// </summary>
+    private class MockHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, LetterboxdClient, HttpResponseMessage> _responder;
+        private LetterboxdClient? _client;
+
+        public MockHandler(Func<HttpRequestMessage, LetterboxdClient, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        public LetterboxdClient CreateClient(ILogger logger)
+        {
+            var client = new LetterboxdClient(logger, this);
+            _client = client;
+            return client;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request, _client!));
+    }
+}

--- a/LetterboxdSync/LetterboxdClient.cs
+++ b/LetterboxdSync/LetterboxdClient.cs
@@ -25,6 +25,8 @@ public class LetterboxdClient : IDisposable
     private readonly HttpClient _client;
     private string _csrf = string.Empty;
     private string _username = string.Empty;
+    private string _password = string.Empty;
+    private bool _hasReauthenticated;
 
     public LetterboxdClient(ILogger logger)
     {
@@ -106,9 +108,20 @@ public class LetterboxdClient : IDisposable
         _csrf = token;
     }
 
+    public async Task ForceReauthenticateAsync(string username, string password)
+    {
+        // Clear session cookies so HasAuthenticatedSession() returns false
+        foreach (Cookie cookie in _cookieContainer.GetCookies(BaseUri))
+            cookie.Expired = true;
+
+        _logger.LogInformation("Forcing fresh login for {Username}", username);
+        await AuthenticateAsync(username, password).ConfigureAwait(false);
+    }
+
     public async Task AuthenticateAsync(string username, string password)
     {
         _username = username;
+        _password = password;
 
         if (HasAuthenticatedSession())
         {
@@ -428,6 +441,14 @@ public class LetterboxdClient : IDisposable
                 {
                     _logger.LogWarning("Endpoint {Endpoint} returned 404, trying next", endpoint);
                     continue;
+                }
+
+                if (res.StatusCode == HttpStatusCode.Unauthorized && !_hasReauthenticated)
+                {
+                    _logger.LogWarning("Got 401, session expired. Re-authenticating and retrying");
+                    _hasReauthenticated = true;
+                    await ForceReauthenticateAsync(_username!, _password!).ConfigureAwait(false);
+                    goto NextAttempt;
                 }
 
                 if (res.StatusCode == HttpStatusCode.Forbidden)

--- a/LetterboxdSync/LetterboxdClient.cs
+++ b/LetterboxdSync/LetterboxdClient.cs
@@ -20,7 +20,7 @@ public class LetterboxdClient : IDisposable
     private const int MaxRetries = 3;
 
     private readonly ILogger _logger;
-    private readonly CookieContainer _cookieContainer = new();
+    internal readonly CookieContainer _cookieContainer = new();
     private readonly HttpClientHandler _handler;
     private readonly HttpClient _client;
     private string _csrf = string.Empty;
@@ -29,16 +29,23 @@ public class LetterboxdClient : IDisposable
     private bool _hasReauthenticated;
 
     public LetterboxdClient(ILogger logger)
+        : this(logger, null)
+    {
+    }
+
+    internal LetterboxdClient(ILogger logger, HttpMessageHandler? handler)
     {
         _logger = logger;
-        _handler = new HttpClientHandler
+        _handler = handler as HttpClientHandler ?? new HttpClientHandler
         {
             CookieContainer = _cookieContainer,
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
             AllowAutoRedirect = true
         };
 
-        _client = new HttpClient(_handler) { BaseAddress = BaseUri };
+        _client = handler != null
+            ? new HttpClient(handler, disposeHandler: false) { BaseAddress = BaseUri }
+            : new HttpClient(_handler) { BaseAddress = BaseUri };
 
         _client.DefaultRequestHeaders.UserAgent.Clear();
         _client.DefaultRequestHeaders.UserAgent.ParseAdd(

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/ServiceRegistrator.cs
+++ b/LetterboxdSync/ServiceRegistrator.cs
@@ -1,0 +1,13 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LetterboxdSync;
+
+public class ServiceRegistrator : IPluginServiceRegistrator
+{
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddHostedService<PlaybackHandler>();
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.3.0.0",
+        "changelog": "Real-time playback sync via PlaybackHandler, automatic session re-auth on 401",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.3.0/jellyfin-plugin-letterboxd-v1.3.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-03-26T22:00:00Z"
+      },
+      {
         "version": "1.2.1.0",
         "changelog": "Fix sync history persistence across version upgrades",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
- Register `PlaybackHandler` as a hosted service via `IPluginServiceRegistrator` so it actually fires on playback stop events
- Auto re-authenticate with Letterboxd when a 401 is returned (expired session), avoiding manual cookie refresh
- Bump assembly version to 1.3.0.0

## Test plan
- [x] Played Mercy to completion, PlaybackHandler fired and synced to Letterboxd
- [x] 401 auto-retry worked — stale session was refreshed and diary entry succeeded on second attempt
- [x] Verified entry appeared on Letterboxd diary