### PR TITLE
User self-service account setup

### DIFF
--- a/LetterboxdSync.Tests/AccountTests.cs
+++ b/LetterboxdSync.Tests/AccountTests.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Linq;
+using LetterboxdSync.Api;
+using LetterboxdSync.Configuration;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class AccountUpdateRequestTests
+{
+    [Fact]
+    public void Defaults_AreCorrect()
+    {
+        var req = new AccountUpdateRequest();
+
+        Assert.Equal(string.Empty, req.LetterboxdUsername);
+        Assert.Equal(string.Empty, req.LetterboxdPassword);
+        Assert.Null(req.RawCookies);
+        Assert.False(req.Enabled);
+        Assert.False(req.SyncFavorites);
+        Assert.False(req.EnableDateFilter);
+        Assert.Equal(7, req.DateFilterDays);
+        Assert.False(req.EnableWatchlistSync);
+        Assert.False(req.EnableDiaryImport);
+    }
+
+    [Fact]
+    public void HasNoUserJellyfinIdField()
+    {
+        // Security: AccountUpdateRequest must NOT have UserJellyfinId
+        // to prevent users from writing to another user's account
+        var properties = typeof(AccountUpdateRequest).GetProperties();
+        Assert.DoesNotContain(properties, p => p.Name == "UserJellyfinId");
+    }
+
+    [Fact]
+    public void AllAccountFieldsAreMapped()
+    {
+        // Every writable field on Account (except UserJellyfinId) should have
+        // a corresponding field on AccountUpdateRequest
+        var accountProps = typeof(Account).GetProperties()
+            .Where(p => p.Name != "UserJellyfinId")
+            .Select(p => p.Name)
+            .ToHashSet();
+
+        var requestProps = typeof(AccountUpdateRequest).GetProperties()
+            .Select(p => p.Name)
+            .ToHashSet();
+
+        foreach (var prop in accountProps)
+        {
+            Assert.Contains(prop, requestProps);
+        }
+    }
+}
+
+public class TestConnectionRequestTests
+{
+    [Fact]
+    public void Defaults_AreCorrect()
+    {
+        var req = new TestConnectionRequest();
+
+        Assert.Equal(string.Empty, req.LetterboxdUsername);
+        Assert.Equal(string.Empty, req.LetterboxdPassword);
+        Assert.Null(req.RawCookies);
+    }
+
+    [Fact]
+    public void HasNoUserJellyfinIdField()
+    {
+        var properties = typeof(TestConnectionRequest).GetProperties();
+        Assert.DoesNotContain(properties, p => p.Name == "UserJellyfinId");
+    }
+}
+
+public class PluginConfigurationAccountTests
+{
+    [Fact]
+    public void FindOrCreate_FindsExistingAccount()
+    {
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account
+        {
+            UserJellyfinId = "abc123",
+            LetterboxdUsername = "existing"
+        });
+
+        var account = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "abc123");
+
+        Assert.NotNull(account);
+        Assert.Equal("existing", account!.LetterboxdUsername);
+    }
+
+    [Fact]
+    public void FindOrCreate_CreatesNewWhenNotFound()
+    {
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account
+        {
+            UserJellyfinId = "abc123",
+            LetterboxdUsername = "existing"
+        });
+
+        var account = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "xyz789");
+        Assert.Null(account);
+
+        // Simulate the PutAccount find-or-create pattern
+        account = new Account { UserJellyfinId = "xyz789" };
+        config.Accounts.Add(account);
+
+        Assert.Equal(2, config.Accounts.Count);
+        Assert.Equal("xyz789", config.Accounts[1].UserJellyfinId);
+    }
+
+    [Fact]
+    public void FindOrCreate_UpdatesExistingInPlace()
+    {
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account
+        {
+            UserJellyfinId = "abc123",
+            LetterboxdUsername = "old_username",
+            Enabled = false
+        });
+
+        var account = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "abc123")!;
+        account.LetterboxdUsername = "new_username";
+        account.Enabled = true;
+
+        // Should modify in place, not create duplicate
+        Assert.Single(config.Accounts);
+        Assert.Equal("new_username", config.Accounts[0].LetterboxdUsername);
+        Assert.True(config.Accounts[0].Enabled);
+    }
+
+    [Fact]
+    public void AccountLookup_MatchesOnUserJellyfinIdOnly()
+    {
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account { UserJellyfinId = "user1", LetterboxdUsername = "lb_user1" });
+        config.Accounts.Add(new Account { UserJellyfinId = "user2", LetterboxdUsername = "lb_user2" });
+
+        var found = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "user2");
+
+        Assert.NotNull(found);
+        Assert.Equal("lb_user2", found!.LetterboxdUsername);
+    }
+
+    [Fact]
+    public void ApplyUpdateRequest_CopiesAllFields()
+    {
+        var account = new Account { UserJellyfinId = "user1" };
+        var request = new AccountUpdateRequest
+        {
+            LetterboxdUsername = "testuser",
+            LetterboxdPassword = "testpass",
+            RawCookies = "cf_clearance=abc",
+            Enabled = true,
+            SyncFavorites = true,
+            EnableDateFilter = true,
+            DateFilterDays = 14,
+            EnableWatchlistSync = true,
+            EnableDiaryImport = true
+        };
+
+        // Simulate the PutAccount field copy
+        account.LetterboxdUsername = request.LetterboxdUsername;
+        account.LetterboxdPassword = request.LetterboxdPassword;
+        account.RawCookies = request.RawCookies;
+        account.Enabled = request.Enabled;
+        account.SyncFavorites = request.SyncFavorites;
+        account.EnableDateFilter = request.EnableDateFilter;
+        account.DateFilterDays = request.DateFilterDays;
+        account.EnableWatchlistSync = request.EnableWatchlistSync;
+        account.EnableDiaryImport = request.EnableDiaryImport;
+
+        Assert.Equal("testuser", account.LetterboxdUsername);
+        Assert.Equal("testpass", account.LetterboxdPassword);
+        Assert.Equal("cf_clearance=abc", account.RawCookies);
+        Assert.True(account.Enabled);
+        Assert.True(account.SyncFavorites);
+        Assert.True(account.EnableDateFilter);
+        Assert.Equal(14, account.DateFilterDays);
+        Assert.True(account.EnableWatchlistSync);
+        Assert.True(account.EnableDiaryImport);
+        // UserJellyfinId must not change
+        Assert.Equal("user1", account.UserJellyfinId);
+    }
+
+    [Fact]
+    public void MultipleUsers_IndependentAccounts()
+    {
+        var config = new PluginConfiguration();
+
+        // Simulate two users saving their accounts
+        var user1 = new Account { UserJellyfinId = "aaa", LetterboxdUsername = "alice", Enabled = true };
+        var user2 = new Account { UserJellyfinId = "bbb", LetterboxdUsername = "bob", Enabled = true };
+        config.Accounts.Add(user1);
+        config.Accounts.Add(user2);
+
+        // User1 updates their password
+        var found = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "aaa")!;
+        found.LetterboxdPassword = "newpass";
+
+        // User2 should be unaffected
+        var other = config.Accounts.FirstOrDefault(a => a.UserJellyfinId == "bbb")!;
+        Assert.Equal(string.Empty, other.LetterboxdPassword);
+        Assert.Equal("bob", other.LetterboxdUsername);
+    }
+}

--- a/LetterboxdSync.Tests/SidebarInjectionTests.cs
+++ b/LetterboxdSync.Tests/SidebarInjectionTests.cs
@@ -1,0 +1,145 @@
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class SidebarTransformTests
+{
+    [Fact]
+    public void Transform_InjectsScriptBeforeHeadClose()
+    {
+        var payload = new SidebarPatchPayload
+        {
+            Contents = "<html><head><title>Jellyfin</title></head><body></body></html>"
+        };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        Assert.Contains("<script src=\"/LetterboxdSync/Web/sidebar.js\" defer></script>", result);
+        Assert.Contains("</head>", result);
+        // Script should appear before </head>
+        var scriptIdx = result.IndexOf("sidebar.js");
+        var headIdx = result.IndexOf("</head>");
+        Assert.True(scriptIdx < headIdx);
+    }
+
+    [Fact]
+    public void Transform_DoesNotDoubleInject()
+    {
+        var payload = new SidebarPatchPayload
+        {
+            Contents = "<html><head><script src=\"/LetterboxdSync/Web/sidebar.js\" defer></script></head><body></body></html>"
+        };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        // Should return content unchanged
+        Assert.Equal(payload.Contents, result);
+    }
+
+    [Fact]
+    public void Transform_SkipsNonHtmlContent()
+    {
+        var jsContent = "\"use strict\";(self.webpackChunk=self.webpackChunk||[]).push([[17244],{session-login-index-html:function(){}}]);";
+        var payload = new SidebarPatchPayload { Contents = jsContent };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        // JS content without </head> should pass through unchanged
+        Assert.Equal(jsContent, result);
+        Assert.DoesNotContain("sidebar.js", result);
+    }
+
+    [Fact]
+    public void Transform_SkipsJsChunkWithIndexHtmlInName()
+    {
+        // This was the actual bug: JS chunks like "session-login-index-html.chunk.js"
+        // were being matched and corrupted with HTML injection
+        var jsContent = "(self.webpackChunk=self.webpackChunk||[]).push([[17244],{14999:function(t,e,a){a.r(e)}}]);";
+        var payload = new SidebarPatchPayload { Contents = jsContent };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        Assert.Equal(jsContent, result);
+        Assert.DoesNotContain("<script", result);
+    }
+
+    [Fact]
+    public void Transform_HandlesNullContents()
+    {
+        var payload = new SidebarPatchPayload { Contents = null };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        // Should return empty string, not throw
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Transform_HandlesEmptyContents()
+    {
+        var payload = new SidebarPatchPayload { Contents = string.Empty };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Transform_PreservesExistingContent()
+    {
+        var html = "<!doctype html><html><head><meta charset=\"utf-8\"><title>Jellyfin</title><script src=\"/Moonfin/Web/loader.js\" defer></script></head><body><div id=\"reactRoot\"></div></body></html>";
+        var payload = new SidebarPatchPayload { Contents = html };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        // Original content should be preserved
+        Assert.Contains("Moonfin/Web/loader.js", result);
+        Assert.Contains("<meta charset=\"utf-8\">", result);
+        Assert.Contains("<div id=\"reactRoot\">", result);
+        // Our script should be added
+        Assert.Contains("LetterboxdSync/Web/sidebar.js", result);
+    }
+
+    [Fact]
+    public void Transform_RealWorldIndexHtml_InjectsCorrectly()
+    {
+        // Simulate the actual Jellyfin index.html structure
+        var html = "<!doctype html><html class=\"preload\" dir=\"ltr\"><head><meta charset=\"utf-8\">"
+            + "<script defer src=\"main.jellyfin.bundle.js\"></script>"
+            + "<style>.headerMoonfinButton{opacity:.6}</style>"
+            + "<script src=\"/Moonfin/Web/loader.js\" defer></script>"
+            + "</head><body dir=\"ltr\"><div id=\"reactRoot\"></div></body></html>";
+
+        var payload = new SidebarPatchPayload { Contents = html };
+
+        var result = SidebarTransformCallback.Transform(payload);
+
+        // Count script tags - should have original 2 + our 1
+        var scriptCount = result.Split("<script").Length - 1;
+        Assert.Equal(3, scriptCount);
+
+        // Our injection should be right before </head>
+        var sidebarIdx = result.IndexOf("LetterboxdSync/Web/sidebar.js");
+        var headCloseIdx = result.IndexOf("</head>");
+        Assert.True(sidebarIdx > 0);
+        Assert.True(sidebarIdx < headCloseIdx);
+    }
+}
+
+public class SidebarPatchPayloadTests
+{
+    [Fact]
+    public void Contents_DefaultsToNull()
+    {
+        var payload = new SidebarPatchPayload();
+        Assert.Null(payload.Contents);
+    }
+
+    [Fact]
+    public void Contents_CanBeSetAndRead()
+    {
+        var payload = new SidebarPatchPayload { Contents = "test content" };
+        Assert.Equal("test content", payload.Contents);
+    }
+}

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -1,0 +1,31 @@
+namespace LetterboxdSync.Api;
+
+public class AccountUpdateRequest
+{
+    public string LetterboxdUsername { get; set; } = string.Empty;
+
+    public string LetterboxdPassword { get; set; } = string.Empty;
+
+    public string? RawCookies { get; set; }
+
+    public bool Enabled { get; set; }
+
+    public bool SyncFavorites { get; set; }
+
+    public bool EnableDateFilter { get; set; }
+
+    public int DateFilterDays { get; set; } = 7;
+
+    public bool EnableWatchlistSync { get; set; }
+
+    public bool EnableDiaryImport { get; set; }
+}
+
+public class TestConnectionRequest
+{
+    public string LetterboxdUsername { get; set; } = string.Empty;
+
+    public string LetterboxdPassword { get; set; } = string.Empty;
+
+    public string? RawCookies { get; set; }
+}

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -74,6 +74,106 @@ public class LetterboxdController : ControllerBase
         return Ok(events);
     }
 
+    [HttpGet("Account")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult GetAccount()
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        var account = Config.Accounts.FirstOrDefault(a => a.UserJellyfinId == userId);
+        if (account == null)
+        {
+            return Ok(new
+            {
+                letterboxdUsername = string.Empty,
+                letterboxdPassword = string.Empty,
+                rawCookies = (string?)null,
+                enabled = false,
+                syncFavorites = false,
+                enableDateFilter = false,
+                dateFilterDays = 7,
+                enableWatchlistSync = false,
+                enableDiaryImport = false,
+                isConfigured = false
+            });
+        }
+
+        return Ok(new
+        {
+            letterboxdUsername = account.LetterboxdUsername,
+            letterboxdPassword = account.LetterboxdPassword,
+            rawCookies = account.RawCookies,
+            enabled = account.Enabled,
+            syncFavorites = account.SyncFavorites,
+            enableDateFilter = account.EnableDateFilter,
+            dateFilterDays = account.DateFilterDays,
+            enableWatchlistSync = account.EnableWatchlistSync,
+            enableDiaryImport = account.EnableDiaryImport,
+            isConfigured = true
+        });
+    }
+
+    [HttpPut("Account")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult PutAccount([FromBody] AccountUpdateRequest request)
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        var account = Config.Accounts.FirstOrDefault(a => a.UserJellyfinId == userId);
+        if (account == null)
+        {
+            account = new Account { UserJellyfinId = userId };
+            Config.Accounts.Add(account);
+        }
+
+        account.LetterboxdUsername = request.LetterboxdUsername;
+        account.LetterboxdPassword = request.LetterboxdPassword;
+        account.RawCookies = request.RawCookies;
+        account.Enabled = request.Enabled;
+        account.SyncFavorites = request.SyncFavorites;
+        account.EnableDateFilter = request.EnableDateFilter;
+        account.DateFilterDays = request.DateFilterDays;
+        account.EnableWatchlistSync = request.EnableWatchlistSync;
+        account.EnableDiaryImport = request.EnableDiaryImport;
+
+        Plugin.Instance!.SaveConfiguration();
+        _logger.LogInformation("User {UserId} saved their Letterboxd account settings", userId);
+
+        return Ok(new { success = true });
+    }
+
+    [HttpPost("TestConnection")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> TestConnection([FromBody] TestConnectionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.LetterboxdUsername) || string.IsNullOrWhiteSpace(request.LetterboxdPassword))
+            return BadRequest(new { success = false, error = "Username and password are required" });
+
+        try
+        {
+            using var httpClient = new LetterboxdHttpClient(_logger);
+            var auth = new LetterboxdAuth(httpClient, _logger);
+
+            httpClient.SetRawCookies(request.RawCookies);
+            await auth.AuthenticateAsync(request.LetterboxdUsername, request.LetterboxdPassword)
+                .ConfigureAwait(false);
+
+            return Ok(new { success = true, letterboxdUsername = request.LetterboxdUsername });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Test connection failed for {Username}: {Message}", request.LetterboxdUsername, ex.Message);
+            return BadRequest(new { success = false, error = ex.Message });
+        }
+    }
+
     [HttpPost("Review")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -112,12 +212,13 @@ public class LetterboxdController : ControllerBase
             _logger.LogInformation("Posted review for {FilmSlug} by {Username}",
                 request.FilmSlug, account.LetterboxdUsername);
 
+            var jellyfinUsername = GetJellyfinUsername() ?? account.LetterboxdUsername;
             var status = request.IsRewatch ? SyncStatus.Rewatch : SyncStatus.Success;
             SyncHistory.Record(new SyncEvent
             {
                 FilmTitle = request.FilmSlug.Replace("-", " "),
                 FilmSlug = request.FilmSlug,
-                Username = account.LetterboxdUsername,
+                Username = jellyfinUsername,
                 Timestamp = DateTime.UtcNow,
                 Status = status,
                 Source = "review"
@@ -129,11 +230,12 @@ public class LetterboxdController : ControllerBase
         {
             _logger.LogError("Failed to post review for {FilmSlug}: {Message}", request.FilmSlug, ex.Message);
 
+            var jellyfinUsernameForError = GetJellyfinUsername() ?? account.LetterboxdUsername;
             SyncHistory.Record(new SyncEvent
             {
                 FilmTitle = request.FilmSlug.Replace("-", " "),
                 FilmSlug = request.FilmSlug,
-                Username = account.LetterboxdUsername,
+                Username = jellyfinUsernameForError,
                 Timestamp = DateTime.UtcNow,
                 Status = SyncStatus.Failed,
                 Error = ex.Message,

--- a/LetterboxdSync/Api/SidebarController.cs
+++ b/LetterboxdSync/Api/SidebarController.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LetterboxdSync.Api;
+
+[ApiController]
+[Route("LetterboxdSync/Web")]
+public class SidebarController : ControllerBase
+{
+    private readonly Assembly _assembly = typeof(SidebarController).Assembly;
+
+    [HttpGet("sidebar.js")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public IActionResult GetSidebarJs()
+    {
+        var stream = _assembly.GetManifestResourceStream("LetterboxdSync.Web.sidebar.js");
+        if (stream == null)
+        {
+            return NotFound();
+        }
+
+        return File(stream, "application/javascript");
+    }
+}

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
+    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <FileVersion>1.5.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,12 +18,15 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.6.11" />
     <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Web\configPage.html" />
     <EmbeddedResource Include="Web\configPage.js" />
     <EmbeddedResource Include="Web\statsPage.html" />
+    <EmbeddedResource Include="Web\userPage.html" />
+    <EmbeddedResource Include="Web\sidebar.js" />
   </ItemGroup>
 
 </Project>

--- a/LetterboxdSync/Plugin.cs
+++ b/LetterboxdSync/Plugin.cs
@@ -42,6 +42,11 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             {
                 Name = "letterboxdstats",
                 EmbeddedResourcePath = $"{GetType().Namespace}.Web.statsPage.html",
+            },
+            new PluginPageInfo
+            {
+                Name = "letterboxduser",
+                EmbeddedResourcePath = $"{GetType().Namespace}.Web.userPage.html",
             }
         };
     }

--- a/LetterboxdSync/SidebarInjection.cs
+++ b/LetterboxdSync/SidebarInjection.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Startup task that registers with File Transformation plugin to inject
+/// the Letterboxd sidebar link into index.html for all users.
+/// </summary>
+public class SidebarInjectionTask : IScheduledTask
+{
+    private readonly ILogger<SidebarInjectionTask> _logger;
+
+    public string Name => "Letterboxd Sidebar Registration";
+
+    public string Key => "LetterboxdSidebarInjection";
+
+    public string Description => "Registers sidebar link with File Transformation plugin.";
+
+    public string Category => "Letterboxd Sync";
+
+    public SidebarInjectionTask(ILogger<SidebarInjectionTask> logger)
+    {
+        _logger = logger;
+    }
+
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        return new[]
+        {
+            new TaskTriggerInfo { Type = TaskTriggerInfoType.StartupTrigger }
+        };
+    }
+
+    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        progress.Report(10);
+
+        try
+        {
+            RegisterWithFileTransformation();
+            _logger.LogInformation("Letterboxd sidebar injection registered successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Sidebar injection failed: {Error}", ex.Message);
+            _logger.LogDebug(ex, "Full sidebar injection error");
+        }
+
+        progress.Report(100);
+        return Task.CompletedTask;
+    }
+
+    private void RegisterWithFileTransformation()
+    {
+        Assembly? ftAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(x => x.FullName?.Contains(".FileTransformation") ?? false);
+
+        if (ftAssembly == null)
+        {
+            ftAssembly = AssemblyLoadContext.All
+                .SelectMany(x => x.Assemblies)
+                .FirstOrDefault(x => x.FullName?.Contains(".FileTransformation") ?? false);
+        }
+
+        if (ftAssembly == null)
+        {
+            _logger.LogDebug("File Transformation plugin not installed, skipping sidebar injection");
+            return;
+        }
+
+        Type? pluginInterface = ftAssembly.GetType("Jellyfin.Plugin.FileTransformation.PluginInterface");
+        if (pluginInterface == null)
+        {
+            _logger.LogWarning("File Transformation PluginInterface type not found");
+            return;
+        }
+
+        var registerMethod = pluginInterface.GetMethod("RegisterTransformation");
+        if (registerMethod == null)
+        {
+            _logger.LogWarning("RegisterTransformation method not found");
+            return;
+        }
+
+        // Build the JObject using File Transformation's own Newtonsoft assembly
+        // to avoid type identity mismatch between different loaded copies
+        Assembly? newtonsoftAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Newtonsoft.Json"
+                && a != typeof(Newtonsoft.Json.Linq.JObject).Assembly);
+
+        // Fall back to any loaded copy
+        if (newtonsoftAssembly == null)
+        {
+            newtonsoftAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "Newtonsoft.Json");
+        }
+
+        if (newtonsoftAssembly == null)
+        {
+            _logger.LogWarning("Newtonsoft.Json assembly not found");
+            return;
+        }
+
+        Type? jObjectType = newtonsoftAssembly.GetType("Newtonsoft.Json.Linq.JObject");
+        Type? jPropertyType = newtonsoftAssembly.GetType("Newtonsoft.Json.Linq.JProperty");
+
+        if (jObjectType == null || jPropertyType == null)
+        {
+            _logger.LogWarning("Could not find JObject/JProperty types in Newtonsoft.Json");
+            return;
+        }
+
+        var jObj = Activator.CreateInstance(jObjectType)!;
+        var addMethod = jObjectType.GetMethod("Add", new[] { typeof(object) });
+
+        void AddProp(string name, string value)
+        {
+            var prop = Activator.CreateInstance(jPropertyType, name, (object)value)!;
+            addMethod!.Invoke(jObj, new[] { prop });
+        }
+
+        AddProp("id", Guid.NewGuid().ToString());
+        AddProp("fileNamePattern", "index.html");
+        AddProp("callbackAssembly", typeof(SidebarTransformCallback).Assembly.FullName!);
+        AddProp("callbackClass", typeof(SidebarTransformCallback).FullName!);
+        AddProp("callbackMethod", nameof(SidebarTransformCallback.Transform));
+
+        _logger.LogInformation("Registering sidebar transformation with File Transformation plugin");
+        registerMethod.Invoke(null, new[] { jObj });
+    }
+}
+
+public static class SidebarTransformCallback
+{
+    public static string Transform(SidebarPatchPayload payload)
+    {
+        var contents = payload.Contents ?? string.Empty;
+
+        // Only transform actual HTML files, not JS chunks with "index-html" in their name
+        if (!contents.Contains("</head>") || contents.Contains("LetterboxdSync/Web/sidebar.js"))
+        {
+            return contents;
+        }
+
+        var injection = "<script src=\"/LetterboxdSync/Web/sidebar.js\" defer></script>";
+        return contents.Replace("</head>", $"{injection}\n</head>");
+    }
+}
+
+public class SidebarPatchPayload
+{
+    public string? Contents { get; set; }
+}

--- a/LetterboxdSync/Web/sidebar.js
+++ b/LetterboxdSync/Web/sidebar.js
@@ -1,0 +1,25 @@
+(function() {
+    function addLbLink() {
+        if (document.getElementById("lb-nav-link")) return;
+        var settingsLink = document.querySelector(".btnSettings");
+        if (!settingsLink) return;
+        var link = document.createElement("a");
+        link.id = "lb-nav-link";
+        link.setAttribute("is", "emby-linkbutton");
+        link.className = "navMenuOption lnkMediaFolder";
+        link.href = "#";
+        link.innerHTML = '<span class="material-icons navMenuOptionIcon movie_filter" aria-hidden="true"></span><span class="navMenuOptionText">Letterboxd</span>';
+        link.addEventListener("click", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            window.location.assign("/web/configurationpage?name=letterboxduser");
+        });
+        settingsLink.parentElement.insertBefore(link, settingsLink);
+    }
+    setInterval(addLbLink, 2000);
+    if (document.readyState === "complete") {
+        setTimeout(addLbLink, 500);
+    } else {
+        window.addEventListener("load", function() { setTimeout(addLbLink, 500); });
+    }
+})();

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -1,0 +1,631 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Letterboxd</title>
+</head>
+<body>
+    <div id="letterboxdUserPage" data-role="page" class="page type-interior"
+         data-require="emby-input,emby-button,emby-checkbox,emby-select">
+        <div data-role="content">
+            <div class="content-primary">
+
+                <style>
+                    /* Standalone base styles for when loaded outside the Jellyfin SPA shell */
+                    html, body { background:#101010; color:#e0e0e0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,sans-serif; margin:0; padding:0; }
+                    #letterboxdUserPage { max-width:900px; margin:0 auto; padding:1.5em; }
+                    .lb-back-link { display:inline-block; margin-bottom:1em; color:#00e054; text-decoration:none; font-size:0.9em; }
+                    .lb-back-link:hover { text-decoration:underline; }
+                </style>
+                <style>
+                    .lb-tabs { display:flex; gap:0; margin-bottom:1.5em; border-bottom:2px solid rgba(255,255,255,0.1); }
+                    .lb-tab { background:none; border:none; color:inherit; opacity:0.5; padding:0.7em 1.5em; cursor:pointer; font-size:1em; border-bottom:2px solid transparent; margin-bottom:-2px; transition: opacity 0.2s, border-color 0.2s; }
+                    .lb-tab.active { opacity:1; border-bottom-color: #00e054; }
+                    .lb-tab:hover { opacity:0.8; }
+
+                    .lb-stat-cards { display:flex; gap:0.75em; flex-wrap:wrap; margin-bottom:2em; }
+                    .lb-stat-card { background:rgba(255,255,255,0.04); padding:1em 1.5em; border-radius:8px; min-width:90px; text-align:center; flex:1; border:1px solid rgba(255,255,255,0.06); }
+                    .lb-stat-val { font-size:2em; font-weight:bold; }
+                    .lb-stat-label { opacity:0.5; font-size:0.85em; margin-top:0.1em; }
+
+                    .lb-table { width:100%; border-collapse:collapse; font-size:0.9em; }
+                    .lb-table thead tr { border-bottom:2px solid rgba(255,255,255,0.1); text-align:left; }
+                    .lb-table th, .lb-table td { padding:0.6em 0.5em; }
+                    .lb-table tbody tr { border-bottom:1px solid rgba(255,255,255,0.04); transition: background 0.15s; }
+                    .lb-table tbody tr:hover { background:rgba(255,255,255,0.03); }
+
+                    .lb-account { background:rgba(255,255,255,0.04); padding:1.5em; border-radius:8px; border:1px solid rgba(255,255,255,0.06); }
+                    .lb-account label.lb-field { display:block; opacity:0.5; font-size:0.85em; margin-bottom:0.2em; }
+                    .lb-account input[type=text], .lb-account input[type=password], .lb-account input[type=number] {
+                        width:100%; padding:0.4em; background:rgba(255,255,255,0.06); color:inherit; border:1px solid rgba(255,255,255,0.1); border-radius:4px; box-sizing:border-box;
+                    }
+                    .lb-account input[type=number] { width:80px; }
+                    .lb-checks { display:flex; flex-wrap:wrap; gap:0.5em 1.5em; margin-top:0.7em; }
+                    .lb-checks label { opacity:0.8; font-size:0.9em; }
+
+                    .lb-btn { border:none; padding:0.5em 1.5em; border-radius:4px; cursor:pointer; font-weight:bold; font-size:0.95em; transition: opacity 0.2s; }
+                    .lb-btn:hover { opacity:0.85; }
+                    .lb-btn:disabled { opacity:0.4; cursor:default; }
+                    .lb-btn-primary { background:#00e054; color:#000; }
+                    .lb-btn-secondary { background:rgba(255,255,255,0.08); color:inherit; border:1px solid rgba(255,255,255,0.1); }
+                    .lb-btn-review { background:none; color:#40bcf4; border:1px solid rgba(64,188,244,0.4); font-size:0.8em; padding:0.15em 0.5em; }
+                    .lb-btn-review:hover { border-color:#40bcf4; }
+
+                    .lb-link { color:#00e054; text-decoration:none; }
+                    .lb-link:hover { text-decoration:underline; }
+
+                    .lb-modal-overlay { display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:9999; }
+                    .lb-modal { background:rgba(30,34,40,0.98); padding:2em; border-radius:8px; max-width:500px; width:90%; margin:15vh auto; border:1px solid rgba(255,255,255,0.1); }
+                    .lb-modal textarea { width:100%; padding:0.5em; background:rgba(255,255,255,0.06); color:inherit; border:1px solid rgba(255,255,255,0.1); border-radius:4px; resize:vertical; box-sizing:border-box; }
+
+                    .c-green { color:#00e054; }
+                    .c-blue { color:#40bcf4; }
+                    .c-red { color:#e74c3c; }
+                    .c-muted { opacity:0.4; }
+                </style>
+
+                <a href="/web/index.html" class="lb-back-link" id="backLink">&larr; Back to Jellyfin</a>
+
+                <div style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.5em;">
+                    <h2 style="margin:0;">Letterboxd Sync</h2>
+                    <span class="c-muted" style="font-size:0.7em;padding-top:0.3em;">by <a href="https://lachlanyoung.dev" target="_blank" class="lb-link">Lachlan Young</a> and <strong style="color:#ff8c00;">AI</strong></span>
+                </div>
+
+                <!-- Admin link -->
+                <div id="adminLink" style="display:none;margin-bottom:1em;">
+                    <a href="/web/index.html#!/dashboard/plugins" class="lb-link" style="font-size:0.85em;">Manage All Accounts (Admin)</a>
+                </div>
+
+                <!-- Tabs -->
+                <div class="lb-tabs">
+                    <button type="button" class="lb-tab active" data-tab="stats">Dashboard</button>
+                    <button type="button" class="lb-tab" data-tab="account">My Account</button>
+                </div>
+
+                <!-- DASHBOARD TAB -->
+                <div id="tab-stats" class="lb-tab-content">
+                    <div id="adminSyncControls" style="display:none;">
+                        <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;">
+                            <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
+                            <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
+                        </div>
+                        <div id="syncProgressBar" style="display:none;margin-bottom:1.5em;">
+                            <div style="background:#2a2a2a;border-radius:4px;height:6px;overflow:hidden;margin-bottom:0.3em;">
+                                <div id="progressFill" style="background:#00e054;height:100%;width:0%;transition:width 0.5s ease;"></div>
+                            </div>
+                            <span id="progressDetail" class="c-muted" style="font-size:0.8em;"></span>
+                        </div>
+                    </div>
+
+                    <div class="lb-stat-cards">
+                        <div class="lb-stat-card"><div class="lb-stat-val" id="statTotal">-</div><div class="lb-stat-label">Total</div></div>
+                        <div class="lb-stat-card"><div class="lb-stat-val c-green" id="statSuccess">-</div><div class="lb-stat-label">Synced</div></div>
+                        <div class="lb-stat-card"><div class="lb-stat-val c-blue" id="statRewatches">-</div><div class="lb-stat-label">Rewatches</div></div>
+                        <div class="lb-stat-card"><div class="lb-stat-val c-muted" id="statSkipped">-</div><div class="lb-stat-label">Skipped</div></div>
+                        <div class="lb-stat-card"><div class="lb-stat-val c-red" id="statFailed">-</div><div class="lb-stat-label">Failed</div></div>
+                    </div>
+
+                    <h3 style="margin-bottom:0.5em;">Recent Activity</h3>
+                    <div style="overflow-x:auto;">
+                        <table class="lb-table">
+                            <thead><tr><th>Film</th><th>Status</th><th>Source</th><th>Date</th><th></th></tr></thead>
+                            <tbody id="historyBody">
+                                <tr><td colspan="5" style="padding:2em;text-align:center;" class="c-muted">Loading...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- MY ACCOUNT TAB -->
+                <div id="tab-account" class="lb-tab-content" style="display:none;">
+                    <h3>Letterboxd Account</h3>
+                    <p class="c-muted" style="font-size:0.9em;">Connect your Letterboxd account to sync your watch history.</p>
+
+                    <div class="lb-account">
+                        <div style="margin-bottom:0.7em;">
+                            <label class="lb-field">Letterboxd Username</label>
+                            <input type="text" id="lbUsername" />
+                        </div>
+                        <div style="margin-bottom:0.7em;">
+                            <label class="lb-field">Letterboxd Password</label>
+                            <input type="password" id="lbPassword" />
+                        </div>
+                        <div style="margin-bottom:0.7em;">
+                            <label class="lb-field">Raw Cookies <span class="c-muted">(optional, Cloudflare bypass)</span></label>
+                            <input type="text" id="rawCookies" placeholder="Paste cookie header if login gets 403" />
+                        </div>
+
+                        <div style="margin-top:1em;margin-bottom:0.5em;">
+                            <button type="button" class="lb-btn lb-btn-secondary" id="testBtn">Test Connection</button>
+                            <span id="testStatus" style="font-size:0.9em;margin-left:0.7em;"></span>
+                        </div>
+
+                        <h4 style="margin-top:1.5em;margin-bottom:0.5em;">Sync Preferences</h4>
+                        <div class="lb-checks">
+                            <label><input type="checkbox" id="accountEnabled" /> Enabled</label>
+                            <label><input type="checkbox" id="syncFavorites" /> Favorites as liked</label>
+                            <label><input type="checkbox" id="enableDateFilter" /> Recently played only</label>
+                            <label><input type="checkbox" id="enableWatchlistSync" /> Watchlist to playlist</label>
+                            <label><input type="checkbox" id="enableDiaryImport" /> Import diary as played</label>
+                        </div>
+                        <div id="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">
+                            <label class="lb-field">Days to look back</label>
+                            <input type="number" id="dateFilterDays" min="1" max="365" value="7" />
+                        </div>
+                    </div>
+
+                    <div style="margin-top:1.5em;display:flex;align-items:center;gap:1em;">
+                        <button type="button" class="lb-btn lb-btn-primary" id="saveBtn">Save</button>
+                        <span id="saveStatus" style="font-size:0.9em;"></span>
+                    </div>
+                </div>
+
+                <!-- REVIEW MODAL -->
+                <div id="reviewModal" class="lb-modal-overlay">
+                    <div class="lb-modal">
+                        <h3 id="reviewTitle" style="margin-top:0;">Write Review</h3>
+                        <textarea id="reviewText" rows="5" placeholder="Write your review..."></textarea>
+                        <div style="margin-top:0.7em;">
+                            <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.3em;">Rating</label>
+                            <div id="starRating" style="display:flex;gap:0.15em;cursor:pointer;font-size:1.6em;user-select:none;">
+                                <span data-val="0.5" class="lb-half">&#9734;</span>
+                                <span data-val="1">&#9734;</span>
+                                <span data-val="1.5" class="lb-half">&#9734;</span>
+                                <span data-val="2">&#9734;</span>
+                                <span data-val="2.5" class="lb-half">&#9734;</span>
+                                <span data-val="3">&#9734;</span>
+                                <span data-val="3.5" class="lb-half">&#9734;</span>
+                                <span data-val="4">&#9734;</span>
+                                <span data-val="4.5" class="lb-half">&#9734;</span>
+                                <span data-val="5">&#9734;</span>
+                            </div>
+                            <span id="ratingLabel" style="font-size:0.85em;opacity:0.5;margin-left:0.3em;">No rating</span>
+                            <input type="hidden" id="reviewRating" value="" />
+                            <style>
+                                .lb-half { font-size:0.6em; vertical-align:super; margin-right:-0.1em; }
+                                #starRating span { transition: color 0.1s; color: rgba(255,255,255,0.2); }
+                                #starRating span.filled { color: #00e054; }
+                                #starRating span:hover { color: #00e054; opacity: 0.7; }
+                            </style>
+                        </div>
+                        <div style="margin-top:0.5em;display:flex;flex-wrap:wrap;gap:0.5em 1.5em;align-items:center;">
+                            <label class="c-muted"><input type="checkbox" id="reviewSpoilers" /> Contains spoilers</label>
+                            <label class="c-muted"><input type="checkbox" id="reviewRewatch" /> This is a rewatch</label>
+                        </div>
+                        <div id="rewatchDateRow" style="display:none;margin-top:0.5em;">
+                            <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.2em;">Date watched</label>
+                            <input type="date" id="reviewDate" style="padding:0.4em;background:rgba(255,255,255,0.06);color:inherit;border:1px solid rgba(255,255,255,0.1);border-radius:4px;" />
+                        </div>
+                        <div style="margin-top:1em;display:flex;gap:1em;">
+                            <button type="button" class="lb-btn lb-btn-primary" id="reviewSubmit">Post to Letterboxd</button>
+                            <button type="button" class="lb-btn lb-btn-secondary" id="reviewCancel">Cancel</button>
+                        </div>
+                        <div id="reviewStatus" style="margin-top:0.5em;font-size:0.9em;"></div>
+                    </div>
+                </div>
+
+                <script type="text/javascript">
+                    var LBUser = {
+                        serverUrl: '',
+                        token: '',
+                        isAdmin: false,
+                        currentSlug: '',
+                        syncPoll: null,
+
+                        resolveAuth: function () {
+                            if (typeof ApiClient !== 'undefined') {
+                                try {
+                                    this.serverUrl = ApiClient.serverAddress();
+                                    this.token = ApiClient.accessToken();
+                                    if (this.serverUrl && this.token) return true;
+                                } catch (e) {}
+                            }
+                            try {
+                                var creds = JSON.parse(localStorage.getItem('jellyfin_credentials') || '{}');
+                                var server = (creds.Servers || [])[0];
+                                if (server) {
+                                    this.serverUrl = server.ManualAddress || server.LocalAddress || '';
+                                    this.token = server.AccessToken || '';
+                                    return !!(this.serverUrl && this.token);
+                                }
+                            } catch (e) {}
+                            return false;
+                        },
+
+                        apiFetch: function (path) {
+                            return fetch(this.serverUrl + '/' + path, {
+                                headers: { 'Authorization': 'MediaBrowser Token="' + this.token + '"' }
+                            });
+                        },
+
+                        apiPost: function (path, body) {
+                            return fetch(this.serverUrl + '/' + path, {
+                                method: 'POST',
+                                headers: {
+                                    'Authorization': 'MediaBrowser Token="' + this.token + '"',
+                                    'Content-Type': 'application/json'
+                                },
+                                body: JSON.stringify(body)
+                            });
+                        },
+
+                        apiPut: function (path, body) {
+                            return fetch(this.serverUrl + '/' + path, {
+                                method: 'PUT',
+                                headers: {
+                                    'Authorization': 'MediaBrowser Token="' + this.token + '"',
+                                    'Content-Type': 'application/json'
+                                },
+                                body: JSON.stringify(body)
+                            });
+                        },
+
+                        initTabs: function () {
+                            var tabs = document.querySelectorAll('.lb-tab');
+                            tabs.forEach(function (tab) {
+                                tab.addEventListener('click', function () {
+                                    tabs.forEach(function (t) { t.classList.remove('active'); });
+                                    tab.classList.add('active');
+                                    document.querySelectorAll('.lb-tab-content').forEach(function (c) { c.style.display = 'none'; });
+                                    document.getElementById('tab-' + tab.getAttribute('data-tab')).style.display = '';
+                                });
+                            });
+                        },
+
+                        loadAccount: function () {
+                            var self = this;
+                            self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Account')
+                            .then(function (r) { return r.json(); })
+                            .then(function (a) {
+                                document.getElementById('lbUsername').value = a.letterboxdUsername || '';
+                                document.getElementById('lbPassword').value = a.letterboxdPassword || '';
+                                document.getElementById('rawCookies').value = a.rawCookies || '';
+                                document.getElementById('accountEnabled').checked = a.enabled === true;
+                                document.getElementById('syncFavorites').checked = a.syncFavorites === true;
+                                document.getElementById('enableDateFilter').checked = a.enableDateFilter === true;
+                                document.getElementById('dateFilterDays').value = a.dateFilterDays || 7;
+                                document.getElementById('enableWatchlistSync').checked = a.enableWatchlistSync === true;
+                                document.getElementById('enableDiaryImport').checked = a.enableDiaryImport === true;
+                                document.getElementById('dateFilterDaysContainer').style.display = a.enableDateFilter ? '' : 'none';
+                            })
+                            .catch(function (err) {
+                                console.error('[LetterboxdSync] Failed to load account:', err);
+                            });
+                        },
+
+                        saveAccount: function () {
+                            var self = this;
+                            var saveBtn = document.getElementById('saveBtn');
+                            var saveStatus = document.getElementById('saveStatus');
+                            saveBtn.disabled = true;
+                            saveStatus.textContent = 'Saving...';
+
+                            var data = {
+                                letterboxdUsername: document.getElementById('lbUsername').value,
+                                letterboxdPassword: document.getElementById('lbPassword').value,
+                                rawCookies: document.getElementById('rawCookies').value || null,
+                                enabled: document.getElementById('accountEnabled').checked,
+                                syncFavorites: document.getElementById('syncFavorites').checked,
+                                enableDateFilter: document.getElementById('enableDateFilter').checked,
+                                dateFilterDays: parseInt(document.getElementById('dateFilterDays').value, 10) || 7,
+                                enableWatchlistSync: document.getElementById('enableWatchlistSync').checked,
+                                enableDiaryImport: document.getElementById('enableDiaryImport').checked
+                            };
+
+                            self.apiPut('Jellyfin.Plugin.LetterboxdSync/Account', data)
+                            .then(function (r) {
+                                if (r.ok) {
+                                    saveStatus.innerHTML = '<span class="c-green">Saved!</span>';
+                                    saveBtn.disabled = false;
+                                } else {
+                                    r.json().then(function (d) {
+                                        saveStatus.innerHTML = '<span class="c-red">' + (d.error || 'Failed to save') + '</span>';
+                                        saveBtn.disabled = false;
+                                    });
+                                }
+                            })
+                            .catch(function (err) {
+                                saveStatus.innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
+                                saveBtn.disabled = false;
+                            });
+                        },
+
+                        testConnection: function () {
+                            var self = this;
+                            var testBtn = document.getElementById('testBtn');
+                            var testStatus = document.getElementById('testStatus');
+                            var username = document.getElementById('lbUsername').value;
+                            var password = document.getElementById('lbPassword').value;
+
+                            if (!username || !password) {
+                                testStatus.innerHTML = '<span class="c-red">Enter username and password first</span>';
+                                return;
+                            }
+
+                            testBtn.disabled = true;
+                            testStatus.innerHTML = '<span class="c-muted" style="opacity:0.7;">Connecting to Letterboxd...</span>';
+
+                            self.apiPost('Jellyfin.Plugin.LetterboxdSync/TestConnection', {
+                                letterboxdUsername: username,
+                                letterboxdPassword: password,
+                                rawCookies: document.getElementById('rawCookies').value || null
+                            })
+                            .then(function (r) { return r.json(); })
+                            .then(function (data) {
+                                testBtn.disabled = false;
+                                if (data.success) {
+                                    testStatus.innerHTML = '<span class="c-green">Connected as ' + data.letterboxdUsername + '</span>';
+                                } else {
+                                    var msg = data.error || 'Connection failed';
+                                    if (msg.indexOf('403') >= 0 || msg.indexOf('Cloudflare') >= 0) {
+                                        msg = 'Blocked by Cloudflare. Try adding Raw Cookies with cf_clearance.';
+                                    }
+                                    testStatus.innerHTML = '<span class="c-red">' + msg + '</span>';
+                                }
+                            })
+                            .catch(function (err) {
+                                testBtn.disabled = false;
+                                testStatus.innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
+                            });
+                        },
+
+                        loadStats: function () {
+                            this.apiFetch('Jellyfin.Plugin.LetterboxdSync/Stats')
+                            .then(function (r) { return r.json(); })
+                            .then(function (s) {
+                                document.getElementById('statTotal').textContent = s.total;
+                                document.getElementById('statSuccess').textContent = s.success;
+                                document.getElementById('statRewatches').textContent = s.rewatches;
+                                document.getElementById('statSkipped').textContent = s.skipped;
+                                document.getElementById('statFailed').textContent = s.failed;
+                            }).catch(function () {});
+                        },
+
+                        loadHistory: function () {
+                            this.apiFetch('Jellyfin.Plugin.LetterboxdSync/History?count=100')
+                            .then(function (r) { return r.json(); })
+                            .then(function (events) {
+                                var tbody = document.getElementById('historyBody');
+                                tbody.innerHTML = '';
+                                if (!events || events.length === 0) {
+                                    tbody.innerHTML = '<tr><td colspan="5" style="padding:2em;text-align:center;" class="c-muted">No sync activity yet.</td></tr>';
+                                    return;
+                                }
+                                events.forEach(function (e) {
+                                    var tr = document.createElement('tr');
+                                    var s = typeof e.Status === 'string' ? e.Status : ['Success','Skipped','Failed','Rewatch'][e.Status] || 'Unknown';
+                                    var statusMap = { Success: {color:'#00e054', label:'Synced'}, Skipped: {color:'', label:'Skipped'}, Failed: {color:'#e74c3c', label:'Failed'}, Rewatch: {color:'#40bcf4', label:'Rewatch'} };
+                                    var sm = statusMap[s] || {color:'', label:s};
+                                    var link = e.FilmSlug ? '<a href="https://letterboxd.com/film/' + e.FilmSlug + '/" target="_blank" class="lb-link">' + e.FilmTitle + '</a>' : e.FilmTitle;
+                                    var ts = new Date(e.Timestamp);
+                                    var time = ts.toLocaleDateString() + ' ' + ts.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'});
+                                    var canReview = (s === 'Success' || s === 'Rewatch' || s === 'Skipped');
+                                    var btn = (e.FilmSlug && canReview) ? '<button type="button" onclick="LBUser.openReview(\'' + e.FilmSlug + '\',\'' + e.FilmTitle.replace(/'/g, "\\'") + '\')" class="lb-btn lb-btn-review">Review</button>' : '';
+                                    var errText = '';
+                                    if (s === 'Failed' && e.Error) {
+                                        var shortErr = e.Error;
+                                        if (shortErr.indexOf('403') >= 0 || shortErr.indexOf('Just a moment') >= 0) shortErr = 'Blocked by Cloudflare. Refresh your Raw Cookies.';
+                                        else if (shortErr.length > 150) shortErr = shortErr.substring(0, 150) + '...';
+                                        errText = ' title="' + shortErr.replace(/"/g, '&quot;') + '"';
+                                    }
+                                    var scStyle = sm.color ? ' style="color:' + sm.color + ';"' : ' class="c-muted"';
+                                    var failIcon = (s === 'Failed' && errText) ? ' <span style="cursor:help;opacity:0.7;"' + errText + '>&#9432;</span>' : '';
+                                    tr.innerHTML = '<td style="padding:0.5em;">' + link + '</td>'
+                                        + '<td style="padding:0.5em;"><span' + scStyle + '>' + sm.label + '</span>' + failIcon + '</td>'
+                                        + '<td style="padding:0.5em;" class="c-muted">' + (e.Source || '') + '</td>'
+                                        + '<td style="padding:0.5em;" class="c-muted">' + time + '</td>'
+                                        + '<td style="padding:0.5em;">' + btn + '</td>';
+                                    tbody.appendChild(tr);
+                                });
+                            }).catch(function () {});
+                        },
+
+                        pollTask: function (taskId) {
+                            var self = this;
+                            if (self.syncPoll) clearInterval(self.syncPoll);
+                            self.syncPoll = setInterval(function () {
+                                self.apiFetch('ScheduledTasks/' + taskId)
+                                .then(function (r) { return r.json(); })
+                                .then(function (t) {
+                                    if (t.State === 'Idle') {
+                                        clearInterval(self.syncPoll);
+                                        self.syncPoll = null;
+                                        document.getElementById('runSyncBtn').disabled = false;
+                                        document.getElementById('syncStatus').innerHTML = '<span class="c-green">Done!</span>';
+                                        document.getElementById('syncProgressBar').style.display = 'none';
+                                        self.loadStats();
+                                        self.loadHistory();
+                                    }
+                                });
+                                self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Progress')
+                                .then(function (r) { return r.json(); })
+                                .then(function (p) {
+                                    if (!p || !p.isRunning) return;
+                                    document.getElementById('syncProgressBar').style.display = 'block';
+                                    var detail = '';
+                                    if (p.totalItems > 0) {
+                                        var pct = Math.round((p.processedItems / p.totalItems) * 100);
+                                        document.getElementById('progressFill').style.width = pct + '%';
+                                        detail = p.processedItems + '/' + p.totalItems + ' films';
+                                    } else if (p.processedItems > 0) {
+                                        detail = p.processedItems + ' films resolved';
+                                    }
+                                    if (p.cacheHits > 0) detail += ' (' + p.cacheHits + ' cached)';
+                                    var elapsed = p.elapsedSeconds || 0;
+                                    var mins = Math.floor(elapsed / 60);
+                                    var secs = elapsed % 60;
+                                    var timeStr = mins > 0 ? mins + 'm ' + secs + 's' : secs + 's';
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-green">' + (p.phase || '') + '</span>';
+                                    document.getElementById('progressDetail').textContent = detail + ' \u2022 ' + timeStr;
+                                }).catch(function () {});
+                            }, 3000);
+                        },
+
+                        runSync: function () {
+                            var self = this;
+                            var btn = document.getElementById('runSyncBtn');
+                            btn.disabled = true;
+                            document.getElementById('syncStatus').textContent = 'Starting...';
+
+                            self.apiFetch('ScheduledTasks')
+                            .then(function (r) { return r.json(); })
+                            .then(function (tasks) {
+                                var task = tasks.find(function (t) { return t.Key === 'LetterboxdSync'; });
+                                if (!task) {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-red">Task not found</span>';
+                                    btn.disabled = false;
+                                    return;
+                                }
+                                fetch(self.serverUrl + '/ScheduledTasks/Running/' + task.Id, {
+                                    method: 'POST',
+                                    headers: { 'Authorization': 'MediaBrowser Token="' + self.token + '"' }
+                                }).then(function () {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing...</span>';
+                                    self.pollTask(task.Id);
+                                });
+                            });
+                        },
+
+                        openReview: function (slug, title) {
+                            this.currentSlug = slug;
+                            document.getElementById('reviewTitle').textContent = 'Review: ' + title;
+                            document.getElementById('reviewText').value = '';
+                            document.getElementById('reviewSpoilers').checked = false;
+                            document.getElementById('reviewRewatch').checked = false;
+                            document.getElementById('rewatchDateRow').style.display = 'none';
+                            document.getElementById('reviewDate').value = new Date().toISOString().split('T')[0];
+                            document.getElementById('reviewRating').value = '';
+                            document.getElementById('ratingLabel').textContent = 'No rating';
+                            document.querySelectorAll('#starRating span').forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
+                            document.getElementById('reviewStatus').textContent = '';
+                            document.getElementById('reviewModal').style.display = 'block';
+                        },
+
+                        submitReview: function () {
+                            var self = this;
+                            var text = document.getElementById('reviewText').value.trim();
+                            var isRewatch = document.getElementById('reviewRewatch').checked;
+                            var date = document.getElementById('reviewDate').value;
+
+                            if (!text && !isRewatch) { document.getElementById('reviewStatus').textContent = 'Write a review or mark as rewatch.'; return; }
+
+                            document.getElementById('reviewStatus').textContent = 'Posting...';
+                            document.getElementById('reviewSubmit').disabled = true;
+
+                            var ratingVal = document.getElementById('reviewRating').value;
+                            var rating = ratingVal ? parseFloat(ratingVal) : null;
+
+                            self.apiPost('Jellyfin.Plugin.LetterboxdSync/Review', {
+                                filmSlug: self.currentSlug,
+                                reviewText: text || null,
+                                containsSpoilers: document.getElementById('reviewSpoilers').checked,
+                                isRewatch: isRewatch,
+                                date: isRewatch && date ? date : null,
+                                rating: rating
+                            })
+                            .then(function (r) { return r.json(); })
+                            .then(function (data) {
+                                document.getElementById('reviewSubmit').disabled = false;
+                                if (data.success) {
+                                    var msg = isRewatch ? 'Rewatch logged!' : 'Review posted!';
+                                    document.getElementById('reviewStatus').innerHTML = '<span class="c-green">' + msg + '</span>';
+                                    self.loadStats();
+                                    self.loadHistory();
+                                    setTimeout(function () { document.getElementById('reviewModal').style.display = 'none'; }, 1500);
+                                } else {
+                                    var errMsg = data.error || 'Failed to post';
+                                    if (errMsg.indexOf('403') >= 0 || errMsg.indexOf('Cloudflare') >= 0) {
+                                        errMsg = 'Blocked by Cloudflare. Try refreshing your Raw Cookies.';
+                                    }
+                                    document.getElementById('reviewStatus').innerHTML = '<span class="c-red">' + errMsg + '</span>';
+                                }
+                            })
+                            .catch(function (err) {
+                                document.getElementById('reviewSubmit').disabled = false;
+                                document.getElementById('reviewStatus').innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
+                            });
+                        },
+
+                        init: function () {
+                            var self = this;
+                            self.initTabs();
+
+                            // Check if current user is admin
+                            self.apiFetch('Users/Me')
+                            .then(function (r) { return r.json(); })
+                            .then(function (user) {
+                                if (user.Policy && user.Policy.IsAdministrator) {
+                                    self.isAdmin = true;
+                                    document.getElementById('adminLink').style.display = '';
+                                    document.getElementById('adminSyncControls').style.display = '';
+
+                                    // Check if sync is already running
+                                    self.apiFetch('ScheduledTasks')
+                                    .then(function (r) { return r.json(); })
+                                    .then(function (tasks) {
+                                        var syncTask = tasks.find(function (t) { return t.Key === 'LetterboxdSync'; });
+                                        var diaryTask = tasks.find(function (t) { return t.Key === 'LetterboxdDiaryImport'; });
+                                        var running = (syncTask && syncTask.State === 'Running') ? syncTask :
+                                                      (diaryTask && diaryTask.State === 'Running') ? diaryTask : null;
+                                        if (running) {
+                                            document.getElementById('runSyncBtn').disabled = true;
+                                            document.getElementById('syncStatus').innerHTML = '<span class="c-green">Sync in progress...</span>';
+                                            self.pollTask(running.Id);
+                                        }
+                                    }).catch(function () {});
+                                }
+                            }).catch(function () {});
+
+                            // Load data
+                            self.loadAccount();
+                            self.loadStats();
+                            self.loadHistory();
+
+                            // Event listeners
+                            document.getElementById('saveBtn').addEventListener('click', function () { self.saveAccount(); });
+                            document.getElementById('testBtn').addEventListener('click', function () { self.testConnection(); });
+                            document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
+                            document.getElementById('reviewCancel').addEventListener('click', function () { document.getElementById('reviewModal').style.display = 'none'; });
+                            document.getElementById('reviewSubmit').addEventListener('click', function () { self.submitReview(); });
+                            document.getElementById('reviewRewatch').addEventListener('change', function () {
+                                document.getElementById('rewatchDateRow').style.display = this.checked ? '' : 'none';
+                            });
+                            document.getElementById('enableDateFilter').addEventListener('change', function () {
+                                document.getElementById('dateFilterDaysContainer').style.display = this.checked ? '' : 'none';
+                            });
+
+                            // Star rating
+                            var stars = document.querySelectorAll('#starRating span');
+                            stars.forEach(function (star) {
+                                star.addEventListener('click', function () {
+                                    var val = parseFloat(this.getAttribute('data-val'));
+                                    var current = parseFloat(document.getElementById('reviewRating').value);
+                                    if (val === current) {
+                                        document.getElementById('reviewRating').value = '';
+                                        document.getElementById('ratingLabel').textContent = 'No rating';
+                                        stars.forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
+                                        return;
+                                    }
+                                    document.getElementById('reviewRating').value = val;
+                                    document.getElementById('ratingLabel').textContent = val + ' / 5';
+                                    stars.forEach(function (s) {
+                                        var sv = parseFloat(s.getAttribute('data-val'));
+                                        if (sv <= val) { s.classList.add('filled'); s.innerHTML = '&#9733;'; }
+                                        else { s.classList.remove('filled'); s.innerHTML = '&#9734;'; }
+                                    });
+                                });
+                            });
+                        }
+                    };
+
+                    if (LBUser.resolveAuth()) {
+                        LBUser.init();
+                    } else {
+                        console.error('[LetterboxdSync] Could not resolve auth');
+                    }
+                </script>
+
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.5.0.0",
+        "changelog": "User self-service account setup, sidebar link for all users, test connection button, standalone user page via File Transformation injection",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.5.0/jellyfin-plugin-letterboxd-v1.5.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-07T00:00:00Z"
+      },
+      {
         "version": "1.4.0.0",
         "changelog": "Architecture refactor, TMDb cache, progress dashboard, diary import fix, Cloudflare resilience, watchlist cleanup",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
- Non-admin Jellyfin users can now configure their own Letterboxd credentials and sync preferences via a new user-facing page
- Sidebar link injected for all users via File Transformation plugin integration
- Test Connection button to verify Letterboxd login before saving
- Standalone dark-themed page that works outside the Jellyfin SPA shell
- Fix: PostReview now records Jellyfin username (not Letterboxd username) in sync history

## New files
- `Api/AccountUpdateRequest.cs` - DTOs for account update and test connection (no UserJellyfinId field for security)
- `Api/SidebarController.cs` - Anonymous controller serving sidebar.js as embedded resource
- `SidebarInjection.cs` - Startup task registering with File Transformation plugin, plus HTML transform callback
- `Web/userPage.html` - User-facing page with Dashboard and My Account tabs
- `Web/sidebar.js` - Sidebar link injection script
- `Tests/AccountTests.cs` - 13 tests covering DTOs, config patterns, security
- `Tests/SidebarInjectionTests.cs` - 8 tests covering HTML injection safety (including JS chunk collision guard)

## API endpoints
- `GET /Account` - returns calling user's Letterboxd config
- `PUT /Account` - saves calling user's account (find-or-create)
- `POST /TestConnection` - verifies Letterboxd login without state mutation

## Test plan
- [x] Non-admin user sees Letterboxd link in sidebar
- [x] Clicking link navigates to user page with proper styling
- [x] User can save credentials and sync preferences
- [x] Test Connection button works
- [x] Admin still sees admin config page in dashboard
- [x] Admin-configured accounts are editable by users
- [x] JS chunks are not corrupted by File Transformation (session-login-index-html guard)
- [x] 112 tests pass