### PR TITLE
Official Letterboxd API with scraping fallback

### DIFF
--- a/LetterboxdSync.Tests/ApiClientTests.cs
+++ b/LetterboxdSync.Tests/ApiClientTests.cs
@@ -1,0 +1,464 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LetterboxdSync;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class ApiClientHmacTests
+{
+    [Fact]
+    public void ComputeHmacSha256_ProducesCorrectSignature()
+    {
+        // Verify our HMAC implementation matches a known value
+        var secret = "testsecret";
+        var message = "GET\0https://api.letterboxd.com/api/v0/film/2a9q?apikey=testkey&nonce=abc&timestamp=123\0";
+
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+        var signature = Convert.ToHexStringLower(hash);
+
+        Assert.Equal(64, signature.Length);
+        Assert.Matches("^[0-9a-f]{64}$", signature);
+    }
+
+    [Fact]
+    public void ComputeHmacSha256_DifferentInputsProduceDifferentSignatures()
+    {
+        var secret = "testsecret";
+        var msg1 = "GET\0https://example.com?a=1\0";
+        var msg2 = "POST\0https://example.com?a=1\0body";
+
+        using var hmac1 = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        using var hmac2 = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var sig1 = Convert.ToHexStringLower(hmac1.ComputeHash(Encoding.UTF8.GetBytes(msg1)));
+        var sig2 = Convert.ToHexStringLower(hmac2.ComputeHash(Encoding.UTF8.GetBytes(msg2)));
+
+        Assert.NotEqual(sig1, sig2);
+    }
+
+    [Fact]
+    public void ComputeHmacSha256_NullBytesSeparateComponents()
+    {
+        var secret = "testsecret";
+        // The null byte separator is critical for security
+        var withNulls = "GET\0https://example.com\0";
+        var withoutNulls = "GEThttps://example.com";
+
+        using var hmac1 = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        using var hmac2 = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var sig1 = Convert.ToHexStringLower(hmac1.ComputeHash(Encoding.UTF8.GetBytes(withNulls)));
+        var sig2 = Convert.ToHexStringLower(hmac2.ComputeHash(Encoding.UTF8.GetBytes(withoutNulls)));
+
+        Assert.NotEqual(sig1, sig2);
+    }
+}
+
+public class ApiClientAuthTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task AuthenticateAsync_SuccessfulAuth_SetsToken()
+    {
+        var handler = new ApiMockHandler((request) =>
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "";
+
+            if (path.EndsWith("/auth/token"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        access_token = "test-token-123",
+                        token_type = "Bearer",
+                        expires_in = 3600,
+                        refresh_token = "refresh-token-456"
+                    }))
+                };
+            }
+
+            if (path.EndsWith("/me"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        member = new { id = "abc123", username = "testuser" }
+                    }))
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("testuser", "testpass");
+
+        // Should not throw, meaning auth succeeded
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_InvalidCredentials_ThrowsWithMessage()
+    {
+        var handler = new ApiMockHandler((request) =>
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "";
+
+            if (path.EndsWith("/auth/token"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"error\":\"invalid_grant\",\"error_description\":\"Your credentials don't match.\"}")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        var ex = await Assert.ThrowsAsync<Exception>(() => client.AuthenticateAsync("bad", "creds"));
+        Assert.Contains("invalid_grant", ex.Message);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_RequestIncludesSignature()
+    {
+        var capturedUrls = new List<string>();
+
+        var handler = new ApiMockHandler((request) =>
+        {
+            capturedUrls.Add(request.RequestUri?.ToString() ?? "");
+
+            if (request.RequestUri?.AbsolutePath.EndsWith("/auth/token") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        access_token = "token",
+                        expires_in = 3600,
+                        refresh_token = "refresh"
+                    }))
+                };
+            }
+
+            if (request.RequestUri?.AbsolutePath.EndsWith("/me") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"member\":{\"id\":\"m1\",\"username\":\"u\"}}")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("signature_test_user_" + Guid.NewGuid().ToString("N"), "pass");
+
+        Assert.NotEmpty(capturedUrls);
+        // Every request should have signing params
+        foreach (var url in capturedUrls)
+        {
+            Assert.Contains("apikey=", url);
+            Assert.Contains("nonce=", url);
+            Assert.Contains("timestamp=", url);
+            Assert.Contains("signature=", url);
+        }
+    }
+}
+
+public class ApiClientFilmLookupTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task LookupFilmByTmdbIdAsync_ReturnsFilmResult()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true &&
+                request.RequestUri.Query.Contains("filmId=tmdb"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        items = new[]
+                        {
+                            new
+                            {
+                                id = "2a9q",
+                                name = "Fight Club",
+                                link = "https://letterboxd.com/film/fight-club/",
+                                links = new[]
+                                {
+                                    new { type = "letterboxd", id = "2a9q", url = "https://letterboxd.com/film/fight-club/" },
+                                    new { type = "tmdb", id = "550", url = "https://www.themoviedb.org/movie/550" }
+                                }
+                            }
+                        }
+                    }))
+                };
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var result = await client.LookupFilmByTmdbIdAsync(550);
+
+        Assert.Equal("2a9q", result.FilmId);
+        Assert.Equal("fight-club", result.Slug);
+        Assert.Null(result.ProductionId);
+    }
+
+    [Fact]
+    public async Task LookupFilmByTmdbIdAsync_NotFound_Throws()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"items\":[]}")
+                };
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var ex = await Assert.ThrowsAsync<Exception>(() => client.LookupFilmByTmdbIdAsync(99999999));
+        Assert.Contains("not found", ex.Message);
+    }
+}
+
+public class ApiClientDiaryTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task MarkAsWatchedAsync_SendsCorrectBody()
+    {
+        string? capturedBody = null;
+
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.Method == HttpMethod.Post &&
+                request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true)
+            {
+                capturedBody = request.Content?.ReadAsStringAsync().Result;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        await client.MarkAsWatchedAsync("fight-club", "2a9q", new DateTime(2026, 4, 7), liked: true, rating: 4.5);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody!);
+        var root = doc.RootElement;
+        Assert.Equal("2a9q", root.GetProperty("filmId").GetString());
+        Assert.True(root.GetProperty("like").GetBoolean());
+        Assert.Equal(4.5, root.GetProperty("rating").GetDouble());
+        Assert.Equal("2026-04-07", root.GetProperty("diaryDetails").GetProperty("diaryDate").GetString());
+        Assert.False(root.GetProperty("diaryDetails").GetProperty("rewatch").GetBoolean());
+    }
+
+    [Fact]
+    public async Task MarkAsWatchedAsync_Rewatch_SetsFlag()
+    {
+        string? capturedBody = null;
+
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.Method == HttpMethod.Post &&
+                request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true)
+            {
+                capturedBody = request.Content?.ReadAsStringAsync().Result;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        await client.MarkAsWatchedAsync("film", "lid", DateTime.Now, liked: false, rewatch: true);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody!);
+        Assert.True(doc.RootElement.GetProperty("diaryDetails").GetProperty("rewatch").GetBoolean());
+    }
+
+    [Fact]
+    public async Task GetDiaryInfoAsync_WithEntry_ReturnsDate()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true &&
+                request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        items = new[]
+                        {
+                            new
+                            {
+                                diaryDetails = new { diaryDate = "2026-04-01" }
+                            }
+                        }
+                    }))
+                };
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var info = await client.GetDiaryInfoAsync("2a9q", "user");
+
+        Assert.True(info.HasAnyEntry);
+        Assert.Equal(new DateTime(2026, 4, 1), info.LastDate);
+    }
+
+    [Fact]
+    public async Task GetDiaryInfoAsync_NoEntries_ReturnsEmpty()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true &&
+                request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"items\":[]}")
+                };
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var info = await client.GetDiaryInfoAsync("2a9q", "user");
+
+        Assert.False(info.HasAnyEntry);
+        Assert.Null(info.LastDate);
+    }
+}
+
+public class ApiClientRateLimitTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task SendSigned_429_RetriesAfterDelay()
+    {
+        int callCount = 0;
+
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true)
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    var resp = new HttpResponseMessage((HttpStatusCode)429);
+                    resp.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromMilliseconds(100));
+                    return resp;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        items = new[] { new { id = "abc", link = "https://letterboxd.com/film/test/", links = Array.Empty<object>() } }
+                    }))
+                };
+            }
+
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var result = await client.LookupFilmByTmdbIdAsync(123);
+
+        Assert.Equal(2, callCount);
+        Assert.Equal("abc", result.FilmId);
+    }
+}
+
+internal static class ApiTestHelpers
+{
+    internal static ApiMockHandler CreateAuthenticatedHandler(Func<HttpRequestMessage, HttpResponseMessage?>? extraHandler = null)
+    {
+        return new ApiMockHandler((request) =>
+        {
+            var extra = extraHandler?.Invoke(request);
+            if (extra != null) return extra;
+
+            var path = request.RequestUri?.AbsolutePath ?? "";
+
+            if (path.EndsWith("/auth/token"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        access_token = "mock-token",
+                        expires_in = 3600,
+                        refresh_token = "mock-refresh"
+                    }))
+                };
+            }
+
+            if (path.EndsWith("/me"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"member\":{\"id\":\"mock-member\",\"username\":\"user\"}}")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+}
+
+internal class ApiMockHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+    public ApiMockHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        _handler = handler;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_handler(request));
+    }
+}

--- a/LetterboxdSync.Tests/ServiceFactoryTests.cs
+++ b/LetterboxdSync.Tests/ServiceFactoryTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LetterboxdSync;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class ServiceFactoryTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public void ScrapingLetterboxdService_ImplementsInterface()
+    {
+        var service = new ScrapingLetterboxdService(TestLogger);
+        Assert.IsAssignableFrom<ILetterboxdService>(service);
+        service.Dispose();
+    }
+
+    [Fact]
+    public void LetterboxdApiClient_ImplementsInterface()
+    {
+        var client = new LetterboxdApiClient(TestLogger);
+        Assert.IsAssignableFrom<ILetterboxdService>(client);
+        client.Dispose();
+    }
+
+    [Fact]
+    public void ILetterboxdService_IsDisposable()
+    {
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(ILetterboxdService)));
+    }
+
+    [Fact]
+    public void LetterboxdApiConstants_HasRequiredFields()
+    {
+        Assert.False(string.IsNullOrEmpty(LetterboxdApiConstants.BaseUrl));
+        Assert.False(string.IsNullOrEmpty(LetterboxdApiConstants.ApiKey));
+        Assert.False(string.IsNullOrEmpty(LetterboxdApiConstants.ApiSecret));
+        Assert.StartsWith("https://", LetterboxdApiConstants.BaseUrl);
+        Assert.Equal(64, LetterboxdApiConstants.ApiKey.Length);
+        Assert.Equal(64, LetterboxdApiConstants.ApiSecret.Length);
+    }
+}

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -158,11 +158,8 @@ public class LetterboxdController : ControllerBase
 
         try
         {
-            using var httpClient = new LetterboxdHttpClient(_logger);
-            var auth = new LetterboxdAuth(httpClient, _logger);
-
-            httpClient.SetRawCookies(request.RawCookies);
-            await auth.AuthenticateAsync(request.LetterboxdUsername, request.LetterboxdPassword)
+            using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                request.LetterboxdUsername, request.LetterboxdPassword, request.RawCookies, _logger)
                 .ConfigureAwait(false);
 
             return Ok(new { success = true, letterboxdUsername = request.LetterboxdUsername });
@@ -195,18 +192,13 @@ public class LetterboxdController : ControllerBase
         if (account == null)
             return BadRequest(new { error = "No Letterboxd account configured for this user" });
 
-        using var httpClient = new LetterboxdHttpClient(_logger);
-        var auth = new LetterboxdAuth(httpClient, _logger);
-        var scraper = new LetterboxdScraper(httpClient, _logger);
-        var diary = new LetterboxdDiary(httpClient, auth, scraper, _logger);
-
         try
         {
-            httpClient.SetRawCookies(account.RawCookies);
-            await auth.AuthenticateAsync(account.LetterboxdUsername, account.LetterboxdPassword)
+            using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                 .ConfigureAwait(false);
 
-            await diary.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating)
+            await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating)
                 .ConfigureAwait(false);
 
             _logger.LogInformation("Posted review for {FilmSlug} by {Username}",

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -56,14 +56,11 @@ public class DiaryImportTask : IScheduledTask
             _logger.LogInformation("Starting diary import for {Username}", user.Username);
             SyncProgress.Start("Diary Import", "Authenticating");
 
-            using var httpClient = new LetterboxdHttpClient(_logger);
-            var auth = new LetterboxdAuth(httpClient, _logger);
-            var scraper = new LetterboxdScraper(httpClient, _logger);
-
+            ILetterboxdService service;
             try
             {
-                httpClient.SetRawCookies(account.RawCookies);
-                await auth.AuthenticateAsync(account.LetterboxdUsername, account.LetterboxdPassword)
+                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -72,11 +69,13 @@ public class DiaryImportTask : IScheduledTask
                 continue;
             }
 
+            using var _s = service;
+
             List<int> diaryTmdbIds;
             try
             {
                 SyncProgress.SetPhase("Scanning Letterboxd films");
-                diaryTmdbIds = await scraper.GetDiaryTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
+                diaryTmdbIds = await service.GetDiaryTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
                 _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd diary",
                     diaryTmdbIds.Count, account.LetterboxdUsername);
             }

--- a/LetterboxdSync/ILetterboxdService.cs
+++ b/LetterboxdSync/ILetterboxdService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LetterboxdSync;
+
+public interface ILetterboxdService : IDisposable
+{
+    Task AuthenticateAsync(string username, string password, string? rawCookies = null);
+
+    Task<FilmResult> LookupFilmByTmdbIdAsync(int tmdbId);
+
+    Task<DiaryInfo> GetDiaryInfoAsync(string filmIdOrSlug, string username);
+
+    Task MarkAsWatchedAsync(string filmSlug, string filmId, DateTime? date, bool liked,
+        string? productionId = null, bool rewatch = false, double? rating = null);
+
+    Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
+        bool isRewatch = false, string? date = null, double? rating = null);
+
+    Task<List<int>> GetWatchlistTmdbIdsAsync(string username);
+
+    Task<List<int>> GetDiaryTmdbIdsAsync(string username);
+}

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+public class LetterboxdApiClient : ILetterboxdService
+{
+    private readonly HttpClient _http;
+    private readonly ILogger _logger;
+    private string _username = string.Empty;
+    private string _memberId = string.Empty;
+    private string _accessToken = string.Empty;
+
+    private static readonly ConcurrentDictionary<string, TokenInfo> TokenCache = new();
+
+    public LetterboxdApiClient(ILogger logger, HttpMessageHandler? handler = null)
+    {
+        _logger = logger;
+        _http = handler != null ? new HttpClient(handler) : new HttpClient();
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("LetterboxdSync/1.5");
+    }
+
+    public async Task AuthenticateAsync(string username, string password, string? rawCookies = null)
+    {
+        _username = username;
+
+        // Check token cache first
+        if (TokenCache.TryGetValue(username, out var cached) && cached.ExpiresAtUtc > DateTime.UtcNow.AddMinutes(5))
+        {
+            _accessToken = cached.AccessToken;
+            _memberId = cached.MemberId;
+            _logger.LogDebug("Reusing cached API token for {Username}", username);
+            return;
+        }
+
+        // Try refresh if we have a refresh token
+        if (cached != null && !string.IsNullOrEmpty(cached.RefreshToken))
+        {
+            try
+            {
+                await RefreshTokenAsync(cached.RefreshToken).ConfigureAwait(false);
+                _logger.LogDebug("Refreshed API token for {Username}", username);
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("Token refresh failed for {Username}, doing full auth: {Message}", username, ex.Message);
+            }
+        }
+
+        // Full password auth
+        var body = $"grant_type=password&username={Uri.EscapeDataString(username)}&password={Uri.EscapeDataString(password)}";
+        var response = await SendSignedAsync(HttpMethod.Post, "/auth/token", body, "application/x-www-form-urlencoded")
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            throw new Exception($"Letterboxd API auth failed ({response.StatusCode}): {errorBody}");
+        }
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        ParseTokenResponse(json, username);
+
+        // Fetch member ID
+        await FetchMemberIdAsync().ConfigureAwait(false);
+
+        _logger.LogInformation("Authenticated with Letterboxd API as {Username}", username);
+    }
+
+    public async Task<FilmResult> LookupFilmByTmdbIdAsync(int tmdbId)
+    {
+        var response = await SendSignedAsync(HttpMethod.Get, "/films", queryParams: $"filmId=tmdb%3A{tmdbId}&perPage=1")
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        var items = doc.RootElement.GetProperty("items");
+
+        if (items.GetArrayLength() == 0)
+            throw new Exception($"Film with TMDb ID {tmdbId} not found on Letterboxd");
+
+        var film = items[0];
+        var lid = film.GetProperty("id").GetString()!;
+        var slug = ExtractSlugFromLink(film);
+
+        return new FilmResult(slug, lid, null);
+    }
+
+    public async Task<DiaryInfo> GetDiaryInfoAsync(string filmIdOrSlug, string username)
+    {
+        EnsureAuthenticated();
+
+        // filmIdOrSlug is the LID when coming from the API path
+        var response = await SendSignedAsync(HttpMethod.Get, "/log-entries",
+            queryParams: $"member={Uri.EscapeDataString(_memberId)}&film={Uri.EscapeDataString(filmIdOrSlug)}&perPage=1&sort=WhenAdded",
+            authenticated: true).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+            return new DiaryInfo(null, false);
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        var items = doc.RootElement.GetProperty("items");
+
+        if (items.GetArrayLength() == 0)
+            return new DiaryInfo(null, false);
+
+        var entry = items[0];
+        DateTime? lastDate = null;
+        if (entry.TryGetProperty("diaryDetails", out var details) &&
+            details.TryGetProperty("diaryDate", out var dateStr))
+        {
+            if (DateTime.TryParse(dateStr.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+                lastDate = parsed;
+        }
+
+        return new DiaryInfo(lastDate, true);
+    }
+
+    public async Task MarkAsWatchedAsync(string filmSlug, string filmId, DateTime? date, bool liked,
+        string? productionId = null, bool rewatch = false, double? rating = null)
+    {
+        EnsureAuthenticated();
+
+        var viewingDate = date ?? DateTime.Now;
+        var bodyObj = new Dictionary<string, object>
+        {
+            ["filmId"] = filmId,
+            ["diaryDetails"] = new Dictionary<string, object>
+            {
+                ["diaryDate"] = viewingDate.ToString("yyyy-MM-dd"),
+                ["rewatch"] = rewatch
+            },
+            ["like"] = liked,
+            ["tags"] = Array.Empty<string>()
+        };
+
+        if (rating.HasValue)
+            bodyObj["rating"] = rating.Value;
+
+        var body = JsonSerializer.Serialize(bodyObj);
+
+        var response = await SendSignedAsync(HttpMethod.Post, "/log-entries", body, "application/json", authenticated: true)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            ClearCachedToken();
+            throw new Exception("Letterboxd API token expired. Will re-authenticate on next sync.");
+        }
+
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NoContent)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            throw new Exception($"Failed to log film: {response.StatusCode} {errorBody}");
+        }
+    }
+
+    public async Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
+        bool isRewatch = false, string? date = null, double? rating = null)
+    {
+        EnsureAuthenticated();
+
+        // Need to look up the film LID from slug
+        var filmResponse = await SendSignedAsync(HttpMethod.Get, "/films",
+            queryParams: $"perPage=1").ConfigureAwait(false);
+
+        // For reviews, we use the filmSlug to resolve the LID
+        // The caller should have already done a lookup, so filmSlug might be a LID
+        // Try direct film endpoint first
+        var lookupResponse = await SendSignedAsync(HttpMethod.Get, $"/film/{Uri.EscapeDataString(filmSlug)}")
+            .ConfigureAwait(false);
+
+        string filmId;
+        if (lookupResponse.IsSuccessStatusCode)
+        {
+            var lookupJson = await lookupResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var lookupDoc = JsonDocument.Parse(lookupJson);
+            filmId = lookupDoc.RootElement.GetProperty("id").GetString()!;
+        }
+        else
+        {
+            // filmSlug might already be a LID
+            filmId = filmSlug;
+        }
+
+        var bodyObj = new Dictionary<string, object>
+        {
+            ["filmId"] = filmId,
+            ["diaryDetails"] = new Dictionary<string, object>
+            {
+                ["diaryDate"] = date ?? DateTime.Now.ToString("yyyy-MM-dd"),
+                ["rewatch"] = isRewatch
+            },
+            ["like"] = false,
+            ["tags"] = Array.Empty<string>()
+        };
+
+        if (!string.IsNullOrWhiteSpace(reviewText))
+        {
+            bodyObj["review"] = new Dictionary<string, object>
+            {
+                ["text"] = reviewText,
+                ["containsSpoilers"] = containsSpoilers
+            };
+        }
+
+        if (rating.HasValue)
+            bodyObj["rating"] = rating.Value;
+
+        var body = JsonSerializer.Serialize(bodyObj);
+
+        var response = await SendSignedAsync(HttpMethod.Post, "/log-entries", body, "application/json", authenticated: true)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NoContent)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            throw new Exception($"Failed to post review: {response.StatusCode} {errorBody}");
+        }
+    }
+
+    public async Task<List<int>> GetWatchlistTmdbIdsAsync(string username)
+    {
+        EnsureAuthenticated();
+        var tmdbIds = new List<int>();
+        string? cursor = null;
+
+        for (int page = 0; page < 50; page++)
+        {
+            var qp = $"perPage=100&member={Uri.EscapeDataString(_memberId)}";
+            if (cursor != null)
+                qp += $"&cursor={Uri.EscapeDataString(cursor)}";
+
+            var response = await SendSignedAsync(HttpMethod.Get, $"/member/{Uri.EscapeDataString(_memberId)}/watchlist",
+                queryParams: qp, authenticated: true).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            var items = doc.RootElement.GetProperty("items");
+
+            if (items.GetArrayLength() == 0)
+                break;
+
+            foreach (var item in items.EnumerateArray())
+            {
+                var tmdbId = ExtractTmdbId(item);
+                if (tmdbId.HasValue)
+                    tmdbIds.Add(tmdbId.Value);
+            }
+
+            if (doc.RootElement.TryGetProperty("cursor", out var cursorEl))
+                cursor = cursorEl.GetString();
+            else
+                break;
+        }
+
+        return tmdbIds;
+    }
+
+    public async Task<List<int>> GetDiaryTmdbIdsAsync(string username)
+    {
+        EnsureAuthenticated();
+        var tmdbIds = new List<int>();
+        string? cursor = null;
+
+        for (int page = 0; page < 50; page++)
+        {
+            var qp = $"perPage=100&member={Uri.EscapeDataString(_memberId)}";
+            if (cursor != null)
+                qp += $"&cursor={Uri.EscapeDataString(cursor)}";
+
+            var response = await SendSignedAsync(HttpMethod.Get, "/log-entries",
+                queryParams: qp, authenticated: true).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            var items = doc.RootElement.GetProperty("items");
+
+            if (items.GetArrayLength() == 0)
+                break;
+
+            foreach (var item in items.EnumerateArray())
+            {
+                if (item.TryGetProperty("film", out var film))
+                {
+                    var tmdbId = ExtractTmdbId(film);
+                    if (tmdbId.HasValue && !tmdbIds.Contains(tmdbId.Value))
+                        tmdbIds.Add(tmdbId.Value);
+                }
+            }
+
+            if (doc.RootElement.TryGetProperty("cursor", out var cursorEl))
+                cursor = cursorEl.GetString();
+            else
+                break;
+        }
+
+        return tmdbIds;
+    }
+
+    public void Dispose()
+    {
+        _http.Dispose();
+    }
+
+    // --- Private helpers ---
+
+    private async Task<HttpResponseMessage> SendSignedAsync(HttpMethod method, string path,
+        string? body = null, string? contentType = null, string? queryParams = null, bool authenticated = false)
+    {
+        var nonce = Guid.NewGuid().ToString();
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+
+        var url = $"{LetterboxdApiConstants.BaseUrl}{path}?apikey={LetterboxdApiConstants.ApiKey}&nonce={nonce}&timestamp={timestamp}";
+        if (!string.IsNullOrEmpty(queryParams))
+            url = $"{LetterboxdApiConstants.BaseUrl}{path}?{queryParams}&apikey={LetterboxdApiConstants.ApiKey}&nonce={nonce}&timestamp={timestamp}";
+
+        var bodyStr = body ?? string.Empty;
+        var sigInput = $"{method.Method}\0{url}\0{bodyStr}";
+        var signature = ComputeHmacSha256(LetterboxdApiConstants.ApiSecret, sigInput);
+
+        url += $"&signature={signature}";
+
+        using var request = new HttpRequestMessage(method, url);
+
+        if (authenticated && !string.IsNullOrEmpty(_accessToken))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+
+        if (body != null && contentType != null)
+            request.Content = new StringContent(body, Encoding.UTF8, contentType);
+
+        var response = await _http.SendAsync(request).ConfigureAwait(false);
+
+        // Handle rate limiting
+        if (response.StatusCode == (HttpStatusCode)429)
+        {
+            var retryAfter = response.Headers.RetryAfter?.Delta?.TotalSeconds ?? 10;
+            _logger.LogWarning("Letterboxd API rate limited, waiting {Seconds}s", retryAfter);
+            await Task.Delay(TimeSpan.FromSeconds(retryAfter)).ConfigureAwait(false);
+
+            // Retry once
+            using var retryRequest = new HttpRequestMessage(method, url);
+            if (authenticated && !string.IsNullOrEmpty(_accessToken))
+                retryRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+            if (body != null && contentType != null)
+                retryRequest.Content = new StringContent(body, Encoding.UTF8, contentType);
+            response = await _http.SendAsync(retryRequest).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    private static string ComputeHmacSha256(string secret, string message)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private void ParseTokenResponse(string json, string username)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        _accessToken = root.GetProperty("access_token").GetString()!;
+        var refreshToken = root.TryGetProperty("refresh_token", out var rt) ? rt.GetString() ?? string.Empty : string.Empty;
+        var expiresIn = root.TryGetProperty("expires_in", out var ei) ? ei.GetInt32() : 3600;
+
+        TokenCache[username] = new TokenInfo(
+            _accessToken,
+            refreshToken,
+            DateTime.UtcNow.AddSeconds(expiresIn),
+            _memberId);
+    }
+
+    private async Task RefreshTokenAsync(string refreshToken)
+    {
+        var body = $"grant_type=refresh_token&refresh_token={Uri.EscapeDataString(refreshToken)}";
+        var response = await SendSignedAsync(HttpMethod.Post, "/auth/token", body, "application/x-www-form-urlencoded")
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        ParseTokenResponse(json, _username);
+        await FetchMemberIdAsync().ConfigureAwait(false);
+    }
+
+    private async Task FetchMemberIdAsync()
+    {
+        var response = await SendSignedAsync(HttpMethod.Get, "/me", authenticated: true).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        _memberId = doc.RootElement.GetProperty("member").GetProperty("id").GetString()!;
+
+        // Update cache with member ID
+        if (TokenCache.TryGetValue(_username, out var cached))
+        {
+            TokenCache[_username] = cached with { MemberId = _memberId };
+        }
+    }
+
+    private void ClearCachedToken()
+    {
+        TokenCache.TryRemove(_username, out _);
+        _accessToken = string.Empty;
+        _logger.LogWarning("API token expired, cleared cache");
+    }
+
+    private void EnsureAuthenticated()
+    {
+        if (string.IsNullOrEmpty(_accessToken))
+            throw new InvalidOperationException("Not authenticated. Call AuthenticateAsync first.");
+    }
+
+    private static string ExtractSlugFromLink(JsonElement film)
+    {
+        if (film.TryGetProperty("links", out var links))
+        {
+            foreach (var link in links.EnumerateArray())
+            {
+                if (link.TryGetProperty("type", out var type) && type.GetString() == "letterboxd" &&
+                    link.TryGetProperty("url", out var url))
+                {
+                    var urlStr = url.GetString() ?? string.Empty;
+                    // https://letterboxd.com/film/fight-club/ -> fight-club
+                    var parts = urlStr.TrimEnd('/').Split('/');
+                    return parts.Length > 0 ? parts[^1] : string.Empty;
+                }
+            }
+        }
+
+        // Fallback: extract from top-level link property
+        if (film.TryGetProperty("link", out var directLink))
+        {
+            var urlStr = directLink.GetString() ?? string.Empty;
+            var parts = urlStr.TrimEnd('/').Split('/');
+            return parts.Length > 0 ? parts[^1] : string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static int? ExtractTmdbId(JsonElement film)
+    {
+        if (film.TryGetProperty("links", out var links))
+        {
+            foreach (var link in links.EnumerateArray())
+            {
+                if (link.TryGetProperty("type", out var type) && type.GetString() == "tmdb" &&
+                    link.TryGetProperty("id", out var id))
+                {
+                    if (int.TryParse(id.GetString(), out var tmdbId))
+                        return tmdbId;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    internal record TokenInfo(string AccessToken, string RefreshToken, DateTime ExpiresAtUtc, string MemberId);
+}

--- a/LetterboxdSync/LetterboxdApiConstants.cs
+++ b/LetterboxdSync/LetterboxdApiConstants.cs
@@ -1,0 +1,10 @@
+namespace LetterboxdSync;
+
+internal static class LetterboxdApiConstants
+{
+    internal const string BaseUrl = "https://api.letterboxd.com/api/v0";
+
+    internal const string ApiKey = "ebe3d27ec52a35fc8d1835c6531c37bd72b7a54337666d5bd759379b72ae16f0";
+
+    internal const string ApiSecret = "c60ce045d25bc90cb56026a8dd621eebeef995cbecc51951192da75348c977cd";
+}

--- a/LetterboxdSync/LetterboxdServiceFactory.cs
+++ b/LetterboxdSync/LetterboxdServiceFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+public static class LetterboxdServiceFactory
+{
+    public static async Task<ILetterboxdService> CreateAuthenticatedAsync(
+        string username, string password, string? rawCookies, ILogger logger)
+    {
+        try
+        {
+            var apiClient = new LetterboxdApiClient(logger);
+            await apiClient.AuthenticateAsync(username, password).ConfigureAwait(false);
+            logger.LogInformation("Using official Letterboxd API for {Username}", username);
+            return apiClient;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning("Official API auth failed for {Username}, falling back to scraping: {Message}",
+                username, ex.Message);
+        }
+
+        var scraping = new ScrapingLetterboxdService(logger);
+        await scraping.AuthenticateAsync(username, password, rawCookies).ConfigureAwait(false);
+        logger.LogInformation("Using web scraping fallback for {Username}", username);
+        return scraping;
+    }
+}

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <FileVersion>1.6.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/PlaybackHandler.cs
+++ b/LetterboxdSync/PlaybackHandler.cs
@@ -83,21 +83,16 @@ public class PlaybackHandler : IHostedService, IDisposable
             _logger.LogInformation("Syncing {Title} (TMDb:{TmdbId}) to Letterboxd for {Username}",
                 e.Item.Name, tmdbId, user.Username);
 
-            using var httpClient = new LetterboxdHttpClient(_logger);
-            var auth = new LetterboxdAuth(httpClient, _logger);
-            var scraper = new LetterboxdScraper(httpClient, _logger);
-            var diary = new LetterboxdDiary(httpClient, auth, scraper, _logger);
-
             try
             {
-                httpClient.SetRawCookies(account.RawCookies);
-                await auth.AuthenticateAsync(account.LetterboxdUsername, account.LetterboxdPassword)
+                using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                     .ConfigureAwait(false);
 
-                var film = await scraper.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
+                var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
                 var viewingDate = DateTime.Now.Date;
 
-                var diaryInfo = await scraper.GetDiaryInfoAsync(film.Slug, account.LetterboxdUsername).ConfigureAwait(false);
+                var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
 
                 if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
                 {
@@ -117,7 +112,7 @@ public class PlaybackHandler : IHostedService, IDisposable
                 bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
                 double? lbRating = Helpers.MapRating(userData?.Rating);
 
-                await diary.MarkAsWatchedAsync(film.Slug, film.FilmId, DateTime.Now, liked,
+                await service.MarkAsWatchedAsync(film.Slug, film.FilmId, DateTime.Now, liked,
                     film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
 
                 var action = isRewatch ? "Logged rewatch of" : "Logged";

--- a/LetterboxdSync/ScrapingLetterboxdService.cs
+++ b/LetterboxdSync/ScrapingLetterboxdService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+public class ScrapingLetterboxdService : ILetterboxdService
+{
+    private readonly LetterboxdHttpClient _http;
+    private readonly LetterboxdAuth _auth;
+    private readonly LetterboxdScraper _scraper;
+    private readonly LetterboxdDiary _diary;
+
+    public ScrapingLetterboxdService(ILogger logger)
+    {
+        _http = new LetterboxdHttpClient(logger);
+        _auth = new LetterboxdAuth(_http, logger);
+        _scraper = new LetterboxdScraper(_http, logger);
+        _diary = new LetterboxdDiary(_http, _auth, _scraper, logger);
+    }
+
+    public async Task AuthenticateAsync(string username, string password, string? rawCookies = null)
+    {
+        _http.SetRawCookies(rawCookies);
+        await _auth.AuthenticateAsync(username, password).ConfigureAwait(false);
+    }
+
+    public Task<FilmResult> LookupFilmByTmdbIdAsync(int tmdbId)
+        => _scraper.LookupFilmByTmdbIdAsync(tmdbId);
+
+    public Task<DiaryInfo> GetDiaryInfoAsync(string filmIdOrSlug, string username)
+        => _scraper.GetDiaryInfoAsync(filmIdOrSlug, username);
+
+    public Task MarkAsWatchedAsync(string filmSlug, string filmId, DateTime? date, bool liked,
+        string? productionId = null, bool rewatch = false, double? rating = null)
+        => _diary.MarkAsWatchedAsync(filmSlug, filmId, date, liked, productionId, rewatch, rating);
+
+    public Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
+        bool isRewatch = false, string? date = null, double? rating = null)
+        => _diary.PostReviewAsync(filmSlug, reviewText, containsSpoilers, isRewatch, date, rating);
+
+    public Task<List<int>> GetWatchlistTmdbIdsAsync(string username)
+        => _scraper.GetWatchlistTmdbIdsAsync(username);
+
+    public Task<List<int>> GetDiaryTmdbIdsAsync(string username)
+        => _scraper.GetDiaryTmdbIdsAsync(username);
+
+    public void Dispose()
+    {
+        _http.Dispose();
+    }
+}

--- a/LetterboxdSync/SyncTask.cs
+++ b/LetterboxdSync/SyncTask.cs
@@ -81,15 +81,11 @@ public class SyncTask : IScheduledTask
             if (movies.Count == 0)
                 continue;
 
-            using var httpClient = new LetterboxdHttpClient(_logger);
-            var auth = new LetterboxdAuth(httpClient, _logger);
-            var scraper = new LetterboxdScraper(httpClient, _logger);
-            var diary = new LetterboxdDiary(httpClient, auth, scraper, _logger);
-
+            ILetterboxdService service;
             try
             {
-                httpClient.SetRawCookies(account.RawCookies);
-                await auth.AuthenticateAsync(account.LetterboxdUsername, account.LetterboxdPassword)
+                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -97,6 +93,8 @@ public class SyncTask : IScheduledTask
                 _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
                 continue;
             }
+
+            using var _ = service;
 
             var synced = 0;
             var skipped = 0;
@@ -119,13 +117,13 @@ public class SyncTask : IScheduledTask
 
                 try
                 {
-                    var film = await scraper.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
+                    var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
                     await Task.Delay(3000 + Random.Shared.Next(2000), cancellationToken).ConfigureAwait(false);
 
                     var userData = _userDataManager.GetUserData(user, movie);
                     var viewingDate = userData?.LastPlayedDate?.Date ?? DateTime.Now.Date;
 
-                    var diaryInfo = await scraper.GetDiaryInfoAsync(film.Slug, account.LetterboxdUsername).ConfigureAwait(false);
+                    var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
                     if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
                     {
                         _logger.LogDebug("{Title} already logged on {Date}, skipping",
@@ -145,7 +143,7 @@ public class SyncTask : IScheduledTask
                     bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
                     double? lbRating = Helpers.MapRating(userData?.Rating);
 
-                    await diary.MarkAsWatchedAsync(film.Slug, film.FilmId, userData?.LastPlayedDate, liked,
+                    await service.MarkAsWatchedAsync(film.Slug, film.FilmId, userData?.LastPlayedDate, liked,
                         film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
 
                     _logger.LogInformation("Logged {Title} (TMDb:{TmdbId}) to Letterboxd for {Username} on {Date}",

--- a/LetterboxdSync/WatchlistSyncTask.cs
+++ b/LetterboxdSync/WatchlistSyncTask.cs
@@ -57,14 +57,11 @@ public class WatchlistSyncTask : IScheduledTask
 
             _logger.LogInformation("Starting watchlist sync for {Username}", user.Username);
 
-            using var httpClient = new LetterboxdHttpClient(_logger);
-            var auth = new LetterboxdAuth(httpClient, _logger);
-            var scraper = new LetterboxdScraper(httpClient, _logger);
-
+            ILetterboxdService service;
             try
             {
-                httpClient.SetRawCookies(account.RawCookies);
-                await auth.AuthenticateAsync(account.LetterboxdUsername, account.LetterboxdPassword)
+                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -73,10 +70,12 @@ public class WatchlistSyncTask : IScheduledTask
                 continue;
             }
 
+            using var _s = service;
+
             List<int> tmdbIds;
             try
             {
-                tmdbIds = await scraper.GetWatchlistTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
+                tmdbIds = await service.GetWatchlistTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
                 _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd watchlist",
                     tmdbIds.Count, account.LetterboxdUsername);
             }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.6.0.0",
+        "changelog": "Official Letterboxd API integration (primary) with web scraping fallback, eliminates Cloudflare 403 errors",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.6.0/jellyfin-plugin-letterboxd-v1.6.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-07T00:00:00Z"
+      },
+      {
         "version": "1.5.0.0",
         "changelog": "User self-service account setup, sidebar link for all users, test connection button, standalone user page via File Transformation injection",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
- Uses the official Letterboxd API (`api.letterboxd.com/api/v0`) as the primary sync path, eliminating Cloudflare 403 errors
- Existing web scraping automatically activates as fallback if API credentials are ever revoked
- No new user configuration needed, API credentials are hardcoded (same pattern as Trakt plugin)

Fixes #7, fixes #8, fixes #9

## Architecture
- `ILetterboxdService` interface abstracts all Letterboxd operations (lookup, diary, watchlist, reviews)
- `LetterboxdApiClient` implements the official API with HMAC-SHA256 request signing and OAuth2 token management
- `ScrapingLetterboxdService` wraps existing scraping classes (unchanged) behind the same interface
- `LetterboxdServiceFactory.CreateAuthenticatedAsync()` tries API first, falls back to scraping on auth failure
- All 5 consumers (SyncTask, PlaybackHandler, WatchlistSyncTask, DiaryImportTask, Controller) refactored to use the factory

## API details
- Auth: HMAC-signed requests + OAuth2 password grant (tokens cached per-user, auto-refresh)
- Film lookup: `GET /films?filmId=tmdb:{id}` (no HTML parsing needed)
- Diary logging: `POST /log-entries` with JSON body
- Rate limit: respects 429 with Retry-After backoff
- No artificial delays needed (unlike scraping's 3-5s anti-Cloudflare delays)

## Test plan
- [x] 129 tests pass (17 new)
- [x] HMAC signing produces correct signatures
- [x] Token caching works across test runs
- [x] Film lookup, diary creation, diary info parsing tested with mock handlers
- [x] Rate limit retry tested
- [x] Factory fallback logic tested
- [x] Deployed to server, triggered sync: "Using official Letterboxd API for 8bitproxy"
- [x] Real-time playback sync verified (Wuthering Heights logged via API)