### PR TITLE
v1.6.1: fix review posting via official API (fixes #12, #13)

### DIFF
--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -198,7 +198,7 @@ public class LetterboxdController : ControllerBase
                 account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
                 .ConfigureAwait(false);
 
-            await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating)
+            await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating, request.TmdbId)
                 .ConfigureAwait(false);
 
             _logger.LogInformation("Posted review for {FilmSlug} by {Username}",
@@ -247,4 +247,5 @@ public class ReviewRequest
     public bool IsRewatch { get; set; }
     public string? Date { get; set; }
     public double? Rating { get; set; }
+    public int? TmdbId { get; set; }
 }

--- a/LetterboxdSync/ILetterboxdService.cs
+++ b/LetterboxdSync/ILetterboxdService.cs
@@ -16,7 +16,7 @@ public interface ILetterboxdService : IDisposable
         string? productionId = null, bool rewatch = false, double? rating = null);
 
     Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
-        bool isRewatch = false, string? date = null, double? rating = null);
+        bool isRewatch = false, string? date = null, double? rating = null, int? tmdbId = null);
 
     Task<List<int>> GetWatchlistTmdbIdsAsync(string username);
 

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -29,7 +29,7 @@ public class LetterboxdApiClient : ILetterboxdService
         _logger = logger;
         _http = handler != null ? new HttpClient(handler) : new HttpClient();
         _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd("LetterboxdSync/1.5");
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("LetterboxdSync/1.6");
     }
 
     public async Task AuthenticateAsync(string username, string password, string? rawCookies = null)
@@ -171,32 +171,17 @@ public class LetterboxdApiClient : ILetterboxdService
     }
 
     public async Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
-        bool isRewatch = false, string? date = null, double? rating = null)
+        bool isRewatch = false, string? date = null, double? rating = null, int? tmdbId = null)
     {
         EnsureAuthenticated();
 
-        // Need to look up the film LID from slug
-        var filmResponse = await SendSignedAsync(HttpMethod.Get, "/films",
-            queryParams: $"perPage=1").ConfigureAwait(false);
+        // The Letterboxd API /log-entries endpoint requires an LID, not a slug.
+        // Resolve the LID via TMDb ID (the only identifier SyncHistory stores that the API accepts).
+        if (!tmdbId.HasValue || tmdbId.Value <= 0)
+            throw new Exception($"Cannot post review for {filmSlug} via the official API without a TMDb ID.");
 
-        // For reviews, we use the filmSlug to resolve the LID
-        // The caller should have already done a lookup, so filmSlug might be a LID
-        // Try direct film endpoint first
-        var lookupResponse = await SendSignedAsync(HttpMethod.Get, $"/film/{Uri.EscapeDataString(filmSlug)}")
-            .ConfigureAwait(false);
-
-        string filmId;
-        if (lookupResponse.IsSuccessStatusCode)
-        {
-            var lookupJson = await lookupResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-            using var lookupDoc = JsonDocument.Parse(lookupJson);
-            filmId = lookupDoc.RootElement.GetProperty("id").GetString()!;
-        }
-        else
-        {
-            // filmSlug might already be a LID
-            filmId = filmSlug;
-        }
+        var film = await LookupFilmByTmdbIdAsync(tmdbId.Value).ConfigureAwait(false);
+        var filmId = film.FilmId;
 
         var bodyObj = new Dictionary<string, object>
         {

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.6.0.0</AssemblyVersion>
-    <FileVersion>1.6.0.0</FileVersion>
+    <AssemblyVersion>1.6.1.0</AssemblyVersion>
+    <FileVersion>1.6.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/ScrapingLetterboxdService.cs
+++ b/LetterboxdSync/ScrapingLetterboxdService.cs
@@ -37,7 +37,7 @@ public class ScrapingLetterboxdService : ILetterboxdService
         => _diary.MarkAsWatchedAsync(filmSlug, filmId, date, liked, productionId, rewatch, rating);
 
     public Task PostReviewAsync(string filmSlug, string? reviewText, bool containsSpoilers = false,
-        bool isRewatch = false, string? date = null, double? rating = null)
+        bool isRewatch = false, string? date = null, double? rating = null, int? tmdbId = null)
         => _diary.PostReviewAsync(filmSlug, reviewText, containsSpoilers, isRewatch, date, rating);
 
     public Task<List<int>> GetWatchlistTmdbIdsAsync(string username)

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -302,7 +302,7 @@
                                     var ts = new Date(e.Timestamp);
                                     var time = ts.toLocaleDateString() + ' ' + ts.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'});
                                     var canReview = (s === 'Success' || s === 'Rewatch' || s === 'Skipped');
-                                    var btn = (e.FilmSlug && canReview) ? '<button type="button" onclick="LB.openReview(\'' + e.FilmSlug + '\',\'' + e.FilmTitle.replace(/'/g, "\\'") + '\')" class="lb-btn lb-btn-review">Review</button>' : '';
+                                    var btn = (e.FilmSlug && canReview) ? '<button type="button" onclick="LB.openReview(\'' + e.FilmSlug + '\',\'' + e.FilmTitle.replace(/'/g, "\\'") + '\',' + (e.TmdbId || 0) + ')" class="lb-btn lb-btn-review">Review</button>' : '';
                                     var errText = '';
                                     if (s === 'Failed' && e.Error) {
                                         var shortErr = e.Error;
@@ -397,8 +397,9 @@
                             });
                         },
 
-                        openReview: function (slug, title) {
+                        openReview: function (slug, title, tmdbId) {
                             this.currentSlug = slug;
+                            this.currentTmdbId = tmdbId || 0;
                             document.getElementById('reviewTitle').textContent = 'Review: ' + title;
                             document.getElementById('reviewText').value = '';
                             document.getElementById('reviewSpoilers').checked = false;
@@ -431,6 +432,7 @@
                                 type: 'POST', contentType: 'application/json',
                                 data: JSON.stringify({
                                     filmSlug: self.currentSlug,
+                                    tmdbId: self.currentTmdbId || null,
                                     reviewText: text || null,
                                     containsSpoilers: document.getElementById('reviewSpoilers').checked,
                                     isRewatch: isRewatch,

--- a/LetterboxdSync/Web/statsPage.html
+++ b/LetterboxdSync/Web/statsPage.html
@@ -163,7 +163,7 @@
 
                                     var reviewBtn = '';
                                     if (e.FilmSlug && (e.Status === 0 || e.Status === 3)) {
-                                        reviewBtn = '<button type="button" onclick="LBStats.openReview(\'' + e.FilmSlug + '\', \'' + e.FilmTitle.replace(/'/g, "\\'") + '\')" style="background:#2c3440;color:#fff;border:1px solid #444;border-radius:4px;padding:0.2em 0.6em;cursor:pointer;font-size:0.85em;">Write</button>';
+                                        reviewBtn = '<button type="button" onclick="LBStats.openReview(\'' + e.FilmSlug + '\', \'' + e.FilmTitle.replace(/'/g, "\\'") + '\', ' + (e.TmdbId || 0) + ')" style="background:#2c3440;color:#fff;border:1px solid #444;border-radius:4px;padding:0.2em 0.6em;cursor:pointer;font-size:0.85em;">Write</button>';
                                     }
 
                                     var errorInfo = e.Status === 2 && e.Error ? ' title="' + e.Error.replace(/"/g, '&quot;') + '"' : '';
@@ -222,7 +222,7 @@
                                     var timeStr = ts.toLocaleDateString() + ' ' + ts.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'});
                                     var reviewBtn = '';
                                     if (e.FilmSlug && (e.Status === 0 || e.Status === 3)) {
-                                        reviewBtn = '<button type="button" onclick="LBStats.openReview(\'' + e.FilmSlug + '\', \'' + e.FilmTitle.replace(/'/g, "\\'") + '\')" style="background:#2c3440;color:#fff;border:1px solid #444;border-radius:4px;padding:0.2em 0.6em;cursor:pointer;font-size:0.85em;">Review</button>';
+                                        reviewBtn = '<button type="button" onclick="LBStats.openReview(\'' + e.FilmSlug + '\', \'' + e.FilmTitle.replace(/'/g, "\\'") + '\', ' + (e.TmdbId || 0) + ')" style="background:#2c3440;color:#fff;border:1px solid #444;border-radius:4px;padding:0.2em 0.6em;cursor:pointer;font-size:0.85em;">Review</button>';
                                     }
                                     var errorInfo = e.Status === 2 && e.Error ? ' title="' + e.Error.replace(/"/g, '&quot;') + '"' : '';
                                     tr.innerHTML = '<td style="padding:0.5em;">' + filmLink + '</td>'
@@ -291,8 +291,9 @@
                             });
                         },
 
-                        openReview: function (slug, title) {
+                        openReview: function (slug, title, tmdbId) {
                             this.currentSlug = slug;
+                            this.currentTmdbId = tmdbId || 0;
                             document.getElementById('reviewTitle').textContent = 'Review: ' + title;
                             document.getElementById('reviewText').value = '';
                             document.getElementById('reviewSpoilers').checked = false;
@@ -313,6 +314,7 @@
 
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/Review', {
                                 filmSlug: self.currentSlug,
+                                tmdbId: self.currentTmdbId || null,
                                 reviewText: text,
                                 containsSpoilers: document.getElementById('reviewSpoilers').checked
                             })

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -399,7 +399,7 @@
                                     var ts = new Date(e.Timestamp);
                                     var time = ts.toLocaleDateString() + ' ' + ts.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'});
                                     var canReview = (s === 'Success' || s === 'Rewatch' || s === 'Skipped');
-                                    var btn = (e.FilmSlug && canReview) ? '<button type="button" onclick="LBUser.openReview(\'' + e.FilmSlug + '\',\'' + e.FilmTitle.replace(/'/g, "\\'") + '\')" class="lb-btn lb-btn-review">Review</button>' : '';
+                                    var btn = (e.FilmSlug && canReview) ? '<button type="button" onclick="LBUser.openReview(\'' + e.FilmSlug + '\',\'' + e.FilmTitle.replace(/'/g, "\\'") + '\',' + (e.TmdbId || 0) + ')" class="lb-btn lb-btn-review">Review</button>' : '';
                                     var errText = '';
                                     if (s === 'Failed' && e.Error) {
                                         var shortErr = e.Error;
@@ -485,8 +485,9 @@
                             });
                         },
 
-                        openReview: function (slug, title) {
+                        openReview: function (slug, title, tmdbId) {
                             this.currentSlug = slug;
+                            this.currentTmdbId = tmdbId || 0;
                             document.getElementById('reviewTitle').textContent = 'Review: ' + title;
                             document.getElementById('reviewText').value = '';
                             document.getElementById('reviewSpoilers').checked = false;
@@ -516,6 +517,7 @@
 
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/Review', {
                                 filmSlug: self.currentSlug,
+                                tmdbId: self.currentTmdbId || null,
                                 reviewText: text || null,
                                 containsSpoilers: document.getElementById('reviewSpoilers').checked,
                                 isRewatch: isRewatch,

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.6.1.0",
+        "changelog": "Fix review posting via official API: resolve film LID from TMDb ID instead of slug (fixes #12)",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.6.1/jellyfin-plugin-letterboxd-v1.6.1.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-14T00:00:00Z"
+      },
+      {
         "version": "1.6.0.0",
         "changelog": "Official Letterboxd API integration (primary) with web scraping fallback, eliminates Cloudflare 403 errors",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
- Fixes #12 and #13 — reviews posted from Jellyfin fail with `NotFound {"error":true,"message":"Film not found"}` on the official API path.
- Root cause: `LetterboxdApiClient.PostReviewAsync` tried `GET /film/{slug}` to resolve the LID, but that endpoint expects a Letterboxd ID (LID), not a slug. On failure it fell through to sending the slug string as `filmId`, which Letterboxd rejects.
- Fix: resolve the LID via `LookupFilmByTmdbIdAsync(tmdbId)` (same call the playback path already uses). TMDb IDs are already stored in `SyncHistory`, so the Review UI passes `e.TmdbId` through to the new `tmdbId` field on `ReviewRequest`.
- Scraping fallback path is unchanged — it continues to resolve the LID by scraping `/film/{slug}/` HTML.

## Changes
- `LetterboxdApiClient.PostReviewAsync`: now requires a TmdbId and resolves the LID via `/films?filmId=tmdb:{id}`. Removed the broken `/film/{slug}` lookup and the dead `/films?perPage=1` call.
- `ILetterboxdService.PostReviewAsync` + both implementations: accept optional `int? tmdbId` parameter.
- `ReviewRequest`: adds `TmdbId` field.
- `configPage.html`, `userPage.html`, `statsPage.html`: pass `e.TmdbId` through to `openReview()` and include it in the POST body.
- Version bump to 1.6.1.0 (csproj, manifest).

## Test plan
- [x] `dotnet build` — succeeds
- [x] `dotnet test` — 129/129 pass
- [x] Deploy to server and confirm review post succeeds against the official API
- [x] Confirm scraping fallback path still works