### PR TITLE
Per-account User-Agent override for Cloudflare cookie compatibility

### DIFF
--- a/LetterboxdSync.Tests/HttpClientTests.cs
+++ b/LetterboxdSync.Tests/HttpClientTests.cs
@@ -16,6 +16,38 @@ public class HttpClientTests
     private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
 
     [Fact]
+    public void DefaultUserAgent_AppliedWhenNoOverride()
+    {
+        using var http = new LetterboxdHttpClient(TestLogger);
+        Assert.Equal(LetterboxdHttpClient.DefaultUserAgent,
+            http.Http.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public void CustomUserAgent_AppliedWhenProvided()
+    {
+        const string chromeUa = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+        using var http = new LetterboxdHttpClient(TestLogger, chromeUa);
+        Assert.Equal(chromeUa, http.Http.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public void InvalidUserAgent_FallsBackToDefault()
+    {
+        using var http = new LetterboxdHttpClient(TestLogger, "this is not a valid \0 ua");
+        Assert.Equal(LetterboxdHttpClient.DefaultUserAgent,
+            http.Http.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public void WhitespaceUserAgent_FallsBackToDefault()
+    {
+        using var http = new LetterboxdHttpClient(TestLogger, "   ");
+        Assert.Equal(LetterboxdHttpClient.DefaultUserAgent,
+            http.Http.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
     public void SetRawCookies_ParsesMultipleCookies()
     {
         using var http = new LetterboxdHttpClient(TestLogger);

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -8,6 +8,8 @@ public class AccountUpdateRequest
 
     public string? RawCookies { get; set; }
 
+    public string? UserAgent { get; set; }
+
     public bool Enabled { get; set; }
 
     public bool SyncFavorites { get; set; }
@@ -28,4 +30,6 @@ public class TestConnectionRequest
     public string LetterboxdPassword { get; set; } = string.Empty;
 
     public string? RawCookies { get; set; }
+
+    public string? UserAgent { get; set; }
 }

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -91,6 +91,7 @@ public class LetterboxdController : ControllerBase
                 letterboxdUsername = string.Empty,
                 letterboxdPassword = string.Empty,
                 rawCookies = (string?)null,
+                userAgent = (string?)null,
                 enabled = false,
                 syncFavorites = false,
                 enableDateFilter = false,
@@ -106,6 +107,7 @@ public class LetterboxdController : ControllerBase
             letterboxdUsername = account.LetterboxdUsername,
             letterboxdPassword = account.LetterboxdPassword,
             rawCookies = account.RawCookies,
+            userAgent = account.UserAgent,
             enabled = account.Enabled,
             syncFavorites = account.SyncFavorites,
             enableDateFilter = account.EnableDateFilter,
@@ -135,6 +137,7 @@ public class LetterboxdController : ControllerBase
         account.LetterboxdUsername = request.LetterboxdUsername;
         account.LetterboxdPassword = request.LetterboxdPassword;
         account.RawCookies = request.RawCookies;
+        account.UserAgent = request.UserAgent;
         account.Enabled = request.Enabled;
         account.SyncFavorites = request.SyncFavorites;
         account.EnableDateFilter = request.EnableDateFilter;
@@ -159,7 +162,7 @@ public class LetterboxdController : ControllerBase
         try
         {
             using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                request.LetterboxdUsername, request.LetterboxdPassword, request.RawCookies, _logger)
+                request.LetterboxdUsername, request.LetterboxdPassword, request.RawCookies, _logger, request.UserAgent)
                 .ConfigureAwait(false);
 
             return Ok(new { success = true, letterboxdUsername = request.LetterboxdUsername });
@@ -195,7 +198,7 @@ public class LetterboxdController : ControllerBase
         try
         {
             using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
+                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
                 .ConfigureAwait(false);
 
             await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating, request.TmdbId)

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -12,6 +12,8 @@ public class Account
 
     public string? RawCookies { get; set; }
 
+    public string? UserAgent { get; set; }
+
     public bool Enabled { get; set; }
 
     public bool SyncFavorites { get; set; }

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -60,7 +60,7 @@ public class DiaryImportTask : IScheduledTask
             try
             {
                 service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/LetterboxdSync/LetterboxdHttpClient.cs
+++ b/LetterboxdSync/LetterboxdHttpClient.cs
@@ -17,18 +17,27 @@ public class LetterboxdHttpClient : IDisposable
     internal static readonly Uri BaseUri = new Uri("https://letterboxd.com/");
     internal const int MaxRetries = 3;
 
+    /// <summary>
+    /// Default browser User-Agent used when an account does not specify one.
+    /// Cloudflare binds <c>cf_clearance</c> cookies to the exact UA that solved the
+    /// challenge, so users who harvest cookies from a different browser must override
+    /// this with the UA of the browser they used.
+    /// </summary>
+    public const string DefaultUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0";
+
     private readonly ILogger _logger;
     internal readonly CookieContainer CookieContainer = new();
     private readonly HttpClientHandler _handler;
     internal readonly HttpClient Http;
     internal string Csrf = string.Empty;
 
-    public LetterboxdHttpClient(ILogger logger)
-        : this(logger, null)
+    public LetterboxdHttpClient(ILogger logger, string? userAgent = null)
+        : this(logger, null, userAgent)
     {
     }
 
-    internal LetterboxdHttpClient(ILogger logger, HttpMessageHandler? handler)
+    internal LetterboxdHttpClient(ILogger logger, HttpMessageHandler? handler, string? userAgent = null)
     {
         _logger = logger;
         _handler = handler as HttpClientHandler ?? new HttpClientHandler
@@ -42,9 +51,13 @@ public class LetterboxdHttpClient : IDisposable
             ? new HttpClient(handler, disposeHandler: false) { BaseAddress = BaseUri }
             : new HttpClient(_handler) { BaseAddress = BaseUri };
 
+        var ua = string.IsNullOrWhiteSpace(userAgent) ? DefaultUserAgent : userAgent!.Trim();
         Http.DefaultRequestHeaders.UserAgent.Clear();
-        Http.DefaultRequestHeaders.UserAgent.ParseAdd(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0");
+        if (!Http.DefaultRequestHeaders.UserAgent.TryParseAdd(ua))
+        {
+            logger.LogWarning("Invalid User-Agent override, falling back to default: {Ua}", ua);
+            Http.DefaultRequestHeaders.UserAgent.ParseAdd(DefaultUserAgent);
+        }
         Http.DefaultRequestHeaders.Accept.Clear();
         Http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
         Http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));

--- a/LetterboxdSync/LetterboxdServiceFactory.cs
+++ b/LetterboxdSync/LetterboxdServiceFactory.cs
@@ -7,7 +7,7 @@ namespace LetterboxdSync;
 public static class LetterboxdServiceFactory
 {
     public static async Task<ILetterboxdService> CreateAuthenticatedAsync(
-        string username, string password, string? rawCookies, ILogger logger)
+        string username, string password, string? rawCookies, ILogger logger, string? userAgent = null)
     {
         try
         {
@@ -22,7 +22,7 @@ public static class LetterboxdServiceFactory
                 username, ex.Message);
         }
 
-        var scraping = new ScrapingLetterboxdService(logger);
+        var scraping = new ScrapingLetterboxdService(logger, userAgent);
         await scraping.AuthenticateAsync(username, password, rawCookies).ConfigureAwait(false);
         logger.LogInformation("Using web scraping fallback for {Username}", username);
         return scraping;

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.6.1.0</AssemblyVersion>
-    <FileVersion>1.6.1.0</FileVersion>
+    <AssemblyVersion>1.7.0.0</AssemblyVersion>
+    <FileVersion>1.7.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/PlaybackHandler.cs
+++ b/LetterboxdSync/PlaybackHandler.cs
@@ -86,7 +86,7 @@ public class PlaybackHandler : IHostedService, IDisposable
             try
             {
                 using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
                     .ConfigureAwait(false);
 
                 var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);

--- a/LetterboxdSync/ScrapingLetterboxdService.cs
+++ b/LetterboxdSync/ScrapingLetterboxdService.cs
@@ -12,9 +12,9 @@ public class ScrapingLetterboxdService : ILetterboxdService
     private readonly LetterboxdScraper _scraper;
     private readonly LetterboxdDiary _diary;
 
-    public ScrapingLetterboxdService(ILogger logger)
+    public ScrapingLetterboxdService(ILogger logger, string? userAgent = null)
     {
-        _http = new LetterboxdHttpClient(logger);
+        _http = new LetterboxdHttpClient(logger, userAgent);
         _auth = new LetterboxdAuth(_http, logger);
         _scraper = new LetterboxdScraper(_http, logger);
         _diary = new LetterboxdDiary(_http, _auth, _scraper, logger);

--- a/LetterboxdSync/SyncTask.cs
+++ b/LetterboxdSync/SyncTask.cs
@@ -85,7 +85,7 @@ public class SyncTask : IScheduledTask
             try
             {
                 service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/LetterboxdSync/WatchlistSyncTask.cs
+++ b/LetterboxdSync/WatchlistSyncTask.cs
@@ -61,7 +61,7 @@ public class WatchlistSyncTask : IScheduledTask
             try
             {
                 service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger)
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -193,6 +193,9 @@
                                 + '<input type="password" class="lbPassword" /></div>'
                                 + '<div style="margin-bottom:0.5em;"><label class="lb-field">Raw Cookies <span class="c-muted">(optional, Cloudflare bypass)</span></label>'
                                 + '<input type="text" class="rawCookies" placeholder="Paste cookie header if login gets 403" /></div>'
+                                + '<div style="margin-bottom:0.5em;"><label class="lb-field">User-Agent <span class="c-muted">(optional, must match the browser used to copy cookies)</span></label>'
+                                + '<input type="text" class="userAgent" placeholder="Leave blank for default (Firefox 134 on Windows)" />'
+                                + '<div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Cloudflare ties the <code>cf_clearance</code> cookie to the exact User-Agent that solved the challenge. If you copied cookies from Chrome, paste Chrome\'s UA here. Find yours at <a href="https://www.whatismybrowser.com/detect/what-is-my-user-agent/" target="_blank" class="lb-link">whatismybrowser.com</a>.</div></div>'
                                 + '<div class="lb-checks">'
                                 + '<label><input type="checkbox" class="accountEnabled" /> Enabled</label>'
                                 + '<label><input type="checkbox" class="syncFavorites" /> Favorites as liked</label>'
@@ -215,6 +218,7 @@
                                 entry.querySelector('.lbUsername').value = account.LetterboxdUsername || '';
                                 entry.querySelector('.lbPassword').value = account.LetterboxdPassword || '';
                                 entry.querySelector('.rawCookies').value = account.RawCookies || '';
+                                entry.querySelector('.userAgent').value = account.UserAgent || '';
                                 entry.querySelector('.accountEnabled').checked = account.Enabled !== false;
                                 entry.querySelector('.syncFavorites').checked = account.SyncFavorites === true;
                                 entry.querySelector('.enableDateFilter').checked = account.EnableDateFilter === true;
@@ -239,6 +243,7 @@
                                     LetterboxdUsername: entry.querySelector('.lbUsername').value,
                                     LetterboxdPassword: entry.querySelector('.lbPassword').value,
                                     RawCookies: entry.querySelector('.rawCookies').value || null,
+                                    UserAgent: entry.querySelector('.userAgent').value || null,
                                     Enabled: entry.querySelector('.accountEnabled').checked,
                                     SyncFavorites: entry.querySelector('.syncFavorites').checked,
                                     EnableDateFilter: entry.querySelector('.enableDateFilter').checked,

--- a/README.md
+++ b/README.md
@@ -86,10 +86,13 @@ If login fails with a 403 error:
 1. Log into Letterboxd in your browser
 2. Open DevTools (F12) > Network tab
 3. Reload and click any request to `letterboxd.com`
-4. Copy the full **Cookie** header value
+4. Copy the **Cookie** header value (everything after `Cookie: `, not the label itself)
 5. Paste it into the **Raw Cookies** field
+6. Copy the **User-Agent** request header value from the same request and paste it into the **User-Agent** field
 
 The `cf_clearance` cookie expires periodically and may need refreshing.
+
+**Important:** Cloudflare ties `cf_clearance` to the exact User-Agent that solved the challenge. If you copied cookies from Chrome but leave the User-Agent field blank, the plugin sends the default Firefox UA and Cloudflare will reject the cookie. Always paste the User-Agent from the same browser you copied the cookies from. Leave it blank only if you copied cookies from Firefox 134 on Windows.
 
 ## Requirements
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.7.0.0",
+        "changelog": "Per-account User-Agent override so Cloudflare cookies copied from any browser (Chrome, Safari, etc.) work without UA mismatch",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.7.0/jellyfin-plugin-letterboxd-v1.7.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-25T00:00:00Z"
+      },
+      {
         "version": "1.6.1.0",
         "changelog": "Fix review posting via official API: resolve film LID from TMDb ID instead of slug (fixes #12)",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

Cloudflare binds `cf_clearance` cookies to the **exact User-Agent** that solved the challenge. The plugin currently hardcodes Firefox 134 on Windows, so users who copy cookies from any other browser (Chrome, Safari, mobile, etc.) get blocked with 403s even when the cookie itself is fresh and complete.

This PR adds a per-account `UserAgent` field next to `RawCookies` so users can paste the UA from the same browser they harvested cookies from. Leaving it blank preserves existing behavior (Firefox 134 default).

## Changes

- `Account.UserAgent` config field (nullable, optional)
- `LetterboxdHttpClient` accepts a UA override via constructor; exposes `DefaultUserAgent` as a public constant
- Invalid UA strings fall back to default with a logged warning (`TryParseAdd`)
- UA plumbed through `LetterboxdServiceFactory.CreateAuthenticatedAsync` to `ScrapingLetterboxdService`. The official `LetterboxdApiClient` path is unaffected since it uses an API-style UA, not browser impersonation.
- All five callers updated: `SyncTask`, `WatchlistSyncTask`, `DiaryImportTask`, `PlaybackHandler`, `LetterboxdController` (Account save/load, TestConnection, Review)
- Config UI: new "User-Agent" input under "Raw Cookies" with help text and a link to whatismybrowser.com
- README: clearer Cloudflare instructions, including the requirement to paste the matching UA
- 4 new tests covering: default UA applied, custom UA applied, invalid UA falls back, whitespace falls back

Version bumped to 1.7.0.

## Test plan

- [x] `dotnet build -c Release` clean
- [x] `dotnet test` passes (133/133, +4 new)
- [x] Manually verify: deploy to a Jellyfin instance, configure an account, paste a Chrome UA + Chrome-issued cookies, confirm scraping fallback succeeds where it would previously 403
- [x] Verify config page round-trips (save then reload preserves the value)
- [x] Verify leaving UA blank still works (uses Firefox default)