### PR TITLE
fix: watchlist sync returning empty results via official API

### DIFF
--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -227,7 +227,7 @@ public class LetterboxdApiClient : ILetterboxdService
 
         for (int page = 0; page < 50; page++)
         {
-            var qp = $"perPage=100&member={Uri.EscapeDataString(_memberId)}";
+            var qp = "perPage=100";
             if (cursor != null)
                 qp += $"&cursor={Uri.EscapeDataString(cursor)}";
 

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.7.0.0</AssemblyVersion>
-    <FileVersion>1.7.0.0</FileVersion>
+    <AssemblyVersion>1.7.1.0</AssemblyVersion>
+    <FileVersion>1.7.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.7.1.0",
+        "changelog": "Fix watchlist sync returning 0 films via official API: redundant `member` query param caused Letterboxd to return empty items",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.7.1/jellyfin-plugin-letterboxd-v1.7.1.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-25T00:00:00Z"
+      },
+      {
         "version": "1.7.0.0",
         "changelog": "Per-account User-Agent override so Cloudflare cookies copied from any browser (Chrome, Safari, etc.) work without UA mismatch",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

`GetWatchlistTmdbIdsAsync` was hitting `/member/{id}/watchlist?perPage=100&member={id}` — passing the same member ID both in the path and as a query param. The Letterboxd API uses `member=` as a relationship filter on global endpoints like `/films`, and on the member-scoped watchlist endpoint it appears to apply an empty intersection, returning `{"items":[]}` regardless of the actual watchlist contents.

## Repro

Triggered against a populated watchlist: response was a literal 12-byte `{"items":[]}`, even though the user's watchlist on letterboxd.com has films.

## Fix

Drop the redundant `&member=` query param. Path-scoped endpoint already knows whose watchlist it is.

## Verified

After deploy:
- saxdog: 2 films found (was 0) — playlist created with both
- 8bitproxy: 1 film found (was 0) — match would create playlist if film existed in library

`/log-entries` (diary path) is correct as-is since it's a global endpoint that legitimately needs the `member=` filter.

Version bumped to 1.7.1.

## Test plan

- [x] `dotnet test` passes (133/133)
- [x] Live verification on production server with debug logging
- [x] Post-merge: tag v1.7.1, redeploy