### PR TITLE
ui: explain account checkboxes with stacked descriptions

### DIFF
--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -32,8 +32,12 @@
                         width:100%; padding:0.4em; background:rgba(255,255,255,0.06); color:inherit; border:1px solid rgba(255,255,255,0.1); border-radius:4px; box-sizing:border-box;
                     }
                     .lb-account input[type=number] { width:80px; }
-                    .lb-checks { display:flex; flex-wrap:wrap; gap:0.5em 1.5em; margin-top:0.7em; }
-                    .lb-checks label { opacity:0.8; font-size:0.9em; }
+                    .lb-checks { display:flex; flex-direction:column; gap:0.7em; margin-top:0.9em; }
+                    .lb-checks label { display:flex; align-items:flex-start; gap:0.6em; cursor:pointer; opacity:1; }
+                    .lb-checks label input[type=checkbox] { margin-top:0.25em; flex:none; }
+                    .lb-checks .lb-check-text { display:flex; flex-direction:column; gap:0.15em; }
+                    .lb-checks .lb-check-title { font-size:0.95em; opacity:0.9; }
+                    .lb-checks .lb-check-desc { font-size:0.8em; opacity:0.5; line-height:1.35; }
 
                     .lb-btn { border:none; padding:0.5em 1.5em; border-radius:4px; cursor:pointer; font-weight:bold; font-size:0.95em; transition: opacity 0.2s; }
                     .lb-btn:hover { opacity:0.85; }
@@ -197,11 +201,26 @@
                                 + '<input type="text" class="userAgent" placeholder="Leave blank for default (Firefox 134 on Windows)" />'
                                 + '<div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Cloudflare ties the <code>cf_clearance</code> cookie to the exact User-Agent that solved the challenge. If you copied cookies from Chrome, paste Chrome\'s UA here. Find yours at <a href="https://www.whatismybrowser.com/detect/what-is-my-user-agent/" target="_blank" class="lb-link">whatismybrowser.com</a>.</div></div>'
                                 + '<div class="lb-checks">'
-                                + '<label><input type="checkbox" class="accountEnabled" /> Enabled</label>'
-                                + '<label><input type="checkbox" class="syncFavorites" /> Favorites as liked</label>'
-                                + '<label><input type="checkbox" class="enableDateFilter" /> Recently played only</label>'
-                                + '<label><input type="checkbox" class="enableWatchlistSync" /> Watchlist to playlist</label>'
-                                + '<label><input type="checkbox" class="enableDiaryImport" /> Import diary as played</label>'
+                                + '<label><input type="checkbox" class="accountEnabled" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Enabled</span>'
+                                + '<span class="lb-check-desc">Master switch for this account. When unchecked, no diary, watchlist, or playback sync runs for this user. Saved settings are kept.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="syncFavorites" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mark Jellyfin favourites as liked on Letterboxd</span>'
+                                + '<span class="lb-check-desc">When a film is in your Jellyfin favourites, the diary entry on Letterboxd gets the red heart (liked). Otherwise it syncs as a plain watch.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableDateFilter" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Only sync recently played films</span>'
+                                + '<span class="lb-check-desc">Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don\'t want to backfill years of history into your Letterboxd diary.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableWatchlistSync" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>'
+                                + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and creates/updates a playlist named "Letterboxd Watchlist" with the films that exist in your Jellyfin library. Films not in the library are skipped.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
+                                + '<span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary. Useful for new Jellyfin users who already have history on Letterboxd.</span>'
+                                + '</span></label>'
                                 + '</div>'
                                 + '<div class="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">'
                                 + '<label class="lb-field">Days to look back</label>'

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -215,7 +215,7 @@
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="enableWatchlistSync" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>'
-                                + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and creates/updates a playlist named "Letterboxd Watchlist" with the films that exist in your Jellyfin library. Films not in the library are skipped.</span>'
+                                + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist named "Letterboxd Watchlist". Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'


### PR DESCRIPTION
## Summary

The five checkboxes in the per-account config (Enabled / Favorites as liked / Recently played only / Watchlist to playlist / Import diary as played) were terse one-liners squeezed into a flex row. Hard to know what each one actually does without trial and error.

This PR converts them to a vertical stacked layout where each checkbox has:
- A clearer title (e.g. "Mirror Letterboxd watchlist as a Jellyfin playlist")
- A muted one-line description below explaining what it does and when you'd want it on

## Before / after labels

| Old | New title | New description |
|-----|-----------|-----------------|
| Enabled | Enabled | Master switch for this account. When unchecked, no diary, watchlist, or playback sync runs for this user. Saved settings are kept. |
| Favorites as liked | Mark Jellyfin favourites as liked on Letterboxd | When a film is in your Jellyfin favourites, the diary entry on Letterboxd gets the red heart (liked). Otherwise it syncs as a plain watch. |
| Recently played only | Only sync recently played films | Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don't want to backfill years of history. |
| Watchlist to playlist | Mirror Letterboxd watchlist as a Jellyfin playlist | Pulls your Letterboxd watchlist daily and creates/updates a playlist named "Letterboxd Watchlist" with the films that exist in your Jellyfin library. |
| Import diary as played | Import Letterboxd diary as Jellyfin watched | Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary. |

## Test plan

- [x] `dotnet build` clean
- [ ] Visual check on live config page after deploy
- [ ] Verify save/load round-trips checkbox states correctly (no logic changed, just markup + CSS)

Bundling into the v1.7.1 release once merged.