### PR TITLE
feat: Jellyseerr auto-request + watchlist dedup fix

### DIFF
--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -21,6 +21,8 @@ public class AccountUpdateRequest
     public bool EnableWatchlistSync { get; set; }
 
     public bool EnableDiaryImport { get; set; }
+
+    public bool AutoRequestWatchlist { get; set; }
 }
 
 public class TestConnectionRequest
@@ -32,4 +34,10 @@ public class TestConnectionRequest
     public string? RawCookies { get; set; }
 
     public string? UserAgent { get; set; }
+}
+
+public class JellyseerrTestRequest
+{
+    public string? Url { get; set; }
+    public string? ApiKey { get; set; }
 }

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -98,6 +98,7 @@ public class LetterboxdController : ControllerBase
                 dateFilterDays = 7,
                 enableWatchlistSync = false,
                 enableDiaryImport = false,
+                autoRequestWatchlist = false,
                 isConfigured = false
             });
         }
@@ -114,6 +115,7 @@ public class LetterboxdController : ControllerBase
             dateFilterDays = account.DateFilterDays,
             enableWatchlistSync = account.EnableWatchlistSync,
             enableDiaryImport = account.EnableDiaryImport,
+            autoRequestWatchlist = account.AutoRequestWatchlist,
             isConfigured = true
         });
     }
@@ -144,6 +146,7 @@ public class LetterboxdController : ControllerBase
         account.DateFilterDays = request.DateFilterDays;
         account.EnableWatchlistSync = request.EnableWatchlistSync;
         account.EnableDiaryImport = request.EnableDiaryImport;
+        account.AutoRequestWatchlist = request.AutoRequestWatchlist;
 
         Plugin.Instance!.SaveConfiguration();
         _logger.LogInformation("User {UserId} saved their Letterboxd account settings", userId);
@@ -170,6 +173,33 @@ public class LetterboxdController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogWarning("Test connection failed for {Username}: {Message}", request.LetterboxdUsername, ex.Message);
+            return BadRequest(new { success = false, error = ex.Message });
+        }
+    }
+
+    [HttpPost("TestJellyseerr")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> TestJellyseerr([FromBody] JellyseerrTestRequest request)
+    {
+        if (!JellyseerrClient.IsConfigured(request.Url, request.ApiKey))
+            return BadRequest(new { success = false, error = "URL and API key are required" });
+
+        try
+        {
+            using var client = new JellyseerrClient(request.Url!, request.ApiKey!, _logger);
+            var userId = await client.GetJellyseerrUserIdAsync(GetCurrentUserId() ?? string.Empty)
+                .ConfigureAwait(false);
+            return Ok(new
+            {
+                success = true,
+                linkedToCurrentUser = userId.HasValue,
+                jellyseerrUserId = userId
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Jellyseerr test failed: {Message}", ex.Message);
             return BadRequest(new { success = false, error = ex.Message });
         }
     }

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -25,4 +25,6 @@ public class Account
     public bool EnableWatchlistSync { get; set; }
 
     public bool EnableDiaryImport { get; set; }
+
+    public bool AutoRequestWatchlist { get; set; }
 }

--- a/LetterboxdSync/Configuration/PluginConfiguration.cs
+++ b/LetterboxdSync/Configuration/PluginConfiguration.cs
@@ -6,4 +6,15 @@ namespace LetterboxdSync.Configuration;
 public class PluginConfiguration : BasePluginConfiguration
 {
     public List<Account> Accounts { get; set; } = new List<Account>();
+
+    /// <summary>
+    /// Base URL of the Jellyseerr instance, e.g. "http://192.168.1.122:5055" or "https://requests.example.com".
+    /// Trailing slash is stripped at use time.
+    /// </summary>
+    public string? JellyseerrUrl { get; set; }
+
+    /// <summary>
+    /// Jellyseerr API key (Settings → General → API Key in Jellyseerr).
+    /// </summary>
+    public string? JellyseerrApiKey { get; set; }
 }

--- a/LetterboxdSync/JellyseerrClient.cs
+++ b/LetterboxdSync/JellyseerrClient.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Lightweight Jellyseerr client for fetching the Jellyfin-user-to-Jellyseerr-user
+/// mapping and creating per-user movie requests by TMDb ID.
+/// </summary>
+public class JellyseerrClient : IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly ILogger _logger;
+    private readonly string _baseUrl;
+
+    private Dictionary<string, int>? _jellyfinIdToJellyseerrId;
+
+    public JellyseerrClient(string baseUrl, string apiKey, ILogger logger, HttpMessageHandler? handler = null)
+    {
+        _baseUrl = baseUrl.TrimEnd('/');
+        _logger = logger;
+        _http = handler != null ? new HttpClient(handler) : new HttpClient();
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _http.DefaultRequestHeaders.TryAddWithoutValidation("X-Api-Key", apiKey);
+    }
+
+    /// <summary>Returns true if the client looks usable (URL + key set).</summary>
+    public static bool IsConfigured(string? url, string? apiKey)
+        => !string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(apiKey);
+
+    /// <summary>
+    /// Looks up the Jellyseerr user ID corresponding to a Jellyfin user ID (32-char hex).
+    /// Returns null if no matching user is found.
+    /// </summary>
+    public async Task<int?> GetJellyseerrUserIdAsync(string jellyfinUserId)
+    {
+        if (_jellyfinIdToJellyseerrId == null)
+            await LoadUserMapAsync().ConfigureAwait(false);
+
+        var normalized = jellyfinUserId.Replace("-", string.Empty).ToLowerInvariant();
+        return _jellyfinIdToJellyseerrId!.TryGetValue(normalized, out var id) ? id : null;
+    }
+
+    private async Task LoadUserMapAsync()
+    {
+        _jellyfinIdToJellyseerrId = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        var take = 100;
+        var skip = 0;
+        while (true)
+        {
+            var url = $"{_baseUrl}/api/v1/user?take={take}&skip={skip}";
+            using var response = await _http.GetAsync(url).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            var results = doc.RootElement.GetProperty("results");
+
+            var count = results.GetArrayLength();
+            if (count == 0) break;
+
+            foreach (var user in results.EnumerateArray())
+            {
+                if (!user.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.Number)
+                    continue;
+                if (!user.TryGetProperty("jellyfinUserId", out var jfIdEl) || jfIdEl.ValueKind != JsonValueKind.String)
+                    continue;
+                var jfId = jfIdEl.GetString();
+                if (string.IsNullOrWhiteSpace(jfId)) continue;
+                var key = jfId.Replace("-", string.Empty).ToLowerInvariant();
+                _jellyfinIdToJellyseerrId[key] = idEl.GetInt32();
+            }
+
+            skip += count;
+            if (count < take) break;
+        }
+
+        _logger.LogInformation("Jellyseerr user map loaded: {Count} users with linked Jellyfin IDs",
+            _jellyfinIdToJellyseerrId.Count);
+    }
+
+    /// <summary>
+    /// Creates a movie request in Jellyseerr for the given TMDb ID, attributed to the given Jellyseerr user.
+    /// Returns true on success or "already requested"; false on transient error.
+    /// </summary>
+    public async Task<bool> RequestMovieAsync(int tmdbId, int jellyseerrUserId)
+    {
+        var url = $"{_baseUrl}/api/v1/request";
+        var body = $"{{\"mediaType\":\"movie\",\"mediaId\":{tmdbId},\"userId\":{jellyseerrUserId}}}";
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        using var response = await _http.PostAsync(url, content).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+            return true;
+
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        // Jellyseerr returns 409 when already requested; treat as a success (no-op).
+        if ((int)response.StatusCode == 409 ||
+            responseBody.Contains("REQUEST_EXISTS", StringComparison.OrdinalIgnoreCase) ||
+            responseBody.Contains("already requested", StringComparison.OrdinalIgnoreCase) ||
+            responseBody.Contains("already available", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("Jellyseerr already has request for TMDb {TmdbId} (user {UserId}): {Body}",
+                tmdbId, jellyseerrUserId, Truncate(responseBody, 200));
+            return true;
+        }
+
+        _logger.LogWarning("Jellyseerr request failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+            tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
+        return false;
+    }
+
+    private static string Truncate(string s, int max) => s.Length > max ? s.Substring(0, max) + "..." : s;
+
+    public void Dispose() => _http.Dispose();
+}

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.7.1.0</AssemblyVersion>
-    <FileVersion>1.7.1.0</FileVersion>
+    <AssemblyVersion>1.8.0.0</AssemblyVersion>
+    <FileVersion>1.8.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/WatchlistSyncTask.cs
+++ b/LetterboxdSync/WatchlistSyncTask.cs
@@ -45,6 +45,12 @@ public class WatchlistSyncTask : IScheduledTask
     {
         var users = _userManager.Users.ToList();
 
+        JellyseerrClient? jellyseerr = null;
+        if (JellyseerrClient.IsConfigured(Config.JellyseerrUrl, Config.JellyseerrApiKey))
+        {
+            jellyseerr = new JellyseerrClient(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger);
+        }
+
         foreach (var user in users)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -134,14 +140,16 @@ public class WatchlistSyncTask : IScheduledTask
             }
             else
             {
-                var existingItems = _libraryManager.GetItemList(new InternalItemsQuery(user)
-                {
-                    ParentId = playlist.Id,
-                    Recursive = false
-                });
-                var existingIds = existingItems.Select(c => c.Id).ToHashSet();
+                // Source of truth: Playlist.LinkedChildren contains the wrapped media item IDs
+                // (the underlying Movie GUIDs). Querying ParentId returns playlist *entries* whose
+                // BaseItem.Id is the entry GUID, not the movie GUID — using that for dedup compared
+                // entry IDs against movie IDs and never matched, causing duplicates each run.
+                var playlistObj = (Playlist)playlist;
+                var existingIds = playlistObj.LinkedChildren
+                    .Where(lc => lc.ItemId.HasValue)
+                    .Select(lc => lc.ItemId!.Value)
+                    .ToHashSet();
 
-                // Add new items
                 var newItems = watchlistItemIds.Where(id => !existingIds.Contains(id)).ToArray();
                 if (newItems.Length > 0)
                 {
@@ -155,28 +163,87 @@ public class WatchlistSyncTask : IScheduledTask
                 // Guard: if the scrape returned zero results but the playlist has items,
                 // skip removal — an empty scrape result likely means Cloudflare blocked us,
                 // not that the user cleared their entire watchlist.
-                var removedItems = (tmdbIds.Count == 0 && existingIds.Count > 0)
+                var removedIds = (tmdbIds.Count == 0 && existingIds.Count > 0)
                     ? Array.Empty<string>()
-                    : existingItems
-                        .Where(item => !watchlistItemIds.Contains(item.Id))
-                        .Select(item => item.Id.ToString("N"))
+                    : existingIds
+                        .Where(id => !watchlistItemIds.Contains(id))
+                        .Select(id => id.ToString("N"))
                         .ToArray();
 
-                if (removedItems.Length > 0)
+                if (removedIds.Length > 0)
                 {
-                    await _playlistManager.RemoveItemFromPlaylistAsync(playlist.Id.ToString("N"), removedItems)
+                    await _playlistManager.RemoveItemFromPlaylistAsync(playlist.Id.ToString("N"), removedIds)
                         .ConfigureAwait(false);
                     _logger.LogInformation("Removed {Count} films from playlist '{Name}' for {Username}",
-                        removedItems.Length, playlistName, user.Username);
+                        removedIds.Length, playlistName, user.Username);
                 }
 
-                if (newItems.Length == 0 && removedItems.Length == 0)
+                if (newItems.Length == 0 && removedIds.Length == 0)
                 {
                     _logger.LogInformation("Playlist '{Name}' already up to date for {Username}",
                         playlistName, user.Username);
                 }
             }
+
+            // Auto-request unmatched watchlist films via Jellyseerr.
+            if (account.AutoRequestWatchlist && jellyseerr != null)
+            {
+                var matchedTmdbIds = new HashSet<int>();
+                foreach (var tmdbId in tmdbIds)
+                {
+                    var match = allMovies.FirstOrDefault(m =>
+                        m.GetProviderId(MetadataProvider.Tmdb) == tmdbId.ToString());
+                    if (match != null) matchedTmdbIds.Add(tmdbId);
+                }
+                var unmatchedTmdbIds = tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
+
+                if (unmatchedTmdbIds.Count > 0)
+                {
+                    int? jellyseerrUserId;
+                    try
+                    {
+                        jellyseerrUserId = await jellyseerr.GetJellyseerrUserIdAsync(account.UserJellyfinId).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning("Could not fetch Jellyseerr user map for {Username}: {Message}",
+                            user.Username, ex.Message);
+                        jellyseerrUserId = null;
+                    }
+
+                    if (jellyseerrUserId == null)
+                    {
+                        _logger.LogWarning("No Jellyseerr user linked to Jellyfin user {Username}; skipping auto-request",
+                            user.Username);
+                    }
+                    else
+                    {
+                        var requested = 0;
+                        var failed = 0;
+                        foreach (var tmdbId in unmatchedTmdbIds)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            try
+                            {
+                                if (await jellyseerr.RequestMovieAsync(tmdbId, jellyseerrUserId.Value).ConfigureAwait(false))
+                                    requested++;
+                                else
+                                    failed++;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning("Jellyseerr request errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                                failed++;
+                            }
+                        }
+                        _logger.LogInformation("Jellyseerr auto-request for {Username}: {Requested} requested, {Failed} failed of {Total} unmatched",
+                            user.Username, requested, failed, unmatchedTmdbIds.Count);
+                    }
+                }
+            }
         }
+
+        jellyseerr?.Dispose();
 
         progress.Report(100);
     }

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -106,7 +106,20 @@
 
                 <!-- SETTINGS TAB -->
                 <div id="tab-settings" class="lb-tab-content" style="display:none;">
-                    <h3>User Accounts</h3>
+                    <h3>Jellyseerr Integration <span class="c-muted" style="font-size:0.7em;">(optional)</span></h3>
+                    <p class="c-muted" style="font-size:0.9em;">Auto-request films from a user's Letterboxd watchlist that aren't yet in your Jellyfin library. Requests are attributed to each user's matching Jellyseerr account (matched by Jellyfin User ID).</p>
+                    <div class="lb-account">
+                        <div style="margin-bottom:0.5em;"><label class="lb-field">Jellyseerr URL</label>
+                            <input type="text" id="jellyseerrUrl" placeholder="http://192.168.1.122:5055" /></div>
+                        <div style="margin-bottom:0.5em;"><label class="lb-field">Jellyseerr API Key</label>
+                            <input type="password" id="jellyseerrApiKey" placeholder="Settings &rarr; General &rarr; API Key" /></div>
+                        <div style="display:flex;gap:0.7em;align-items:center;">
+                            <button type="button" class="lb-btn lb-btn-secondary" id="testJellyseerrBtn">Test Connection</button>
+                            <span id="jellyseerrTestStatus" class="c-muted" style="font-size:0.85em;"></span>
+                        </div>
+                    </div>
+
+                    <h3 style="margin-top:1.5em;">User Accounts</h3>
                     <p class="c-muted" style="font-size:0.9em;">Map Jellyfin users to their Letterboxd accounts.</p>
                     <div id="accountsList"></div>
                     <button type="button" class="lb-btn lb-btn-secondary" id="addAccountBtn" style="margin-top:1em;">+ Add Account</button>
@@ -217,6 +230,10 @@
                                 + '<span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>'
                                 + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist named "Letterboxd Watchlist". Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
                                 + '</span></label>'
+                                + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
+                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Jellyseerr (configure URL + API key above). Requests are attributed to this user\'s Jellyseerr account (matched by Jellyfin User ID). Requires Jellyseerr to be configured.</span>'
+                                + '</span></label>'
                                 + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
                                 + '<span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary. Useful for new Jellyfin users who already have history on Letterboxd.</span>'
@@ -243,6 +260,7 @@
                                 entry.querySelector('.enableDateFilter').checked = account.EnableDateFilter === true;
                                 entry.querySelector('.dateFilterDays').value = account.DateFilterDays || 7;
                                 entry.querySelector('.enableWatchlistSync').checked = account.EnableWatchlistSync === true;
+                                entry.querySelector('.autoRequestWatchlist').checked = account.AutoRequestWatchlist === true;
                                 entry.querySelector('.enableDiaryImport').checked = account.EnableDiaryImport === true;
                                 if (account.EnableDateFilter) entry.querySelector('.dateFilterDaysContainer').style.display = '';
                             } else {
@@ -268,6 +286,7 @@
                                     EnableDateFilter: entry.querySelector('.enableDateFilter').checked,
                                     DateFilterDays: parseInt(entry.querySelector('.dateFilterDays').value, 10) || 7,
                                     EnableWatchlistSync: entry.querySelector('.enableWatchlistSync').checked,
+                                    AutoRequestWatchlist: entry.querySelector('.autoRequestWatchlist').checked,
                                     EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked
                                 });
                             });
@@ -282,6 +301,8 @@
                                     document.getElementById('accountsList').innerHTML = '';
                                     if (config.Accounts && config.Accounts.length > 0)
                                         config.Accounts.forEach(function (a) { self.addAccount(a); });
+                                    document.getElementById('jellyseerrUrl').value = config.JellyseerrUrl || '';
+                                    document.getElementById('jellyseerrApiKey').value = config.JellyseerrApiKey || '';
                                 });
                             });
                         },
@@ -290,9 +311,42 @@
                             var self = this;
                             ApiClient.getPluginConfiguration(self.PluginId).then(function (config) {
                                 config.Accounts = self.collectAccounts();
+                                config.JellyseerrUrl = document.getElementById('jellyseerrUrl').value.trim() || null;
+                                config.JellyseerrApiKey = document.getElementById('jellyseerrApiKey').value.trim() || null;
                                 ApiClient.updatePluginConfiguration(self.PluginId, config).then(function () {
                                     Dashboard.processPluginConfigurationUpdateResult();
                                 });
+                            });
+                        },
+
+                        testJellyseerr: function () {
+                            var url = document.getElementById('jellyseerrUrl').value.trim();
+                            var key = document.getElementById('jellyseerrApiKey').value.trim();
+                            var statusEl = document.getElementById('jellyseerrTestStatus');
+                            if (!url || !key) {
+                                statusEl.innerHTML = '<span class="c-red">URL and API key are required.</span>';
+                                return;
+                            }
+                            statusEl.innerHTML = '<span class="c-muted">Testing...</span>';
+                            ApiClient.ajax({
+                                url: ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/TestJellyseerr'),
+                                type: 'POST', contentType: 'application/json',
+                                data: JSON.stringify({ url: url, apiKey: key })
+                            }).then(function (response) {
+                                response.json().then(function (data) {
+                                    if (data.linkedToCurrentUser) {
+                                        statusEl.innerHTML = '<span class="c-green">Connected. Your Jellyfin user is linked to Jellyseerr user ID ' + data.jellyseerrUserId + '.</span>';
+                                    } else {
+                                        statusEl.innerHTML = '<span class="c-blue">Connected, but no Jellyseerr user is linked to your Jellyfin account. Import Jellyfin users in Jellyseerr first.</span>';
+                                    }
+                                });
+                            }, function (err) {
+                                var msg = 'Connection failed';
+                                try {
+                                    var data = JSON.parse(err.responseText || '{}');
+                                    if (data.error) msg = data.error;
+                                } catch (e) {}
+                                statusEl.innerHTML = '<span class="c-red">' + msg + '</span>';
                             });
                         },
 
@@ -496,6 +550,7 @@
 
                             document.getElementById('addAccountBtn').addEventListener('click', function () { self.addAccount(null); });
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveSettings(); });
+                            document.getElementById('testJellyseerrBtn').addEventListener('click', function () { self.testJellyseerr(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
                             document.getElementById('reviewCancel').addEventListener('click', function () { document.getElementById('reviewModal').style.display = 'none'; });
                             document.getElementById('reviewSubmit').addEventListener('click', function () { self.submitReview(); });

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -39,8 +39,12 @@
                         width:100%; padding:0.4em; background:rgba(255,255,255,0.06); color:inherit; border:1px solid rgba(255,255,255,0.1); border-radius:4px; box-sizing:border-box;
                     }
                     .lb-account input[type=number] { width:80px; }
-                    .lb-checks { display:flex; flex-wrap:wrap; gap:0.5em 1.5em; margin-top:0.7em; }
-                    .lb-checks label { opacity:0.8; font-size:0.9em; }
+                    .lb-checks { display:flex; flex-direction:column; gap:0.7em; margin-top:0.9em; }
+                    .lb-checks label { display:flex; align-items:flex-start; gap:0.6em; cursor:pointer; opacity:1; }
+                    .lb-checks label input[type=checkbox] { margin-top:0.25em; flex:none; }
+                    .lb-checks .lb-check-text { display:flex; flex-direction:column; gap:0.15em; }
+                    .lb-checks .lb-check-title { font-size:0.95em; opacity:0.9; }
+                    .lb-checks .lb-check-desc { font-size:0.8em; opacity:0.5; line-height:1.35; }
 
                     .lb-btn { border:none; padding:0.5em 1.5em; border-radius:4px; cursor:pointer; font-weight:bold; font-size:0.95em; transition: opacity 0.2s; }
                     .lb-btn:hover { opacity:0.85; }
@@ -133,6 +137,11 @@
                             <label class="lb-field">Raw Cookies <span class="c-muted">(optional, Cloudflare bypass)</span></label>
                             <input type="text" id="rawCookies" placeholder="Paste cookie header if login gets 403" />
                         </div>
+                        <div style="margin-bottom:0.7em;">
+                            <label class="lb-field">User-Agent <span class="c-muted">(optional, must match the browser used to copy cookies)</span></label>
+                            <input type="text" id="userAgent" placeholder="Leave blank for default (Firefox 134 on Windows)" />
+                            <div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Cloudflare ties the <code>cf_clearance</code> cookie to the exact User-Agent that solved the challenge. If you copied cookies from Chrome, paste Chrome's UA here.</div>
+                        </div>
 
                         <div style="margin-top:1em;margin-bottom:0.5em;">
                             <button type="button" class="lb-btn lb-btn-secondary" id="testBtn">Test Connection</button>
@@ -141,11 +150,30 @@
 
                         <h4 style="margin-top:1.5em;margin-bottom:0.5em;">Sync Preferences</h4>
                         <div class="lb-checks">
-                            <label><input type="checkbox" id="accountEnabled" /> Enabled</label>
-                            <label><input type="checkbox" id="syncFavorites" /> Favorites as liked</label>
-                            <label><input type="checkbox" id="enableDateFilter" /> Recently played only</label>
-                            <label><input type="checkbox" id="enableWatchlistSync" /> Watchlist to playlist</label>
-                            <label><input type="checkbox" id="enableDiaryImport" /> Import diary as played</label>
+                            <label><input type="checkbox" id="accountEnabled" /><span class="lb-check-text">
+                                <span class="lb-check-title">Enabled</span>
+                                <span class="lb-check-desc">Master switch for your account. When unchecked, no diary, watchlist, or playback sync runs for you. Saved settings are kept.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="syncFavorites" /><span class="lb-check-text">
+                                <span class="lb-check-title">Mark Jellyfin favourites as liked on Letterboxd</span>
+                                <span class="lb-check-desc">When a film is in your Jellyfin favourites, the diary entry on Letterboxd gets the red heart (liked). Otherwise it syncs as a plain watch.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="enableDateFilter" /><span class="lb-check-text">
+                                <span class="lb-check-title">Only sync recently played films</span>
+                                <span class="lb-check-desc">Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don't want to backfill years of history.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="enableWatchlistSync" /><span class="lb-check-text">
+                                <span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>
+                                <span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist named "Letterboxd Watchlist". Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="autoRequestWatchlist" /><span class="lb-check-text">
+                                <span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>
+                                <span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, request it through Jellyseerr. The request is attributed to your Jellyseerr account (matched by your Jellyfin login). The admin must have configured Jellyseerr in the plugin settings.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="enableDiaryImport" /><span class="lb-check-text">
+                                <span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>
+                                <span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary.</span>
+                            </span></label>
                         </div>
                         <div id="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">
                             <label class="lb-field">Days to look back</label>
@@ -279,11 +307,13 @@
                                 document.getElementById('lbUsername').value = a.letterboxdUsername || '';
                                 document.getElementById('lbPassword').value = a.letterboxdPassword || '';
                                 document.getElementById('rawCookies').value = a.rawCookies || '';
+                                document.getElementById('userAgent').value = a.userAgent || '';
                                 document.getElementById('accountEnabled').checked = a.enabled === true;
                                 document.getElementById('syncFavorites').checked = a.syncFavorites === true;
                                 document.getElementById('enableDateFilter').checked = a.enableDateFilter === true;
                                 document.getElementById('dateFilterDays').value = a.dateFilterDays || 7;
                                 document.getElementById('enableWatchlistSync').checked = a.enableWatchlistSync === true;
+                                document.getElementById('autoRequestWatchlist').checked = a.autoRequestWatchlist === true;
                                 document.getElementById('enableDiaryImport').checked = a.enableDiaryImport === true;
                                 document.getElementById('dateFilterDaysContainer').style.display = a.enableDateFilter ? '' : 'none';
                             })
@@ -303,11 +333,13 @@
                                 letterboxdUsername: document.getElementById('lbUsername').value,
                                 letterboxdPassword: document.getElementById('lbPassword').value,
                                 rawCookies: document.getElementById('rawCookies').value || null,
+                                userAgent: document.getElementById('userAgent').value || null,
                                 enabled: document.getElementById('accountEnabled').checked,
                                 syncFavorites: document.getElementById('syncFavorites').checked,
                                 enableDateFilter: document.getElementById('enableDateFilter').checked,
                                 dateFilterDays: parseInt(document.getElementById('dateFilterDays').value, 10) || 7,
                                 enableWatchlistSync: document.getElementById('enableWatchlistSync').checked,
+                                autoRequestWatchlist: document.getElementById('autoRequestWatchlist').checked,
                                 enableDiaryImport: document.getElementById('enableDiaryImport').checked
                             };
 
@@ -347,7 +379,8 @@
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/TestConnection', {
                                 letterboxdUsername: username,
                                 letterboxdPassword: password,
-                                rawCookies: document.getElementById('rawCookies').value || null
+                                rawCookies: document.getElementById('rawCookies').value || null,
+                                userAgent: document.getElementById('userAgent').value || null
                             })
                             .then(function (r) { return r.json(); })
                             .then(function (data) {

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.8.0.0",
+        "changelog": "Jellyseerr auto-request for unmatched watchlist films (per-user attribution via Jellyfin User ID), plus dedup fix so the watchlist playlist no longer accumulates duplicate entries on each run",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.8.0/jellyfin-plugin-letterboxd-v1.8.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-26T00:00:00Z"
+      },
+      {
         "version": "1.7.1.0",
         "changelog": "Fix watchlist sync returning 0 films via official API: redundant `member` query param caused Letterboxd to return empty items",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

Two related features and one bugfix bundled for v1.8.0.

### 1. Jellyseerr auto-request for unmatched watchlist films

When a user's Letterboxd watchlist contains a film that isn't in the Jellyfin library, the plugin can now submit a movie request to Jellyseerr **attributed to that specific user** (not the admin).

- Plugin-level config: Jellyseerr URL + API key (admin-only, in Settings tab) with a Test Connection button
- Per-account checkbox: **Auto-request unmatched watchlist films via Jellyseerr** (available in both admin Settings and the user-facing self-service page)
- User mapping is automatic: `JellyseerrClient.GetJellyseerrUserIdAsync` queries `/api/v1/user` and matches each Jellyfin user ID to its linked Jellyseerr user
- Each request POST includes the user's Jellyseerr ID so requests, quotas, notifications, and approval rules apply to the right user
- 409 / "REQUEST_EXISTS" responses are treated as a successful no-op
- If a user has no linked Jellyseerr account, their auto-requests are skipped with a warning (does not break the playlist sync)

End users never see or handle the API key — they just tick the checkbox.

### 2. Watchlist playlist dedup fix

`WatchlistSyncTask` was using `_libraryManager.GetItemList(... ParentId = playlist.Id)` to compare against the watchlist for adds/removes. That returned playlist *entry* GUIDs rather than the underlying movie GUIDs, so the dedup compare never matched and "Added 2 new films" appeared on every run. Switched to `Playlist.LinkedChildren.ItemId` as the source of truth — this is the canonical playlist storage.

Verified live: re-running the sync after the fix reports **"Playlist 'Letterboxd Watchlist' already up to date"** instead of constantly re-adding the same films.

### 3. User-facing config page parity

The user-facing self-service page (`userPage.html`) was several versions behind the admin page:

- Now uses the same stacked descriptive checkbox layout as `configPage.html`
- Adds the per-account User-Agent input (parity with v1.7.0)
- Adds the new Auto-request checkbox so users can opt in for themselves

## Test plan

- [x] Build clean, all 133 tests pass
- [x] Live verification on production server:
  - Jellyseerr Test Connection: 12 users with linked Jellyfin IDs
  - Saxon's watchlist: 4 films, 2 matched, 2 unmatched → 2 successful Jellyseerr requests under his account
  - Playlist dedup: now reports "already up to date" on re-run
  - Newly added watchlist film → auto-requested on next sync