### PR TITLE
docs: document watchlist-to-playlist with Jellyseerr auto-request

### DIFF
--- a/site/src/components/TransferBento.astro
+++ b/site/src/components/TransferBento.astro
@@ -94,7 +94,7 @@ const watchlist = [
   <div class="tile tile-watchlist">
     <div class="tile-head">
       <span class="tile-label">Watchlist</span>
-      <span class="tile-meta">Letterboxd → Jellyfin playlist</span>
+      <span class="tile-meta">Letterboxd → playlist · request the rest</span>
     </div>
     <div class="posters">
       {watchlist.map((p) => (
@@ -108,6 +108,8 @@ const watchlist = [
       <span class="wl-count">47 films</span>
       <span class="wl-arrow">→</span>
       <span class="wl-pill">Jellyfin playlist</span>
+      <span class="wl-arrow">·</span>
+      <span class="wl-pill wl-pill-seerr">Jellyseerr request if missing</span>
     </div>
   </div>
 </div>
@@ -405,7 +407,8 @@ const watchlist = [
   .watchlist-foot {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
+    flex-wrap: wrap;
     font-size: 12px;
     color: var(--text-dim);
   }
@@ -423,5 +426,10 @@ const watchlist = [
     border-radius: 999px;
     font-size: 11px;
     font-weight: 500;
+  }
+  .wl-pill-seerr {
+    background: rgba(255,140,0,0.12);
+    border-color: rgba(255,140,0,0.35);
+    color: #ffb86c;
   }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -35,7 +35,8 @@ const featureGroups: FeatureGroup[] = [
     items: [
       { title: 'Ratings as stars', body: 'Jellyfin 0-10 maps onto Letterboxd 0.5-5.', icon: 'star' },
       { title: 'Favorites as likes', body: 'Hearted on Letterboxd when favorited in Jellyfin.', icon: 'heart' },
-      { title: 'Watchlist + reviews', body: 'Watchlist becomes a playlist; reviews post from the dashboard.', icon: 'list' },
+      { title: 'Watchlist as playlist', body: 'Each user\'s Letterboxd watchlist mirrors into a Jellyfin playlist daily. Films missing from the library get auto-requested through Jellyseerr, attributed to the right user.', icon: 'list' },
+      { title: 'Reviews from the dashboard', body: 'Write in Jellyfin, post straight to Letterboxd with rating, spoiler tag, and rewatch flag.', icon: 'pencil' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Updates the landing site to reflect the v1.8.0 watchlist→playlist→Jellyseerr flow.

### Changes

- **Feature group "What transfers"** now has a dedicated **"Watchlist as playlist"** entry that explicitly mentions auto-request through Jellyseerr, attributed to the right user
- The combined watchlist/reviews bullet was split: reviews get their own line ("Reviews from the dashboard")
- The **Watchlist tile** in `TransferBento` now shows the two-step outcome: green pill for "Jellyfin playlist" + orange pill for "Jellyseerr request if missing"
- Tile meta caption updated from "Letterboxd → Jellyfin playlist" to "Letterboxd → playlist · request the rest"

## Test plan

- [x] `npm run build` clean
- [x] Visual check post-deploy at https://lachlanyoung.dev/jellyfin-plugin-letterboxd/

The deploy workflow auto-runs on merge since `site/**` paths are touched.