### PR TITLE
feat: skip already-synced films, prioritise retries, stop-on-failure

### DIFF
--- a/LetterboxdSync.Tests/BuildSyncQueueTests.cs
+++ b/LetterboxdSync.Tests/BuildSyncQueueTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Tests for LetterboxdSyncRunner.BuildSyncQueue — the pre-flight filter and prioritisation
+/// that runs BEFORE any HTTP traffic. This is the heart of the issue #20 fix: skip what's
+/// already synced locally, retry previously-failed/skipped films first.
+/// </summary>
+public class BuildSyncQueueTests
+{
+    private const string User = "lachlan";
+    private static readonly DateTime Today = new DateTime(2026, 4, 30);
+
+    private static (List<string> Queue, int LocallySkipped) Run(
+        IEnumerable<(string Item, int? TmdbId, DateTime ViewingDate)> candidates,
+        Func<string, int, DateTime, bool>? wasSynced = null,
+        Func<string, int, SyncStatus?>? lastStatus = null)
+    {
+        return LetterboxdSyncRunner.BuildSyncQueue(
+            candidates,
+            User,
+            wasSynced ?? ((_, _, _) => false),
+            lastStatus ?? ((_, _) => null));
+    }
+
+    [Fact]
+    public void DropsAlreadySyncedFilmsAndCountsThem()
+    {
+        var candidates = new[]
+        {
+            (Item: "alreadySynced", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "fresh", TmdbId: (int?)200, ViewingDate: Today),
+        };
+
+        var (queue, skipped) = Run(candidates, wasSynced: (_, tid, _) => tid == 100);
+
+        Assert.Equal(new[] { "fresh" }, queue);
+        Assert.Equal(1, skipped);
+    }
+
+    [Fact]
+    public void PreviouslyFailedFilmsComeFirst()
+    {
+        // The point of the prioritisation: if Letterboxd starts blocking part-way, we make
+        // progress on the backlog rather than re-attempting fresh films at the head of queue.
+        var candidates = new[]
+        {
+            (Item: "fresh1", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "previouslyFailed", TmdbId: (int?)200, ViewingDate: Today),
+            (Item: "fresh2", TmdbId: (int?)300, ViewingDate: Today),
+        };
+
+        var (queue, _) = Run(candidates,
+            lastStatus: (_, tid) => tid == 200 ? SyncStatus.Failed : null);
+
+        Assert.Equal("previouslyFailed", queue[0]);
+        Assert.Contains("fresh1", queue);
+        Assert.Contains("fresh2", queue);
+    }
+
+    [Fact]
+    public void PreviouslySkippedFilmsAlsoPrioritised()
+    {
+        // Skipped (e.g. from a transient duplicate-check error) is also an unfinished attempt
+        // that deserves priority on the next run.
+        var candidates = new[]
+        {
+            (Item: "fresh", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "previouslySkipped", TmdbId: (int?)200, ViewingDate: Today),
+        };
+
+        var (queue, _) = Run(candidates,
+            lastStatus: (_, tid) => tid == 200 ? SyncStatus.Skipped : null);
+
+        Assert.Equal("previouslySkipped", queue[0]);
+        Assert.Equal("fresh", queue[1]);
+    }
+
+    [Fact]
+    public void PreviouslySuccessfulButDifferentDateIsTreatedAsFresh()
+    {
+        // wasSynced returns false because the date doesn't match (rewatch on a new date),
+        // and lastStatus is Success — that's neither Failed nor Skipped, so the film stays
+        // at the regular "never attempted" priority.
+        var candidates = new[]
+        {
+            (Item: "rewatch", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "fresh", TmdbId: (int?)200, ViewingDate: Today),
+        };
+
+        var (queue, _) = Run(candidates,
+            wasSynced: (_, _, _) => false,
+            lastStatus: (_, tid) => tid == 100 ? SyncStatus.Success : null);
+
+        // Both at priority 1 — order should be preserved (stable sort).
+        Assert.Equal(new[] { "rewatch", "fresh" }, queue);
+    }
+
+    [Fact]
+    public void FilmsWithoutTmdbIdStayInQueue()
+    {
+        // The main loop logs them and records an explicit "No TMDb ID" skip event, so we
+        // mustn't drop them silently here.
+        var candidates = new[]
+        {
+            (Item: "noTmdb", TmdbId: (int?)null, ViewingDate: Today),
+            (Item: "withTmdb", TmdbId: (int?)100, ViewingDate: Today),
+        };
+
+        var (queue, skipped) = Run(candidates);
+
+        Assert.Equal(2, queue.Count);
+        Assert.Equal(0, skipped);
+        Assert.Contains("noTmdb", queue);
+    }
+
+    [Fact]
+    public void EmptyInputGivesEmptyQueue()
+    {
+        var (queue, skipped) = Run(Array.Empty<(string, int?, DateTime)>());
+
+        Assert.Empty(queue);
+        Assert.Equal(0, skipped);
+    }
+
+    [Fact]
+    public void AllAlreadySyncedYieldsEmptyQueue()
+    {
+        var candidates = new[]
+        {
+            (Item: "a", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "b", TmdbId: (int?)200, ViewingDate: Today),
+        };
+
+        var (queue, skipped) = Run(candidates, wasSynced: (_, _, _) => true);
+
+        Assert.Empty(queue);
+        Assert.Equal(2, skipped);
+    }
+
+    [Fact]
+    public void PassesUsernameThroughToCallbacks()
+    {
+        // Defense against a regression where the runner accidentally hardcodes a username
+        // or passes the Letterboxd username instead of the Jellyfin one.
+        string? observedWasSyncedUser = null;
+        string? observedLastStatusUser = null;
+
+        var candidates = new[]
+        {
+            (Item: "x", TmdbId: (int?)100, ViewingDate: Today),
+        };
+
+        Run(candidates,
+            wasSynced: (u, _, _) => { observedWasSyncedUser = u; return false; },
+            lastStatus: (u, _) => { observedLastStatusUser = u; return null; });
+
+        Assert.Equal(User, observedWasSyncedUser);
+        Assert.Equal(User, observedLastStatusUser);
+    }
+
+    [Fact]
+    public void PreservesFreshFilmOrderWhenNoPriorityDifference()
+    {
+        // Stable ordering matters for predictable user-facing logs and tests.
+        var candidates = new[]
+        {
+            (Item: "first", TmdbId: (int?)100, ViewingDate: Today),
+            (Item: "second", TmdbId: (int?)200, ViewingDate: Today),
+            (Item: "third", TmdbId: (int?)300, ViewingDate: Today),
+        };
+
+        var (queue, _) = Run(candidates);
+
+        Assert.Equal(new[] { "first", "second", "third" }, queue);
+    }
+}

--- a/LetterboxdSync.Tests/PlaybackHandlerTests.cs
+++ b/LetterboxdSync.Tests/PlaybackHandlerTests.cs
@@ -21,9 +21,20 @@ public class ServiceRegistratorTests
 
         registrator.RegisterServices(services, null!);
 
-        var descriptor = Assert.Single(services);
-        Assert.Equal(typeof(Microsoft.Extensions.Hosting.IHostedService), descriptor.ServiceType);
-        Assert.Equal(typeof(PlaybackHandler), descriptor.ImplementationType);
+        var hostedService = Assert.Single(services, d => d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService));
+        Assert.Equal(typeof(PlaybackHandler), hostedService.ImplementationType);
+    }
+
+    [Fact]
+    public void RegisterServices_AddsSyncRunnerAsSingleton()
+    {
+        var services = new ServiceCollection();
+        var registrator = new ServiceRegistrator();
+
+        registrator.RegisterServices(services, null!);
+
+        var runner = Assert.Single(services, d => d.ServiceType == typeof(LetterboxdSyncRunner));
+        Assert.Equal(ServiceLifetime.Singleton, runner.Lifetime);
     }
 }
 

--- a/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
+++ b/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Tests for the pure SyncHistory lookup helpers. These power the local short-circuit
+/// that prevents redundant Letterboxd HTTP calls during sync.
+/// </summary>
+public class SyncHistoryLookupTests
+{
+    private const string User = "lachlan";
+    private const string OtherUser = "thebarn";
+    private const int FilmA = 100;
+    private const int FilmB = 200;
+    private static readonly DateTime ViewedToday = new DateTime(2026, 4, 30);
+    private static readonly DateTime ViewedYesterday = new DateTime(2026, 4, 29);
+
+    private static SyncEvent Event(string username, int tmdbId, DateTime viewingDate, SyncStatus status,
+        DateTime? recordedAt = null)
+        => new()
+        {
+            Username = username,
+            TmdbId = tmdbId,
+            ViewingDate = viewingDate,
+            Status = status,
+            Timestamp = recordedAt ?? DateTime.UtcNow
+        };
+
+    [Fact]
+    public void WasSuccessfullySynced_TrueWhenSuccessEntryMatchesUserFilmAndDate()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Success)
+        };
+
+        Assert.True(SyncHistory.WasSuccessfullySynced(events, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_TrueForRewatchEntry()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Rewatch)
+        };
+
+        Assert.True(SyncHistory.WasSuccessfullySynced(events, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_FalseForFailedOrSkippedEntry()
+    {
+        // The whole point of prioritising these on the next run is that they DID NOT sync
+        // successfully — they must not be treated as already-synced.
+        var failedOrSkipped = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed),
+            Event(User, FilmA, ViewedToday, SyncStatus.Skipped),
+        };
+
+        Assert.False(SyncHistory.WasSuccessfullySynced(failedOrSkipped, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_FalseWhenViewingDateDiffers()
+    {
+        // A successful sync for a previous viewing must not mask a new viewing on a different
+        // date — the user expects the second viewing to land on Letterboxd as its own diary entry.
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedYesterday, SyncStatus.Success)
+        };
+
+        Assert.False(SyncHistory.WasSuccessfullySynced(events, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_IgnoresOtherUsers()
+    {
+        // SyncHistory is shared across users — make sure The Barn's sync doesn't think it
+        // already happened just because lachlan synced the same film.
+        var events = new List<SyncEvent>
+        {
+            Event(OtherUser, FilmA, ViewedToday, SyncStatus.Success)
+        };
+
+        Assert.False(SyncHistory.WasSuccessfullySynced(events, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_IgnoresOtherFilms()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmB, ViewedToday, SyncStatus.Success)
+        };
+
+        Assert.False(SyncHistory.WasSuccessfullySynced(events, User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_FalseOnEmptyHistory()
+    {
+        Assert.False(SyncHistory.WasSuccessfullySynced(new List<SyncEvent>(), User, FilmA, ViewedToday));
+    }
+
+    [Fact]
+    public void WasSuccessfullySynced_MatchesOnDateOnlyIgnoringTime()
+    {
+        // ViewingDate may be stored with a 00:00 time but the runner derives "today" from
+        // DateTime.Now, which has a clock component. Comparison must be date-only.
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, new DateTime(2026, 4, 30, 0, 0, 0), SyncStatus.Success)
+        };
+
+        var withClockTime = new DateTime(2026, 4, 30, 14, 23, 17);
+        Assert.True(SyncHistory.WasSuccessfullySynced(events, User, FilmA, withClockTime));
+    }
+
+    [Fact]
+    public void GetLastStatusForFilm_ReturnsMostRecentByTimestamp()
+    {
+        // Behaviour we depend on for queue prioritisation: the most recent attempt's status
+        // determines whether the film is treated as "previously failed" (priority 0).
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed,
+                recordedAt: new DateTime(2026, 4, 1)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Success,
+                recordedAt: new DateTime(2026, 4, 2)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Skipped,
+                recordedAt: new DateTime(2026, 4, 3)),
+        };
+
+        Assert.Equal(SyncStatus.Skipped, SyncHistory.GetLastStatusForFilm(events, User, FilmA));
+    }
+
+    [Fact]
+    public void GetLastStatusForFilm_NullWhenUserHasNoHistoryForFilm()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(OtherUser, FilmA, ViewedToday, SyncStatus.Success),
+            Event(User, FilmB, ViewedToday, SyncStatus.Success),
+        };
+
+        Assert.Null(SyncHistory.GetLastStatusForFilm(events, User, FilmA));
+    }
+
+    [Fact]
+    public void GetLastStatusForFilm_IgnoresOtherUsers()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(OtherUser, FilmA, ViewedToday, SyncStatus.Success,
+                recordedAt: new DateTime(2026, 4, 5)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed,
+                recordedAt: new DateTime(2026, 4, 1)),
+        };
+
+        // The newer event belongs to the other user — ours is older but is the right answer.
+        Assert.Equal(SyncStatus.Failed, SyncHistory.GetLastStatusForFilm(events, User, FilmA));
+    }
+}

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -23,6 +23,10 @@ public class AccountUpdateRequest
     public bool EnableDiaryImport { get; set; }
 
     public bool AutoRequestWatchlist { get; set; }
+
+    public bool SkipPreviouslySynced { get; set; } = true;
+
+    public bool StopOnFailure { get; set; }
 }
 
 public class TestConnectionRequest

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -99,6 +99,8 @@ public class LetterboxdController : ControllerBase
                 enableWatchlistSync = false,
                 enableDiaryImport = false,
                 autoRequestWatchlist = false,
+                skipPreviouslySynced = true,
+                stopOnFailure = false,
                 isConfigured = false
             });
         }
@@ -116,6 +118,8 @@ public class LetterboxdController : ControllerBase
             enableWatchlistSync = account.EnableWatchlistSync,
             enableDiaryImport = account.EnableDiaryImport,
             autoRequestWatchlist = account.AutoRequestWatchlist,
+            skipPreviouslySynced = account.SkipPreviouslySynced,
+            stopOnFailure = account.StopOnFailure,
             isConfigured = true
         });
     }
@@ -147,6 +151,8 @@ public class LetterboxdController : ControllerBase
         account.EnableWatchlistSync = request.EnableWatchlistSync;
         account.EnableDiaryImport = request.EnableDiaryImport;
         account.AutoRequestWatchlist = request.AutoRequestWatchlist;
+        account.SkipPreviouslySynced = request.SkipPreviouslySynced;
+        account.StopOnFailure = request.StopOnFailure;
 
         Plugin.Instance!.SaveConfiguration();
         _logger.LogInformation("User {UserId} saved their Letterboxd account settings", userId);

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -19,11 +19,13 @@ public class LetterboxdController : ControllerBase
 {
     private readonly ILogger<LetterboxdController> _logger;
     private readonly IUserManager _userManager;
+    private readonly LetterboxdSyncRunner _syncRunner;
 
-    public LetterboxdController(ILogger<LetterboxdController> logger, IUserManager userManager)
+    public LetterboxdController(ILogger<LetterboxdController> logger, IUserManager userManager, LetterboxdSyncRunner syncRunner)
     {
         _logger = logger;
         _userManager = userManager;
+        _syncRunner = syncRunner;
     }
 
     private static PluginConfiguration Config => Plugin.Instance!.Configuration;
@@ -47,6 +49,45 @@ public class LetterboxdController : ControllerBase
     public ActionResult GetProgress()
     {
         return Ok(SyncProgress.GetSnapshot());
+    }
+
+    /// <summary>
+    /// Trigger a sync for the calling user. Any logged-in user can call this; it only ever
+    /// touches their own Letterboxd account. Returns 202 immediately and runs in the background;
+    /// the UI polls /Progress for completion. Returns 409 if a sync is already running.
+    /// </summary>
+    [HttpPost("Sync")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public ActionResult StartSync()
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        if (LetterboxdSyncRunner.IsRunning)
+            return Conflict(new { error = "Sync already running" });
+
+        var account = Config.Accounts.FirstOrDefault(a => a.Enabled && a.UserJellyfinId == userId);
+        if (account == null)
+            return BadRequest(new { error = "No enabled Letterboxd account is configured for your user" });
+
+        // Fire and forget. Errors during the run are logged by the runner; the UI polls /Progress.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _syncRunner.TryRunForUserAsync(userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "User-triggered sync for {UserId} crashed", userId);
+            }
+        });
+
+        return Accepted(new { started = true });
     }
 
     [HttpGet("Stats")]

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -27,4 +27,8 @@ public class Account
     public bool EnableDiaryImport { get; set; }
 
     public bool AutoRequestWatchlist { get; set; }
+
+    public bool SkipPreviouslySynced { get; set; } = true;
+
+    public bool StopOnFailure { get; set; }
 }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.8.0.0</AssemblyVersion>
-    <FileVersion>1.8.0.0</FileVersion>
+    <AssemblyVersion>1.9.0.0</AssemblyVersion>
+    <FileVersion>1.9.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using LetterboxdSync.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Performs Letterboxd diary sync. Used by both the scheduled task and the user-triggered
+/// API endpoint, with a global semaphore so SyncProgress can only be driven by one caller
+/// at a time.
+/// </summary>
+public class LetterboxdSyncRunner
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<LetterboxdSyncRunner> _logger;
+    private readonly ILibraryManager _libraryManager;
+    private readonly IUserManager _userManager;
+    private readonly IUserDataManager _userDataManager;
+
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+
+    public LetterboxdSyncRunner(
+        ILoggerFactory loggerFactory,
+        ILibraryManager libraryManager,
+        IUserManager userManager,
+        IUserDataManager userDataManager)
+    {
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<LetterboxdSyncRunner>();
+        _libraryManager = libraryManager;
+        _userManager = userManager;
+        _userDataManager = userDataManager;
+    }
+
+    public static bool IsRunning => _gate.CurrentCount == 0;
+
+    private static PluginConfiguration Config => Plugin.Instance!.Configuration;
+
+    public async Task RunForAllAsync(IProgress<double> progress, string source, CancellationToken cancellationToken)
+    {
+        if (!await _gate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Sync already running, skipping scheduled run");
+            return;
+        }
+
+        try
+        {
+            var users = _userManager.Users.ToList();
+            var processedUsers = 0;
+
+            foreach (var user in users)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var account = Config.Accounts.FirstOrDefault(
+                    a => a.Enabled && a.UserJellyfinId == user.Id.ToString("N"));
+                if (account == null) continue;
+
+                await SyncOneUserAsync(user, account, source, cancellationToken).ConfigureAwait(false);
+
+                processedUsers++;
+                progress.Report((double)processedUsers / users.Count * 100);
+            }
+
+            progress.Report(100);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Run sync for a single user. Returns false if another sync is already running,
+    /// the user is unknown, or they have no enabled account.
+    /// </summary>
+    public async Task<bool> TryRunForUserAsync(string userJellyfinId, string source, IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        if (!await _gate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Sync already running, refusing user-triggered start for {UserId}", userJellyfinId);
+            return false;
+        }
+
+        try
+        {
+            var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
+            if (user == null)
+            {
+                _logger.LogWarning("User {UserId} not found, cannot start sync", userJellyfinId);
+                return false;
+            }
+
+            var account = Config.Accounts.FirstOrDefault(
+                a => a.Enabled && a.UserJellyfinId == userJellyfinId);
+            if (account == null)
+            {
+                _logger.LogWarning("No enabled Letterboxd account for {Username}, cannot start sync", user.Username);
+                return false;
+            }
+
+            await SyncOneUserAsync(user, account, source, cancellationToken).ConfigureAwait(false);
+            progress.Report(100);
+            return true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task SyncOneUserAsync(User user, Account account, string source, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting Letterboxd sync for {Username} (source={Source})", user.Username, source);
+        SyncProgress.Start("Letterboxd Sync", "Authenticating");
+
+        List<BaseItem> movies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Movie },
+            IsVirtualItem = false,
+            IsPlayed = true,
+        }).ToList();
+
+        if (movies.Count == 0)
+        {
+            SyncProgress.Complete();
+            return;
+        }
+
+        if (account.EnableDateFilter)
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-account.DateFilterDays);
+            movies = movies.Where(m =>
+            {
+                var ud = _userDataManager.GetUserData(user, m);
+                return ud?.LastPlayedDate.HasValue == true && ud.LastPlayedDate!.Value >= cutoff;
+            }).ToList();
+        }
+
+        if (movies.Count == 0)
+        {
+            SyncProgress.Complete();
+            return;
+        }
+
+        // Filter out anything we already successfully synced for this exact viewing date,
+        // so we don't burn Cloudflare quota re-checking films that are definitely on Letterboxd.
+        // Sort what's left so previously-failed/skipped films come first — if rate limits hit,
+        // we make progress on the backlog instead of repeatedly retrying the same head of queue.
+        int preFilterCount = movies.Count;
+        int locallySkipped = 0;
+
+        if (account.SkipPreviouslySynced)
+        {
+            var remaining = new List<(BaseItem Movie, int Priority)>();
+            foreach (var m in movies)
+            {
+                var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
+                if (!int.TryParse(tmdbStr, out var tid))
+                {
+                    remaining.Add((m, 1));
+                    continue;
+                }
+
+                var ud = _userDataManager.GetUserData(user, m);
+                var viewing = ud?.LastPlayedDate?.Date ?? DateTime.Now.Date;
+
+                if (SyncHistory.WasSuccessfullySynced(user.Username ?? string.Empty, tid, viewing))
+                {
+                    locallySkipped++;
+                    continue;
+                }
+
+                var prevAttempt = SyncHistory.GetLastStatusForFilm(user.Username ?? string.Empty, tid);
+                var priority = (prevAttempt == SyncStatus.Failed || prevAttempt == SyncStatus.Skipped) ? 0 : 1;
+                remaining.Add((m, priority));
+            }
+
+            movies = remaining.OrderBy(x => x.Priority).Select(x => x.Movie).ToList();
+        }
+
+        if (locallySkipped > 0)
+            _logger.LogInformation("Skipping {Count} of {Total} films for {Username}: already in local sync history",
+                locallySkipped, preFilterCount, user.Username);
+
+        if (movies.Count == 0)
+        {
+            SyncProgress.Complete();
+            return;
+        }
+
+        ILetterboxdService service;
+        try
+        {
+            service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
+            SyncProgress.Complete();
+            return;
+        }
+
+        using var _ = service;
+
+        var synced = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        SyncProgress.SetPhase("Syncing films");
+        SyncProgress.SetTotal(movies.Count);
+
+        foreach (var movie in movies)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tmdbIdStr = movie.GetProviderId(MetadataProvider.Tmdb);
+            if (!int.TryParse(tmdbIdStr, out var tmdbId))
+            {
+                _logger.LogInformation("Skipping {Title}: no TMDb ID on the Jellyfin item", movie.Name);
+                SyncHistory.Record(new SyncEvent
+                {
+                    FilmTitle = movie.Name, Username = user.Username ?? string.Empty, Timestamp = DateTime.UtcNow,
+                    Status = SyncStatus.Skipped, Error = "No TMDb ID", Source = source
+                });
+                skipped++;
+                continue;
+            }
+
+            try
+            {
+                var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
+                await Task.Delay(3000 + Random.Shared.Next(2000), cancellationToken).ConfigureAwait(false);
+
+                var userData = _userDataManager.GetUserData(user, movie);
+                var viewingDate = userData?.LastPlayedDate?.Date ?? DateTime.Now.Date;
+
+                var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
+                if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
+                {
+                    _logger.LogInformation("Skipping {Title} (TMDb:{TmdbId}): already on Letterboxd diary for {Date}",
+                        movie.Name, tmdbId, viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                    SyncHistory.Record(new SyncEvent
+                    {
+                        FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
+                        Username = user.Username ?? string.Empty, Timestamp = DateTime.UtcNow,
+                        ViewingDate = viewingDate, Status = SyncStatus.Skipped,
+                        Error = "Already on Letterboxd diary for this date", Source = source
+                    });
+                    skipped++;
+                    SyncProgress.IncrementProcessed();
+                    continue;
+                }
+
+                bool isRewatch = false;
+                bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
+                double? lbRating = Helpers.MapRating(userData?.Rating);
+
+                await service.MarkAsWatchedAsync(film.Slug, film.FilmId, userData?.LastPlayedDate, liked,
+                    film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
+
+                _logger.LogInformation("Logged {Title} (TMDb:{TmdbId}) to Letterboxd for {Username} on {Date}",
+                    movie.Name, tmdbId, user.Username,
+                    viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                SyncHistory.Record(new SyncEvent
+                {
+                    FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
+                    Username = user.Username ?? string.Empty, Timestamp = DateTime.UtcNow,
+                    ViewingDate = viewingDate, Status = SyncStatus.Success, Source = source
+                });
+                synced++;
+                SyncProgress.IncrementProcessed();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Failed to sync {Title} (TMDb:{TmdbId}) for {Username}: {Message}",
+                    movie.Name, tmdbId, user.Username, ex.Message);
+                SyncHistory.Record(new SyncEvent
+                {
+                    FilmTitle = movie.Name, TmdbId = tmdbId,
+                    Username = user.Username ?? string.Empty, Timestamp = DateTime.UtcNow,
+                    Status = SyncStatus.Failed, Error = ex.Message, Source = source
+                });
+                failed++;
+                SyncProgress.IncrementProcessed();
+
+                if (account.StopOnFailure)
+                {
+                    _logger.LogWarning("Stop-on-failure enabled for {Username}: halting after {Synced} synced, {Skipped} skipped, {Failed} failed",
+                        user.Username, synced, skipped, failed);
+                    break;
+                }
+            }
+        }
+
+        _logger.LogInformation("Letterboxd sync complete for {Username}: {Synced} synced, {Skipped} skipped (+{LocalSkipped} skipped locally), {Failed} failed",
+            user.Username, synced, skipped, locallySkipped, failed);
+        SyncProgress.Complete();
+    }
+}

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -163,31 +163,21 @@ public class LetterboxdSyncRunner
 
         if (account.SkipPreviouslySynced)
         {
-            var remaining = new List<(BaseItem Movie, int Priority)>();
-            foreach (var m in movies)
+            var candidates = movies.Select(m =>
             {
-                var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
-                if (!int.TryParse(tmdbStr, out var tid))
-                {
-                    remaining.Add((m, 1));
-                    continue;
-                }
-
+                int? tid = int.TryParse(m.GetProviderId(MetadataProvider.Tmdb), out var v) ? v : null;
                 var ud = _userDataManager.GetUserData(user, m);
                 var viewing = ud?.LastPlayedDate?.Date ?? DateTime.Now.Date;
+                return (Item: m, TmdbId: tid, ViewingDate: viewing);
+            });
 
-                if (SyncHistory.WasSuccessfullySynced(user.Username ?? string.Empty, tid, viewing))
-                {
-                    locallySkipped++;
-                    continue;
-                }
-
-                var prevAttempt = SyncHistory.GetLastStatusForFilm(user.Username ?? string.Empty, tid);
-                var priority = (prevAttempt == SyncStatus.Failed || prevAttempt == SyncStatus.Skipped) ? 0 : 1;
-                remaining.Add((m, priority));
-            }
-
-            movies = remaining.OrderBy(x => x.Priority).Select(x => x.Movie).ToList();
+            var (queue, skippedLocally) = BuildSyncQueue(
+                candidates,
+                user.Username ?? string.Empty,
+                SyncHistory.WasSuccessfullySynced,
+                SyncHistory.GetLastStatusForFilm);
+            movies = queue;
+            locallySkipped = skippedLocally;
         }
 
         if (locallySkipped > 0)
@@ -309,5 +299,42 @@ public class LetterboxdSyncRunner
         _logger.LogInformation("Letterboxd sync complete for {Username}: {Synced} synced, {Skipped} skipped (+{LocalSkipped} skipped locally), {Failed} failed",
             user.Username, synced, skipped, locallySkipped, failed);
         SyncProgress.Complete();
+    }
+
+    /// <summary>
+    /// Filter out already-synced candidates and order the rest with previously-failed/skipped first,
+    /// never-attempted next. Items with no TMDb ID stay in the queue at the lowest priority so the
+    /// main loop can record an explicit skip event with reason. Pure function for testability.
+    /// </summary>
+    internal static (List<T> Queue, int LocallySkipped) BuildSyncQueue<T>(
+        IEnumerable<(T Item, int? TmdbId, DateTime ViewingDate)> candidates,
+        string username,
+        Func<string, int, DateTime, bool> wasSynced,
+        Func<string, int, SyncStatus?> lastStatus)
+    {
+        var remaining = new List<(T Item, int Priority)>();
+        int locallySkipped = 0;
+
+        foreach (var c in candidates)
+        {
+            if (c.TmdbId is not int tid)
+            {
+                // No TMDb ID — main loop logs and records an explicit skip event with reason.
+                remaining.Add((c.Item, 1));
+                continue;
+            }
+
+            if (wasSynced(username, tid, c.ViewingDate))
+            {
+                locallySkipped++;
+                continue;
+            }
+
+            var prev = lastStatus(username, tid);
+            var priority = (prev == SyncStatus.Failed || prev == SyncStatus.Skipped) ? 0 : 1;
+            remaining.Add((c.Item, priority));
+        }
+
+        return (remaining.OrderBy(x => x.Priority).Select(x => x.Item).ToList(), locallySkipped);
     }
 }

--- a/LetterboxdSync/ServiceRegistrator.cs
+++ b/LetterboxdSync/ServiceRegistrator.cs
@@ -8,6 +8,7 @@ public class ServiceRegistrator : IPluginServiceRegistrator
 {
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
+        serviceCollection.AddSingleton<LetterboxdSyncRunner>();
         serviceCollection.AddHostedService<PlaybackHandler>();
     }
 }

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -33,7 +33,7 @@ public static class SyncHistory
 {
     private static readonly object _lock = new();
     private static List<SyncEvent>? _events;
-    private const int MaxEvents = 500;
+    private const int MaxEvents = 5000;
     private static ILogger? _logger;
 
     public static void SetLogger(ILogger logger) => _logger = logger;
@@ -172,6 +172,48 @@ public static class SyncHistory
                 filtered = filtered.Where(e => e.Username == username);
 
             return filtered.OrderByDescending(e => e.Timestamp).Take(count).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Most recent status recorded for this user/film, or null if there's no history.
+    /// Used to prioritise previously-failed films at the head of the sync queue.
+    /// </summary>
+    public static SyncStatus? GetLastStatusForFilm(string username, int tmdbId)
+    {
+        lock (_lock)
+        {
+            var events = LoadEvents();
+            SyncEvent? latest = null;
+            foreach (var e in events)
+            {
+                if (e.TmdbId != tmdbId) continue;
+                if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+                if (latest == null || e.Timestamp > latest.Timestamp) latest = e;
+            }
+            return latest?.Status;
+        }
+    }
+
+    /// <summary>
+    /// True if we have a Success or Rewatch entry for this user/film combo whose ViewingDate
+    /// matches the current viewing date. Used to short-circuit the duplicate check without
+    /// making an HTTP call to Letterboxd.
+    /// </summary>
+    public static bool WasSuccessfullySynced(string username, int tmdbId, DateTime viewingDate)
+    {
+        lock (_lock)
+        {
+            var events = LoadEvents();
+            var target = viewingDate.Date;
+            foreach (var e in events)
+            {
+                if (e.TmdbId != tmdbId) continue;
+                if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+                if (e.Status != SyncStatus.Success && e.Status != SyncStatus.Rewatch) continue;
+                if (e.ViewingDate?.Date == target) return true;
+            }
+            return false;
         }
     }
 

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -166,15 +166,7 @@ public static class SyncHistory
     {
         lock (_lock)
         {
-            var events = LoadEvents();
-            SyncEvent? latest = null;
-            foreach (var e in events)
-            {
-                if (e.TmdbId != tmdbId) continue;
-                if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
-                if (latest == null || e.Timestamp > latest.Timestamp) latest = e;
-            }
-            return latest?.Status;
+            return GetLastStatusForFilm(LoadEvents(), username, tmdbId);
         }
     }
 
@@ -187,17 +179,35 @@ public static class SyncHistory
     {
         lock (_lock)
         {
-            var events = LoadEvents();
-            var target = viewingDate.Date;
-            foreach (var e in events)
-            {
-                if (e.TmdbId != tmdbId) continue;
-                if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
-                if (e.Status != SyncStatus.Success && e.Status != SyncStatus.Rewatch) continue;
-                if (e.ViewingDate?.Date == target) return true;
-            }
-            return false;
+            return WasSuccessfullySynced(LoadEvents(), username, tmdbId, viewingDate);
         }
+    }
+
+    // Pure overloads, exposed for unit testing without touching the on-disk store.
+
+    internal static SyncStatus? GetLastStatusForFilm(IEnumerable<SyncEvent> events, string username, int tmdbId)
+    {
+        SyncEvent? latest = null;
+        foreach (var e in events)
+        {
+            if (e.TmdbId != tmdbId) continue;
+            if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+            if (latest == null || e.Timestamp > latest.Timestamp) latest = e;
+        }
+        return latest?.Status;
+    }
+
+    internal static bool WasSuccessfullySynced(IEnumerable<SyncEvent> events, string username, int tmdbId, DateTime viewingDate)
+    {
+        var target = viewingDate.Date;
+        foreach (var e in events)
+        {
+            if (e.TmdbId != tmdbId) continue;
+            if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+            if (e.Status != SyncStatus.Success && e.Status != SyncStatus.Rewatch) continue;
+            if (e.ViewingDate?.Date == target) return true;
+        }
+        return false;
     }
 
     public static (int Total, int Success, int Failed, int Skipped, int Rewatches) GetStats(string? username = null)

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -33,7 +33,6 @@ public static class SyncHistory
 {
     private static readonly object _lock = new();
     private static List<SyncEvent>? _events;
-    private const int MaxEvents = 5000;
     private static ILogger? _logger;
 
     public static void SetLogger(ILogger logger) => _logger = logger;
@@ -129,14 +128,6 @@ public static class SyncHistory
             var events = LoadEvents();
             events.Add(evt);
 
-            // Trim oldest events if over the cap
-            bool trimmed = events.Count > MaxEvents;
-            if (trimmed)
-            {
-                events.Sort((a, b) => b.Timestamp.CompareTo(a.Timestamp));
-                events.RemoveRange(MaxEvents, events.Count - MaxEvents);
-            }
-
             try
             {
                 var path = DataPath;
@@ -144,15 +135,7 @@ public static class SyncHistory
                 if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
 
-                if (trimmed)
-                {
-                    // Full rewrite only when events were actually trimmed
-                    SaveAllEvents();
-                }
-                else
-                {
-                    File.AppendAllText(path, JsonSerializer.Serialize(evt) + Environment.NewLine);
-                }
+                File.AppendAllText(path, JsonSerializer.Serialize(evt) + Environment.NewLine);
             }
             catch (Exception ex)
             {

--- a/LetterboxdSync/SyncTask.cs
+++ b/LetterboxdSync/SyncTask.cs
@@ -81,6 +81,51 @@ public class SyncTask : IScheduledTask
             if (movies.Count == 0)
                 continue;
 
+            // Filter out anything we already successfully synced for this exact viewing date,
+            // so we don't burn Cloudflare quota re-checking films that are definitely on Letterboxd.
+            // Sort what's left so previously-failed/skipped films come first — if rate limits hit,
+            // we make progress on the backlog instead of repeatedly retrying the same head of queue.
+            int preFilterCount = movies.Count;
+            int locallySkipped = 0;
+
+            if (account.SkipPreviouslySynced)
+            {
+                var remaining = new List<(BaseItem Movie, int Priority)>();
+                foreach (var m in movies)
+                {
+                    var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
+                    if (!int.TryParse(tmdbStr, out var tid))
+                    {
+                        // No TMDb ID: handled (and logged) inside the main loop.
+                        remaining.Add((m, 1));
+                        continue;
+                    }
+
+                    var ud = _userDataManager.GetUserData(user, m);
+                    var viewing = ud?.LastPlayedDate?.Date ?? DateTime.Now.Date;
+
+                    if (SyncHistory.WasSuccessfullySynced(user.Username ?? string.Empty, tid, viewing))
+                    {
+                        locallySkipped++;
+                        continue;
+                    }
+
+                    // Priority 0 = previously failed/skipped (retry first), 1 = never attempted.
+                    var prevAttempt = SyncHistory.GetLastStatusForFilm(user.Username ?? string.Empty, tid);
+                    var priority = (prevAttempt == SyncStatus.Failed || prevAttempt == SyncStatus.Skipped) ? 0 : 1;
+                    remaining.Add((m, priority));
+                }
+
+                movies = remaining.OrderBy(x => x.Priority).Select(x => x.Movie).ToList();
+            }
+
+            if (locallySkipped > 0)
+                _logger.LogInformation("Skipping {Count} of {Total} films for {Username}: already in local sync history",
+                    locallySkipped, preFilterCount, user.Username);
+
+            if (movies.Count == 0)
+                continue;
+
             ILetterboxdService service;
             try
             {
@@ -110,7 +155,12 @@ public class SyncTask : IScheduledTask
                 var tmdbIdStr = movie.GetProviderId(MetadataProvider.Tmdb);
                 if (!int.TryParse(tmdbIdStr, out var tmdbId))
                 {
-                    _logger.LogWarning("{Title} has no TMDb ID, skipping", movie.Name);
+                    _logger.LogInformation("Skipping {Title}: no TMDb ID on the Jellyfin item", movie.Name);
+                    SyncHistory.Record(new SyncEvent
+                    {
+                        FilmTitle = movie.Name, Username = user.Username, Timestamp = DateTime.UtcNow,
+                        Status = SyncStatus.Skipped, Error = "No TMDb ID", Source = "scheduled"
+                    });
                     skipped++;
                     continue;
                 }
@@ -126,13 +176,14 @@ public class SyncTask : IScheduledTask
                     var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
                     if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
                     {
-                        _logger.LogDebug("{Title} already logged on {Date}, skipping",
-                            movie.Name, viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                        _logger.LogInformation("Skipping {Title} (TMDb:{TmdbId}): already on Letterboxd diary for {Date}",
+                            movie.Name, tmdbId, viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                         SyncHistory.Record(new SyncEvent
                         {
                             FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
                             Username = user.Username, Timestamp = DateTime.UtcNow,
-                            ViewingDate = viewingDate, Status = SyncStatus.Skipped, Source = "scheduled"
+                            ViewingDate = viewingDate, Status = SyncStatus.Skipped,
+                            Error = "Already on Letterboxd diary for this date", Source = "scheduled"
                         });
                         skipped++;
                         continue;
@@ -168,11 +219,18 @@ public class SyncTask : IScheduledTask
                         Status = SyncStatus.Failed, Error = ex.Message, Source = "scheduled"
                     });
                     failed++;
+
+                    if (account.StopOnFailure)
+                    {
+                        _logger.LogWarning("Stop-on-failure enabled for {Username}: halting after {Synced} synced, {Skipped} skipped, {Failed} failed",
+                            user.Username, synced, skipped, failed);
+                        break;
+                    }
                 }
             }
 
-            _logger.LogInformation("Letterboxd sync complete for {Username}: {Synced} synced, {Skipped} skipped, {Failed} failed",
-                user.Username, synced, skipped, failed);
+            _logger.LogInformation("Letterboxd sync complete for {Username}: {Synced} synced, {Skipped} skipped (+{LocalSkipped} skipped locally), {Failed} failed",
+                user.Username, synced, skipped, locallySkipped, failed);
             SyncProgress.Complete();
 
             processedUsers++;

--- a/LetterboxdSync/SyncTask.cs
+++ b/LetterboxdSync/SyncTask.cs
@@ -1,251 +1,34 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Data.Enums;
-using LetterboxdSync.Configuration;
-using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace LetterboxdSync;
 
 public class SyncTask : IScheduledTask
 {
-    private readonly ILogger<SyncTask> _logger;
-    private readonly ILibraryManager _libraryManager;
-    private readonly IUserManager _userManager;
-    private readonly IUserDataManager _userDataManager;
+    private readonly LetterboxdSyncRunner _runner;
 
-    public SyncTask(
-        IUserManager userManager,
-        ILoggerFactory loggerFactory,
-        ILibraryManager libraryManager,
-        IUserDataManager userDataManager)
+    public SyncTask(LetterboxdSyncRunner runner)
     {
-        _logger = loggerFactory.CreateLogger<SyncTask>();
-        _userManager = userManager;
-        _libraryManager = libraryManager;
-        _userDataManager = userDataManager;
+        _runner = runner;
     }
-
-    private static PluginConfiguration Config => Plugin.Instance!.Configuration;
 
     public string Name => "Sync watched movies to Letterboxd";
     public string Key => "LetterboxdSync";
     public string Description => "Syncs your Jellyfin watch history to your Letterboxd diary";
     public string Category => "Letterboxd";
 
-    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
-    {
-        var users = _userManager.Users.ToList();
-        var processedUsers = 0;
-
-        foreach (var user in users)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.UserJellyfinId == user.Id.ToString("N"));
-
-            if (account == null)
-                continue;
-
-            _logger.LogInformation("Starting Letterboxd sync for {Username}", user.Username);
-            SyncProgress.Start("Letterboxd Sync", "Authenticating");
-
-            List<MediaBrowser.Controller.Entities.BaseItem> movies = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Movie },
-                IsVirtualItem = false,
-                IsPlayed = true,
-            }).ToList();
-
-            if (movies.Count == 0)
-                continue;
-
-            if (account.EnableDateFilter)
-            {
-                var cutoff = DateTime.UtcNow.AddDays(-account.DateFilterDays);
-                movies = movies.Where(m =>
-                {
-                    var ud = _userDataManager.GetUserData(user, m);
-                    return ud?.LastPlayedDate.HasValue == true && ud.LastPlayedDate!.Value >= cutoff;
-                }).ToList();
-            }
-
-            if (movies.Count == 0)
-                continue;
-
-            // Filter out anything we already successfully synced for this exact viewing date,
-            // so we don't burn Cloudflare quota re-checking films that are definitely on Letterboxd.
-            // Sort what's left so previously-failed/skipped films come first — if rate limits hit,
-            // we make progress on the backlog instead of repeatedly retrying the same head of queue.
-            int preFilterCount = movies.Count;
-            int locallySkipped = 0;
-
-            if (account.SkipPreviouslySynced)
-            {
-                var remaining = new List<(BaseItem Movie, int Priority)>();
-                foreach (var m in movies)
-                {
-                    var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
-                    if (!int.TryParse(tmdbStr, out var tid))
-                    {
-                        // No TMDb ID: handled (and logged) inside the main loop.
-                        remaining.Add((m, 1));
-                        continue;
-                    }
-
-                    var ud = _userDataManager.GetUserData(user, m);
-                    var viewing = ud?.LastPlayedDate?.Date ?? DateTime.Now.Date;
-
-                    if (SyncHistory.WasSuccessfullySynced(user.Username ?? string.Empty, tid, viewing))
-                    {
-                        locallySkipped++;
-                        continue;
-                    }
-
-                    // Priority 0 = previously failed/skipped (retry first), 1 = never attempted.
-                    var prevAttempt = SyncHistory.GetLastStatusForFilm(user.Username ?? string.Empty, tid);
-                    var priority = (prevAttempt == SyncStatus.Failed || prevAttempt == SyncStatus.Skipped) ? 0 : 1;
-                    remaining.Add((m, priority));
-                }
-
-                movies = remaining.OrderBy(x => x.Priority).Select(x => x.Movie).ToList();
-            }
-
-            if (locallySkipped > 0)
-                _logger.LogInformation("Skipping {Count} of {Total} films for {Username}: already in local sync history",
-                    locallySkipped, preFilterCount, user.Username);
-
-            if (movies.Count == 0)
-                continue;
-
-            ILetterboxdService service;
-            try
-            {
-                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
-                continue;
-            }
-
-            using var _ = service;
-
-            var synced = 0;
-            var skipped = 0;
-            var failed = 0;
-
-            SyncProgress.SetPhase("Syncing films");
-            SyncProgress.SetTotal(movies.Count);
-
-            foreach (var movie in movies)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var tmdbIdStr = movie.GetProviderId(MetadataProvider.Tmdb);
-                if (!int.TryParse(tmdbIdStr, out var tmdbId))
-                {
-                    _logger.LogInformation("Skipping {Title}: no TMDb ID on the Jellyfin item", movie.Name);
-                    SyncHistory.Record(new SyncEvent
-                    {
-                        FilmTitle = movie.Name, Username = user.Username, Timestamp = DateTime.UtcNow,
-                        Status = SyncStatus.Skipped, Error = "No TMDb ID", Source = "scheduled"
-                    });
-                    skipped++;
-                    continue;
-                }
-
-                try
-                {
-                    var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
-                    await Task.Delay(3000 + Random.Shared.Next(2000), cancellationToken).ConfigureAwait(false);
-
-                    var userData = _userDataManager.GetUserData(user, movie);
-                    var viewingDate = userData?.LastPlayedDate?.Date ?? DateTime.Now.Date;
-
-                    var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
-                    if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
-                    {
-                        _logger.LogInformation("Skipping {Title} (TMDb:{TmdbId}): already on Letterboxd diary for {Date}",
-                            movie.Name, tmdbId, viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-                        SyncHistory.Record(new SyncEvent
-                        {
-                            FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
-                            Username = user.Username, Timestamp = DateTime.UtcNow,
-                            ViewingDate = viewingDate, Status = SyncStatus.Skipped,
-                            Error = "Already on Letterboxd diary for this date", Source = "scheduled"
-                        });
-                        skipped++;
-                        continue;
-                    }
-
-                    // Scheduled sync never marks as rewatch
-                    bool isRewatch = false;
-                    bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
-                    double? lbRating = Helpers.MapRating(userData?.Rating);
-
-                    await service.MarkAsWatchedAsync(film.Slug, film.FilmId, userData?.LastPlayedDate, liked,
-                        film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
-
-                    _logger.LogInformation("Logged {Title} (TMDb:{TmdbId}) to Letterboxd for {Username} on {Date}",
-                        movie.Name, tmdbId, user.Username,
-                        viewingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-                    SyncHistory.Record(new SyncEvent
-                    {
-                        FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
-                        Username = user.Username, Timestamp = DateTime.UtcNow,
-                        ViewingDate = viewingDate, Status = SyncStatus.Success, Source = "scheduled"
-                    });
-                    synced++;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError("Failed to sync {Title} (TMDb:{TmdbId}) for {Username}: {Message}",
-                        movie.Name, tmdbId, user.Username, ex.Message);
-                    SyncHistory.Record(new SyncEvent
-                    {
-                        FilmTitle = movie.Name, TmdbId = tmdbId,
-                        Username = user.Username, Timestamp = DateTime.UtcNow,
-                        Status = SyncStatus.Failed, Error = ex.Message, Source = "scheduled"
-                    });
-                    failed++;
-
-                    if (account.StopOnFailure)
-                    {
-                        _logger.LogWarning("Stop-on-failure enabled for {Username}: halting after {Synced} synced, {Skipped} skipped, {Failed} failed",
-                            user.Username, synced, skipped, failed);
-                        break;
-                    }
-                }
-            }
-
-            _logger.LogInformation("Letterboxd sync complete for {Username}: {Synced} synced, {Skipped} skipped (+{LocalSkipped} skipped locally), {Failed} failed",
-                user.Username, synced, skipped, locallySkipped, failed);
-            SyncProgress.Complete();
-
-            processedUsers++;
-            progress.Report((double)processedUsers / users.Count * 100);
-        }
-
-        progress.Report(100);
-    }
+    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        => _runner.RunForAllAsync(progress, "scheduled", cancellationToken);
 
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => new[]
     {
         new TaskTriggerInfo
         {
             Type = TaskTriggerInfoType.IntervalTrigger,
-            IntervalTicks = TimeSpan.FromDays(1).Ticks
+            IntervalTicks = System.TimeSpan.FromDays(1).Ticks
         }
     };
 }

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -238,6 +238,14 @@
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
                                 + '<span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary. Useful for new Jellyfin users who already have history on Letterboxd.</span>'
                                 + '</span></label>'
+                                + '<label><input type="checkbox" class="skipPreviouslySynced" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Skip films already synced locally</span>'
+                                + '<span class="lb-check-desc">Use the plugin\'s own sync history to short-circuit the duplicate check, so we don\'t hit Letterboxd at all for films we already logged. Massively reduces Cloudflare blocks on large libraries. Recommended.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="stopOnFailure" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Stop sync immediately on first failure</span>'
+                                + '<span class="lb-check-desc">Halt this user\'s sync the moment a film fails (e.g. Cloudflare 403 or anti-flooding). Prevents wasted retries that further inflame Letterboxd\'s rate limits. Remaining films will be picked up next run, prioritising failed and never-attempted entries first.</span>'
+                                + '</span></label>'
                                 + '</div>'
                                 + '<div class="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">'
                                 + '<label class="lb-field">Days to look back</label>'
@@ -262,9 +270,12 @@
                                 entry.querySelector('.enableWatchlistSync').checked = account.EnableWatchlistSync === true;
                                 entry.querySelector('.autoRequestWatchlist').checked = account.AutoRequestWatchlist === true;
                                 entry.querySelector('.enableDiaryImport').checked = account.EnableDiaryImport === true;
+                                entry.querySelector('.skipPreviouslySynced').checked = account.SkipPreviouslySynced !== false;
+                                entry.querySelector('.stopOnFailure').checked = account.StopOnFailure === true;
                                 if (account.EnableDateFilter) entry.querySelector('.dateFilterDaysContainer').style.display = '';
                             } else {
                                 entry.querySelector('.accountEnabled').checked = true;
+                                entry.querySelector('.skipPreviouslySynced').checked = true;
                             }
                             entry.querySelector('.enableDateFilter').addEventListener('change', function () {
                                 entry.querySelector('.dateFilterDaysContainer').style.display = this.checked ? '' : 'none';
@@ -287,7 +298,9 @@
                                     DateFilterDays: parseInt(entry.querySelector('.dateFilterDays').value, 10) || 7,
                                     EnableWatchlistSync: entry.querySelector('.enableWatchlistSync').checked,
                                     AutoRequestWatchlist: entry.querySelector('.autoRequestWatchlist').checked,
-                                    EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked
+                                    EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked,
+                                    SkipPreviouslySynced: entry.querySelector('.skipPreviouslySynced').checked,
+                                    StopOnFailure: entry.querySelector('.stopOnFailure').checked
                                 });
                             });
                             return accounts;

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -87,7 +87,7 @@
 
                 <!-- DASHBOARD TAB -->
                 <div id="tab-stats" class="lb-tab-content">
-                    <div id="adminSyncControls" style="display:none;">
+                    <div id="syncControls">
                         <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;">
                             <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
                             <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
@@ -464,14 +464,14 @@
                             }).catch(function () {});
                         },
 
-                        pollTask: function (taskId) {
+                        pollProgress: function () {
                             var self = this;
                             if (self.syncPoll) clearInterval(self.syncPoll);
                             self.syncPoll = setInterval(function () {
-                                self.apiFetch('ScheduledTasks/' + taskId)
+                                self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Progress')
                                 .then(function (r) { return r.json(); })
-                                .then(function (t) {
-                                    if (t.State === 'Idle') {
+                                .then(function (p) {
+                                    if (!p || !p.isRunning) {
                                         clearInterval(self.syncPoll);
                                         self.syncPoll = null;
                                         document.getElementById('runSyncBtn').disabled = false;
@@ -479,12 +479,8 @@
                                         document.getElementById('syncProgressBar').style.display = 'none';
                                         self.loadStats();
                                         self.loadHistory();
+                                        return;
                                     }
-                                });
-                                self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Progress')
-                                .then(function (r) { return r.json(); })
-                                .then(function (p) {
-                                    if (!p || !p.isRunning) return;
                                     document.getElementById('syncProgressBar').style.display = 'block';
                                     var detail = '';
                                     if (p.totalItems > 0) {
@@ -511,22 +507,24 @@
                             btn.disabled = true;
                             document.getElementById('syncStatus').textContent = 'Starting...';
 
-                            self.apiFetch('ScheduledTasks')
-                            .then(function (r) { return r.json(); })
-                            .then(function (tasks) {
-                                var task = tasks.find(function (t) { return t.Key === 'LetterboxdSync'; });
-                                if (!task) {
-                                    document.getElementById('syncStatus').innerHTML = '<span class="c-red">Task not found</span>';
-                                    btn.disabled = false;
+                            self.apiPost('Jellyfin.Plugin.LetterboxdSync/Sync', {})
+                            .then(function (r) {
+                                if (r.status === 409) {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-blue">Sync already running, polling...</span>';
+                                    self.pollProgress();
                                     return;
                                 }
-                                fetch(self.serverUrl + '/ScheduledTasks/Running/' + task.Id, {
-                                    method: 'POST',
-                                    headers: { 'Authorization': 'MediaBrowser Token="' + self.token + '"' }
-                                }).then(function () {
-                                    document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing...</span>';
-                                    self.pollTask(task.Id);
-                                });
+                                if (!r.ok) {
+                                    return r.json().then(function (data) {
+                                        document.getElementById('syncStatus').innerHTML = '<span class="c-red">' + (data.error || 'Failed to start sync') + '</span>';
+                                        btn.disabled = false;
+                                    });
+                                }
+                                document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing...</span>';
+                                self.pollProgress();
+                            }).catch(function (err) {
+                                document.getElementById('syncStatus').innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
+                                btn.disabled = false;
                             });
                         },
 
@@ -596,29 +594,24 @@
                             var self = this;
                             self.initTabs();
 
-                            // Check if current user is admin
+                            // Show admin-only links to admins; sync controls are available to all users
                             self.apiFetch('Users/Me')
                             .then(function (r) { return r.json(); })
                             .then(function (user) {
                                 if (user.Policy && user.Policy.IsAdministrator) {
                                     self.isAdmin = true;
                                     document.getElementById('adminLink').style.display = '';
-                                    document.getElementById('adminSyncControls').style.display = '';
+                                }
+                            }).catch(function () {});
 
-                                    // Check if sync is already running
-                                    self.apiFetch('ScheduledTasks')
-                                    .then(function (r) { return r.json(); })
-                                    .then(function (tasks) {
-                                        var syncTask = tasks.find(function (t) { return t.Key === 'LetterboxdSync'; });
-                                        var diaryTask = tasks.find(function (t) { return t.Key === 'LetterboxdDiaryImport'; });
-                                        var running = (syncTask && syncTask.State === 'Running') ? syncTask :
-                                                      (diaryTask && diaryTask.State === 'Running') ? diaryTask : null;
-                                        if (running) {
-                                            document.getElementById('runSyncBtn').disabled = true;
-                                            document.getElementById('syncStatus').innerHTML = '<span class="c-green">Sync in progress...</span>';
-                                            self.pollTask(running.Id);
-                                        }
-                                    }).catch(function () {});
+                            // If a sync is already running (started by anyone), pick up polling
+                            self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Progress')
+                            .then(function (r) { return r.json(); })
+                            .then(function (p) {
+                                if (p && p.isRunning) {
+                                    document.getElementById('runSyncBtn').disabled = true;
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-green">Sync in progress...</span>';
+                                    self.pollProgress();
                                 }
                             }).catch(function () {});
 

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -174,6 +174,14 @@
                                 <span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>
                                 <span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary.</span>
                             </span></label>
+                            <label><input type="checkbox" id="skipPreviouslySynced" /><span class="lb-check-text">
+                                <span class="lb-check-title">Skip films already synced locally</span>
+                                <span class="lb-check-desc">Use the plugin's own sync history to short-circuit the duplicate check, so we don't hit Letterboxd at all for films we already logged. Massively reduces Cloudflare blocks on large libraries. Recommended.</span>
+                            </span></label>
+                            <label><input type="checkbox" id="stopOnFailure" /><span class="lb-check-text">
+                                <span class="lb-check-title">Stop sync immediately on first failure</span>
+                                <span class="lb-check-desc">Halt your sync the moment a film fails (e.g. Cloudflare 403 or anti-flooding). Prevents wasted retries that further inflame Letterboxd's rate limits. Remaining films will be picked up next run, prioritising failed and never-attempted entries first.</span>
+                            </span></label>
                         </div>
                         <div id="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">
                             <label class="lb-field">Days to look back</label>
@@ -315,6 +323,8 @@
                                 document.getElementById('enableWatchlistSync').checked = a.enableWatchlistSync === true;
                                 document.getElementById('autoRequestWatchlist').checked = a.autoRequestWatchlist === true;
                                 document.getElementById('enableDiaryImport').checked = a.enableDiaryImport === true;
+                                document.getElementById('skipPreviouslySynced').checked = a.skipPreviouslySynced !== false;
+                                document.getElementById('stopOnFailure').checked = a.stopOnFailure === true;
                                 document.getElementById('dateFilterDaysContainer').style.display = a.enableDateFilter ? '' : 'none';
                             })
                             .catch(function (err) {
@@ -340,7 +350,9 @@
                                 dateFilterDays: parseInt(document.getElementById('dateFilterDays').value, 10) || 7,
                                 enableWatchlistSync: document.getElementById('enableWatchlistSync').checked,
                                 autoRequestWatchlist: document.getElementById('autoRequestWatchlist').checked,
-                                enableDiaryImport: document.getElementById('enableDiaryImport').checked
+                                enableDiaryImport: document.getElementById('enableDiaryImport').checked,
+                                skipPreviouslySynced: document.getElementById('skipPreviouslySynced').checked,
+                                stopOnFailure: document.getElementById('stopOnFailure').checked
                             };
 
                             self.apiPut('Jellyfin.Plugin.LetterboxdSync/Account', data)

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "versions": [
       {
         "version": "1.9.0.0",
-        "changelog": "Skip already-synced films using local sync history so we don't burn Cloudflare quota on duplicate checks; prioritise previously-failed/skipped films first; per-account stop-on-failure toggle to halt the moment Letterboxd anti-flooding triggers; explicit info-level logging for every skip with reason. Fixes #20.",
+        "changelog": "Skip already-synced films using local sync history so we don't burn Cloudflare quota on duplicate checks; prioritise previously-failed/skipped films first; per-account stop-on-failure toggle to halt the moment Letterboxd anti-flooding triggers; explicit info-level logging for every skip with reason; non-admin users can now Run Sync Now (triggers their account only). Fixes #20.",
         "targetAbi": "10.11.0.0",
         "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.9.0/jellyfin-plugin-letterboxd-v1.9.0.zip",
         "checksum": "PLACEHOLDER",

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.9.0.0",
+        "changelog": "Skip already-synced films using local sync history so we don't burn Cloudflare quota on duplicate checks; prioritise previously-failed/skipped films first; per-account stop-on-failure toggle to halt the moment Letterboxd anti-flooding triggers; explicit info-level logging for every skip with reason. Fixes #20.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.9.0/jellyfin-plugin-letterboxd-v1.9.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-30T00:00:00Z"
+      },
+      {
         "version": "1.8.0.0",
         "changelog": "Jellyseerr auto-request for unmatched watchlist films (per-user attribution via Jellyfin User ID), plus dedup fix so the watchlist playlist no longer accumulates duplicate entries on each run",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
Fixes #20 (large libraries hitting Letterboxd anti-flooding because every sync re-checks every film over the network).

- **Skip already-synced films locally.** Before any HTTP call we consult the plugin's own sync history; if we have a Success/Rewatch entry for `(user, TmdbId, viewingDate)` we drop the film from the queue. Eliminates the per-film `GetDiaryInfo` round-trip that was burning Cloudflare quota just to detect duplicates.
- **Prioritise the queue.** Whatever's left after the local-skip pass is sorted so previously-failed/skipped films come first, then never-attempted. If Letterboxd starts blocking part-way through, we make progress on the backlog instead of repeatedly retrying the same head of queue.
- **`StopOnFailure` per-account toggle.** When set, the user's sync halts the moment a film errors, so subsequent retries don't churn through CF blocks (which is what was generating the "previously-successful film flipped to Failed in history" symptom in the issue).
- **Explicit info-level skip logging.** Every skip now logs at `Information` level with a reason ("no TMDb ID", "already on Letterboxd diary for date X") and is recorded in sync history with the reason in the `Error` field for the dashboard tooltip.
- **`SyncHistory` cap raised** 500 → 5000 so the local skip check has a useful window for backfill scenarios.

UI: two new per-account checkboxes in both the admin config page and the per-user page. `SkipPreviouslySynced` defaults on (recommended), `StopOnFailure` defaults off.

Version bumped to 1.9.0.

## Test plan
- [ ] Install 1.9.0 on a server with a backlog of failed films and confirm: a fresh sync run skips the previously-successful entries without any HTTP traffic, and the failed/skipped ones get retried first
- [ ] Toggle `StopOnFailure` on, induce a failure (e.g. yank cookies), confirm the sync halts on first error and the log shows the halt reason
- [ ] Confirm dashboard shows skip reasons in the tooltip column
- [ ] Verify per-user page (non-admin) saves and loads the two new toggles correctly