### PR TITLE
feat: local-history duplicate backstop, paginated history dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 .vs/
 *.nupkg
 release/
+.gstack/

--- a/LetterboxdSync.Tests/DuplicateBackstopTests.cs
+++ b/LetterboxdSync.Tests/DuplicateBackstopTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Tests for SyncHistory.GetLastSuccessfulSyncDate (the lookup powering the local-history
+/// duplicate backstop) combined with Helpers.IsRewatch (the threshold deciding whether the
+/// new viewing is a genuine rewatch or a likely duplicate). The runner uses both together
+/// before MarkAsWatched, so these tests verify the suppression decision matrix end to end.
+/// </summary>
+public class DuplicateBackstopTests
+{
+    private const string User = "lachlan";
+    private const int FilmA = 100;
+    private const int FilmB = 200;
+
+    private static SyncEvent SuccessAt(DateTime viewingDate, DateTime? recordedAt = null, string username = User, int tmdbId = FilmA)
+        => new()
+        {
+            Username = username,
+            TmdbId = tmdbId,
+            ViewingDate = viewingDate,
+            Status = SyncStatus.Success,
+            Timestamp = recordedAt ?? viewingDate.AddHours(1),
+        };
+
+    /// <summary>
+    /// Returns true when the runner would suppress, i.e. there is prior sync history and
+    /// IsRewatch says the new viewing is too soon to be a genuine rewatch.
+    /// </summary>
+    private static bool WouldSuppress(IEnumerable<SyncEvent> history, string username, int tmdbId, DateTime newViewingDate)
+    {
+        var last = SyncHistory.GetLastSuccessfulSyncDate(history, username, tmdbId);
+        return last.HasValue && !Helpers.IsRewatch(last, newViewingDate);
+    }
+
+    [Fact]
+    public void Suppresses_TwinlessCase_SameDateAsPriorSuccess()
+    {
+        // Real Letterboxd duplicate observed in Drvke97's diary and our own (Twinless on
+        // 2026-03-25, logged 2x): the GetDiaryInfo Cloudflare-failure path let MarkAsWatched
+        // create a second entry on the same date.
+        var history = new List<SyncEvent> { SuccessAt(new DateTime(2026, 3, 25)) };
+
+        Assert.True(WouldSuppress(history, User, FilmA, new DateTime(2026, 3, 25)));
+    }
+
+    [Fact]
+    public void Suppresses_OneDayApart_AvatarMercyTrialPattern()
+    {
+        // Avatar / Mercy / Trial of the Chicago 7 all showed pairs one calendar day apart
+        // with no rewatch flag. The IsRewatch threshold is strictly > 1 day, so consecutive
+        // days suppress.
+        var history = new List<SyncEvent> { SuccessAt(new DateTime(2026, 4, 28)) };
+
+        Assert.True(WouldSuppress(history, User, FilmA, new DateTime(2026, 4, 29)));
+    }
+
+    [Fact]
+    public void Allows_GenuineRewatchTwoDaysLater()
+    {
+        // Two clear days between viewings, treat as a rewatch and let MarkAsWatched proceed.
+        var history = new List<SyncEvent> { SuccessAt(new DateTime(2026, 4, 28)) };
+
+        Assert.False(WouldSuppress(history, User, FilmA, new DateTime(2026, 4, 30)));
+    }
+
+    [Fact]
+    public void Allows_GenuineRewatchThreeWeeksLater_TreasurePlanetPattern()
+    {
+        // Treasure Planet was logged 2026-03-03 (rewatch) and again 2026-03-25 — clearly a
+        // legitimate later viewing, must not be suppressed.
+        var history = new List<SyncEvent> { SuccessAt(new DateTime(2026, 3, 3)) };
+
+        Assert.False(WouldSuppress(history, User, FilmA, new DateTime(2026, 3, 25)));
+    }
+
+    [Fact]
+    public void Allows_NeverSyncedFilm()
+    {
+        // Without prior history, nothing to suppress against; runner proceeds to MarkAsWatched.
+        var history = new List<SyncEvent>();
+
+        Assert.False(WouldSuppress(history, User, FilmA, new DateTime(2026, 4, 29)));
+    }
+
+    [Fact]
+    public void GetLastSuccessfulSyncDate_PrefersMostRecentByTimestamp()
+    {
+        // If multiple successful syncs exist (e.g. a real rewatch was correctly logged),
+        // the backstop should compare against the most recent one, not an old one that
+        // would falsely look like a rewatch threshold pass.
+        var history = new List<SyncEvent>
+        {
+            SuccessAt(new DateTime(2026, 1, 1), recordedAt: new DateTime(2026, 1, 1, 12, 0, 0)),
+            SuccessAt(new DateTime(2026, 4, 28), recordedAt: new DateTime(2026, 4, 28, 12, 0, 0)),
+        };
+
+        var last = SyncHistory.GetLastSuccessfulSyncDate(history, User, FilmA);
+
+        Assert.Equal(new DateTime(2026, 4, 28), last);
+    }
+
+    [Fact]
+    public void GetLastSuccessfulSyncDate_IgnoresFailedAndSkipped()
+    {
+        // Backstop is about preventing ANOTHER successful entry from going to Letterboxd.
+        // Failed/Skipped attempts are not entries on Letterboxd and must not block retries.
+        var history = new List<SyncEvent>
+        {
+            new() { Username = User, TmdbId = FilmA, ViewingDate = new DateTime(2026, 4, 28),
+                    Status = SyncStatus.Failed, Timestamp = DateTime.UtcNow },
+            new() { Username = User, TmdbId = FilmA, ViewingDate = new DateTime(2026, 4, 28),
+                    Status = SyncStatus.Skipped, Timestamp = DateTime.UtcNow },
+        };
+
+        Assert.Null(SyncHistory.GetLastSuccessfulSyncDate(history, User, FilmA));
+    }
+
+    [Fact]
+    public void GetLastSuccessfulSyncDate_AcceptsRewatchAsValidPriorSuccess()
+    {
+        // Rewatch entries are real diary entries on Letterboxd and count as a prior sync
+        // for the purposes of duplicate prevention.
+        var history = new List<SyncEvent>
+        {
+            new() { Username = User, TmdbId = FilmA, ViewingDate = new DateTime(2026, 4, 1),
+                    Status = SyncStatus.Rewatch, Timestamp = DateTime.UtcNow },
+        };
+
+        Assert.Equal(new DateTime(2026, 4, 1), SyncHistory.GetLastSuccessfulSyncDate(history, User, FilmA));
+    }
+
+    [Fact]
+    public void GetLastSuccessfulSyncDate_IsScopedPerFilmAndPerUser()
+    {
+        var history = new List<SyncEvent>
+        {
+            SuccessAt(new DateTime(2026, 4, 28), tmdbId: FilmB),
+            SuccessAt(new DateTime(2026, 4, 28), username: "thebarn"),
+        };
+
+        Assert.Null(SyncHistory.GetLastSuccessfulSyncDate(history, User, FilmA));
+    }
+}

--- a/LetterboxdSync.Tests/SyncHistoryPaginationTests.cs
+++ b/LetterboxdSync.Tests/SyncHistoryPaginationTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Tests for SyncHistory.GetPage. Powers the dashboard paginator added in 1.9.1
+/// after we removed the 500-entry cap.
+/// </summary>
+public class SyncHistoryPaginationTests
+{
+    private static List<SyncEvent> Events(int n, string username = "lachlan")
+    {
+        var list = new List<SyncEvent>(n);
+        for (int i = 0; i < n; i++)
+        {
+            list.Add(new SyncEvent
+            {
+                FilmTitle = $"Film {i:D3}",
+                TmdbId = 1000 + i,
+                Username = username,
+                Status = SyncStatus.Success,
+                // Older index = older timestamp, so newest-first ordering puts the highest indexes first.
+                Timestamp = new DateTime(2026, 1, 1).AddMinutes(i),
+            });
+        }
+        return list;
+    }
+
+    [Fact]
+    public void GetPage_ReturnsNewestFirst()
+    {
+        var events = Events(5);
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 0, count: 3);
+
+        Assert.Equal(5, total);
+        Assert.Equal(new[] { "Film 004", "Film 003", "Film 002" }, slice.Select(e => e.FilmTitle));
+    }
+
+    [Fact]
+    public void GetPage_OffsetSkipsFromTheTopOfNewestFirst()
+    {
+        var events = Events(10);
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 3, count: 2);
+
+        Assert.Equal(10, total);
+        // Sorted newest-first: Film 009, 008, 007, then offset 3 lands on Film 006, 005.
+        Assert.Equal(new[] { "Film 006", "Film 005" }, slice.Select(e => e.FilmTitle));
+    }
+
+    [Fact]
+    public void GetPage_OffsetPastEndYieldsEmptySlice()
+    {
+        var events = Events(10);
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 50, count: 10);
+
+        Assert.Empty(slice);
+        Assert.Equal(10, total);
+    }
+
+    [Fact]
+    public void GetPage_NegativeOffsetTreatedAsZero()
+    {
+        var events = Events(5);
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: -10, count: 2);
+
+        Assert.Equal(5, total);
+        Assert.Equal(new[] { "Film 004", "Film 003" }, slice.Select(e => e.FilmTitle));
+    }
+
+    [Fact]
+    public void GetPage_NegativeCountYieldsEmptySlice()
+    {
+        var events = Events(5);
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 0, count: -1);
+
+        Assert.Empty(slice);
+        Assert.Equal(5, total);
+    }
+
+    [Fact]
+    public void GetPage_TotalReflectsUserFilter()
+    {
+        var events = new List<SyncEvent>();
+        events.AddRange(Events(7, "lachlan"));
+        events.AddRange(Events(3, "thebarn"));
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 0, count: 100, username: "thebarn");
+
+        Assert.Equal(3, total);
+        Assert.Equal(3, slice.Count);
+        Assert.All(slice, e => Assert.Equal("thebarn", e.Username));
+    }
+
+    [Fact]
+    public void GetPage_NoUsernameFilterReturnsAllUsersInOrder()
+    {
+        var events = new List<SyncEvent>
+        {
+            new() { FilmTitle = "A", Username = "lachlan", Timestamp = new DateTime(2026, 1, 1) },
+            new() { FilmTitle = "B", Username = "thebarn", Timestamp = new DateTime(2026, 1, 2) },
+            new() { FilmTitle = "C", Username = "lachlan", Timestamp = new DateTime(2026, 1, 3) },
+        };
+
+        var (slice, total) = SyncHistory.GetPage(events, offset: 0, count: 100);
+
+        Assert.Equal(3, total);
+        Assert.Equal(new[] { "C", "B", "A" }, slice.Select(e => e.FilmTitle));
+    }
+}

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -106,13 +106,20 @@ public class LetterboxdController : ControllerBase
         });
     }
 
+    /// <summary>
+    /// Paginated sync history. Returns the slice plus the total so the dashboard can
+    /// render a paginator. Without an offset the response is backwards-compatible with
+    /// pre-pagination clients that just consumed the array, since callers that ignore
+    /// the wrapper still get the most recent items via /History?count=N.
+    /// </summary>
     [HttpGet("History")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult GetHistory([FromQuery] int count = 50)
+    public ActionResult GetHistory([FromQuery] int count = 50, [FromQuery] int offset = 0)
     {
         var jellyfinUsername = GetJellyfinUsername();
-        var events = SyncHistory.GetRecent(Math.Min(count, 200), jellyfinUsername);
-        return Ok(events);
+        var capped = Math.Min(Math.Max(count, 1), 200);
+        var (events, total) = SyncHistory.GetPage(Math.Max(offset, 0), capped, jellyfinUsername);
+        return Ok(new { events, total, offset = Math.Max(offset, 0), count = capped });
     }
 
     [HttpGet("Account")]

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.9.0.0</AssemblyVersion>
-    <FileVersion>1.9.0.0</FileVersion>
+    <AssemblyVersion>1.9.1.0</AssemblyVersion>
+    <FileVersion>1.9.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -255,6 +255,30 @@ public class LetterboxdSyncRunner
                     continue;
                 }
 
+                // Local-history backstop. The Letterboxd-side IsDuplicate check above silently
+                // returns false when GetDiaryInfo fails (e.g. Cloudflare 403 -> null lastDate),
+                // which used to let MarkAsWatched create a duplicate entry. Cross-check our own
+                // append-only log: if we have a recent successful sync that is not far enough
+                // back to count as a real rewatch, refuse rather than risk a duplicate.
+                var localLastSync = SyncHistory.GetLastSuccessfulSyncDate(user.Username ?? string.Empty, tmdbId);
+                if (localLastSync.HasValue && !Helpers.IsRewatch(localLastSync, viewingDate))
+                {
+                    var lastSyncStr = localLastSync.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                    _logger.LogInformation("Skipping {Title} (TMDb:{TmdbId}): local history shows prior sync on {Date}, suppressing potential duplicate",
+                        movie.Name, tmdbId, lastSyncStr);
+                    SyncHistory.Record(new SyncEvent
+                    {
+                        FilmTitle = movie.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
+                        Username = user.Username ?? string.Empty, Timestamp = DateTime.UtcNow,
+                        ViewingDate = viewingDate, Status = SyncStatus.Skipped,
+                        Error = $"Local history shows prior sync on {lastSyncStr}, suppressing potential duplicate",
+                        Source = source
+                    });
+                    skipped++;
+                    SyncProgress.IncrementProcessed();
+                    continue;
+                }
+
                 bool isRewatch = false;
                 bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
                 double? lbRating = Helpers.MapRating(userData?.Rating);

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -159,6 +159,32 @@ public static class SyncHistory
     }
 
     /// <summary>
+    /// Page through history newest-first. Returns the slice plus the total count for the
+    /// caller's paginator. Username, when supplied, restricts both the slice and the total
+    /// to that user's events.
+    /// </summary>
+    public static (List<SyncEvent> Events, int Total) GetPage(int offset, int count, string? username = null)
+    {
+        lock (_lock)
+        {
+            return GetPage(LoadEvents(), offset, count, username);
+        }
+    }
+
+    internal static (List<SyncEvent> Events, int Total) GetPage(IEnumerable<SyncEvent> events, int offset, int count, string? username = null)
+    {
+        IEnumerable<SyncEvent> filtered = events;
+        if (!string.IsNullOrEmpty(username))
+            filtered = filtered.Where(e => e.Username == username);
+
+        var ordered = filtered.OrderByDescending(e => e.Timestamp).ToList();
+        var safeOffset = Math.Max(0, offset);
+        var safeCount = Math.Max(0, count);
+        var slice = ordered.Skip(safeOffset).Take(safeCount).ToList();
+        return (slice, ordered.Count);
+    }
+
+    /// <summary>
     /// Most recent status recorded for this user/film, or null if there's no history.
     /// Used to prioritise previously-failed films at the head of the sync queue.
     /// </summary>
@@ -208,6 +234,34 @@ public static class SyncHistory
             if (e.ViewingDate?.Date == target) return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// ViewingDate of the most recent Success or Rewatch entry for this user/film, or null
+    /// if there isn't one. Used as a local-history backstop against duplicates that can
+    /// otherwise be created when Letterboxd's own duplicate-check call fails (Cloudflare
+    /// 403 returns null lastDate, which the original IsDuplicate check then treats as
+    /// "not a duplicate").
+    /// </summary>
+    public static DateTime? GetLastSuccessfulSyncDate(string username, int tmdbId)
+    {
+        lock (_lock)
+        {
+            return GetLastSuccessfulSyncDate(LoadEvents(), username, tmdbId);
+        }
+    }
+
+    internal static DateTime? GetLastSuccessfulSyncDate(IEnumerable<SyncEvent> events, string username, int tmdbId)
+    {
+        SyncEvent? latest = null;
+        foreach (var e in events)
+        {
+            if (e.TmdbId != tmdbId) continue;
+            if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+            if (e.Status != SyncStatus.Success && e.Status != SyncStatus.Rewatch) continue;
+            if (latest == null || e.Timestamp > latest.Timestamp) latest = e;
+        }
+        return latest?.ViewingDate;
     }
 
     public static (int Total, int Success, int Failed, int Skipped, int Rewatches) GetStats(string? username = null)

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -102,6 +102,13 @@
                             </tbody>
                         </table>
                     </div>
+                    <div id="historyPagination" style="display:none;margin-top:0.7em;align-items:center;gap:0.4em;flex-wrap:wrap;font-size:0.9em;">
+                        <button type="button" class="lb-btn lb-btn-secondary" id="historyFirst" title="First page">&laquo;</button>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="historyPrev" title="Previous page">&lsaquo;</button>
+                        <span id="historyPageInfo" class="c-muted" style="margin:0 0.4em;"></span>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="historyNext" title="Next page">&rsaquo;</button>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="historyLast" title="Last page">&raquo;</button>
+                    </div>
                 </div>
 
                 <!-- SETTINGS TAB -->
@@ -178,6 +185,9 @@
                         users: [],
                         currentSlug: '',
                         syncPoll: null,
+                        historyPageSize: 100,
+                        historyOffset: 0,
+                        historyTotal: 0,
 
                         initTabs: function () {
                             var tabs = document.querySelectorAll('.lb-tab');
@@ -373,11 +383,19 @@
                             });
                         },
 
-                        loadHistory: function () {
-                            ApiClient.getJSON(ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/History', { count: 100 })).then(function (events) {
+                        loadHistory: function (resetToFirstPage) {
+                            var self = this;
+                            if (resetToFirstPage) self.historyOffset = 0;
+                            var pageSize = self.historyPageSize || 100;
+                            var offset = self.historyOffset || 0;
+                            ApiClient.getJSON(ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/History', { count: pageSize, offset: offset })).then(function (resp) {
+                                // Backwards-compat: pre-1.9.1 responded with a bare array.
+                                var events = (resp && resp.events) ? resp.events : (Array.isArray(resp) ? resp : []);
+                                self.historyTotal = (resp && typeof resp.total === 'number') ? resp.total : events.length;
+                                self.renderPaginator();
                                 var tbody = document.getElementById('historyBody');
                                 tbody.innerHTML = '';
-                                if (!events || events.length === 0) {
+                                if (events.length === 0) {
                                     tbody.innerHTML = '<tr><td colspan="5" style="padding:2em;text-align:center;" class="c-muted">Run a sync to see activity here.</td></tr>';
                                     return;
                                 }
@@ -412,6 +430,28 @@
                                     tbody.appendChild(tr);
                                 });
                             });
+                        },
+
+                        renderPaginator: function () {
+                            var pager = document.getElementById('historyPagination');
+                            if (!pager) return;
+                            if (this.historyTotal <= this.historyPageSize) { pager.style.display = 'none'; return; }
+                            pager.style.display = 'flex';
+                            var totalPages = Math.max(1, Math.ceil(this.historyTotal / this.historyPageSize));
+                            var currentPage = Math.floor(this.historyOffset / this.historyPageSize) + 1;
+                            document.getElementById('historyPageInfo').textContent =
+                                'Page ' + currentPage + ' of ' + totalPages + ' (' + this.historyTotal + ' entries)';
+                            document.getElementById('historyFirst').disabled = currentPage === 1;
+                            document.getElementById('historyPrev').disabled = currentPage === 1;
+                            document.getElementById('historyNext').disabled = currentPage === totalPages;
+                            document.getElementById('historyLast').disabled = currentPage === totalPages;
+                        },
+
+                        gotoHistoryPage: function (page) {
+                            var totalPages = Math.max(1, Math.ceil(this.historyTotal / this.historyPageSize));
+                            var clamped = Math.min(Math.max(page, 1), totalPages);
+                            this.historyOffset = (clamped - 1) * this.historyPageSize;
+                            this.loadHistory(false);
                         },
 
                         checkSyncRunning: function () {
@@ -565,6 +605,10 @@
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveSettings(); });
                             document.getElementById('testJellyseerrBtn').addEventListener('click', function () { self.testJellyseerr(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
+                            document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
+                            document.getElementById('historyPrev').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize)); });
+                            document.getElementById('historyNext').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize) + 2); });
+                            document.getElementById('historyLast').addEventListener('click', function () { self.gotoHistoryPage(Math.ceil(self.historyTotal / self.historyPageSize)); });
                             document.getElementById('reviewCancel').addEventListener('click', function () { document.getElementById('reviewModal').style.display = 'none'; });
                             document.getElementById('reviewSubmit').addEventListener('click', function () { self.submitReview(); });
                             document.getElementById('reviewRewatch').addEventListener('change', function () {

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -117,6 +117,13 @@
                             </tbody>
                         </table>
                     </div>
+                    <div id="historyPagination" style="display:none;margin-top:0.7em;align-items:center;gap:0.4em;flex-wrap:wrap;font-size:0.9em;">
+                        <button type="button" class="lb-btn lb-btn-secondary lb-page-btn" id="historyFirst" title="First page">&laquo;</button>
+                        <button type="button" class="lb-btn lb-btn-secondary lb-page-btn" id="historyPrev" title="Previous page">&lsaquo;</button>
+                        <span id="historyPageInfo" class="c-muted" style="margin:0 0.4em;"></span>
+                        <button type="button" class="lb-btn lb-btn-secondary lb-page-btn" id="historyNext" title="Next page">&rsaquo;</button>
+                        <button type="button" class="lb-btn lb-btn-secondary lb-page-btn" id="historyLast" title="Last page">&raquo;</button>
+                    </div>
                 </div>
 
                 <!-- MY ACCOUNT TAB -->
@@ -246,6 +253,9 @@
                         isAdmin: false,
                         currentSlug: '',
                         syncPoll: null,
+                        historyPageSize: 100,
+                        historyOffset: 0,
+                        historyTotal: 0,
 
                         resolveAuth: function () {
                             if (typeof ApiClient !== 'undefined') {
@@ -425,13 +435,20 @@
                             }).catch(function () {});
                         },
 
-                        loadHistory: function () {
-                            this.apiFetch('Jellyfin.Plugin.LetterboxdSync/History?count=100')
+                        loadHistory: function (resetToFirstPage) {
+                            var self = this;
+                            if (resetToFirstPage) self.historyOffset = 0;
+                            var url = 'Jellyfin.Plugin.LetterboxdSync/History?count=' + self.historyPageSize + '&offset=' + self.historyOffset;
+                            this.apiFetch(url)
                             .then(function (r) { return r.json(); })
-                            .then(function (events) {
+                            .then(function (resp) {
+                                // Backwards-compat: pre-1.9.1 returned a bare array.
+                                var events = (resp && resp.events) ? resp.events : (Array.isArray(resp) ? resp : []);
+                                self.historyTotal = (resp && typeof resp.total === 'number') ? resp.total : events.length;
+                                self.renderPaginator();
                                 var tbody = document.getElementById('historyBody');
                                 tbody.innerHTML = '';
-                                if (!events || events.length === 0) {
+                                if (events.length === 0) {
                                     tbody.innerHTML = '<tr><td colspan="5" style="padding:2em;text-align:center;" class="c-muted">No sync activity yet.</td></tr>';
                                     return;
                                 }
@@ -462,6 +479,28 @@
                                     tbody.appendChild(tr);
                                 });
                             }).catch(function () {});
+                        },
+
+                        renderPaginator: function () {
+                            var pager = document.getElementById('historyPagination');
+                            if (!pager) return;
+                            if (this.historyTotal <= this.historyPageSize) { pager.style.display = 'none'; return; }
+                            pager.style.display = 'flex';
+                            var totalPages = Math.max(1, Math.ceil(this.historyTotal / this.historyPageSize));
+                            var currentPage = Math.floor(this.historyOffset / this.historyPageSize) + 1;
+                            document.getElementById('historyPageInfo').textContent =
+                                'Page ' + currentPage + ' of ' + totalPages + ' (' + this.historyTotal + ' entries)';
+                            document.getElementById('historyFirst').disabled = currentPage === 1;
+                            document.getElementById('historyPrev').disabled = currentPage === 1;
+                            document.getElementById('historyNext').disabled = currentPage === totalPages;
+                            document.getElementById('historyLast').disabled = currentPage === totalPages;
+                        },
+
+                        gotoHistoryPage: function (page) {
+                            var totalPages = Math.max(1, Math.ceil(this.historyTotal / this.historyPageSize));
+                            var clamped = Math.min(Math.max(page, 1), totalPages);
+                            this.historyOffset = (clamped - 1) * this.historyPageSize;
+                            this.loadHistory(false);
                         },
 
                         pollProgress: function () {
@@ -624,6 +663,10 @@
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveAccount(); });
                             document.getElementById('testBtn').addEventListener('click', function () { self.testConnection(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
+                            document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
+                            document.getElementById('historyPrev').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize)); });
+                            document.getElementById('historyNext').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize) + 2); });
+                            document.getElementById('historyLast').addEventListener('click', function () { self.gotoHistoryPage(Math.ceil(self.historyTotal / self.historyPageSize)); });
                             document.getElementById('reviewCancel').addEventListener('click', function () { document.getElementById('reviewModal').style.display = 'none'; });
                             document.getElementById('reviewSubmit').addEventListener('click', function () { self.submitReview(); });
                             document.getElementById('reviewRewatch').addEventListener('change', function () {

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.9.1.0",
+        "changelog": "Local-history duplicate backstop: refuse to MarkAsWatched when sync history shows a recent successful sync that does not pass the rewatch threshold, fixes the Cloudflare-failed-validator path that was creating real Letterboxd diary duplicates. Paginated dashboard history table (100 per page) now that the 500-entry cap is gone. Addresses #21.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.9.1/jellyfin-plugin-letterboxd-v1.9.1.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-30T00:00:00Z"
+      },
+      {
         "version": "1.9.0.0",
         "changelog": "Skip already-synced films using local sync history so we don't burn Cloudflare quota on duplicate checks; prioritise previously-failed/skipped films first; per-account stop-on-failure toggle to halt the moment Letterboxd anti-flooding triggers; explicit info-level logging for every skip with reason; non-admin users can now Run Sync Now (triggers their account only). Fixes #20.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
Addresses #21 directly:

- **Duplicate backstop.** Before `MarkAsWatchedAsync` runs, also consult our own append-only `SyncHistory` for any prior Success or Rewatch event for `(user, tmdbId)`. If one exists and the new viewing is not far enough back to count as a real rewatch (per the existing `Helpers.IsRewatch` threshold of more than one day), refuse the call and record an explicit Skipped event with reason. Catches the failure mode where Letterboxd's own validator (`GetDiaryInfoAsync`) silently returns `(null, false)` on a Cloudflare 403, which used to let `MarkAsWatched` create a second diary entry.
- **Paginated history dashboard.** `/History` now accepts `offset` alongside `count` and returns `{events, total, offset, count}`. Both userPage and configPage render a paginator (first / prev / page X of Y / next / last) at 100 entries per page. Backwards compatible with pre-1.9.1 clients that just consumed the array.

## Verified against
RSS sample of my own diary (browse skill could not reach it via Cloudflare, switched to RSS) shows:
- Hard same-date duplicate: Twinless 2025 logged 2x on 2026-03-25
- One-day-apart pairs: Avatar (04-28 + 04-29), Mercy (03-26 + 03-27), Trial of the Chicago 7 (04-24 + 04-25)

All four are caught by the backstop. Test cases in `DuplicateBackstopTests.cs` cover both patterns plus the genuine-rewatch case (Treasure Planet, 22 days apart) which still goes through.

## Caveats
- Only protects entries created from 1.9.1 onwards. Existing duplicates need manual cleanup on Letterboxd.
- Genuine same-day or next-day re-watches are now suppressed. Consistent with how `IsRewatch` already worked elsewhere in the plugin, but worth noting.

## Test plan
- [ ] Install 1.9.1 on a server with prior duplicate-creating behaviour, run a sync, watch the new `local history shows prior sync on X, suppressing potential duplicate` log lines fire instead of `MarkAsWatched` calls
- [ ] Dashboard shows pagination controls when total exceeds 100 entries, navigates correctly
- [ ] First page renders fast for users with thousands of events