### PR TITLE
feat: Jellyseerr watchlist mirror, on-demand sync button, dedup pre-check (v1.10.0)

### DIFF
--- a/LetterboxdSync.Tests/JellyseerrClientTests.cs
+++ b/LetterboxdSync.Tests/JellyseerrClientTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using LetterboxdSync;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class JellyseerrClientTests
+{
+    private const string BaseUrl = "http://jellyseerr.test";
+    private const string ApiKey = "test-key";
+
+    [Fact]
+    public async Task RequestMovieAsync_NoExistingMedia_PostsRequest()
+    {
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100}"); // no mediaInfo → safe to request
+
+            if (req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/request"))
+            {
+                posted = true;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7);
+
+        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.True(posted, "request endpoint should have been called");
+    }
+
+    [Theory]
+    [InlineData(2)] // PENDING
+    [InlineData(3)] // PROCESSING
+    [InlineData(4)] // PARTIALLY_AVAILABLE
+    [InlineData(5)] // AVAILABLE
+    [InlineData(6)] // BLOCKLISTED
+    public async Task RequestMovieAsync_AlreadyKnownStatus_DoesNotPost(int status)
+    {
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse($"{{\"id\":100,\"mediaInfo\":{{\"status\":{status}}}}}");
+
+            if (req.Method == HttpMethod.Post)
+                posted = true;
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7);
+
+        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.False(posted, "request endpoint must not be called when media is already known");
+    }
+
+    [Fact]
+    public async Task RequestMovieAsync_DeletedStatus_RequestsAgain()
+    {
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100,\"mediaInfo\":{\"status\":7}}"); // DELETED
+
+            if (req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/request"))
+            {
+                posted = true;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7);
+
+        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.True(posted);
+    }
+
+    [Fact]
+    public async Task RequestMovieAsync_PostReturns409_TreatsAsAlreadyExists()
+    {
+        // Belt-and-braces: if the status pre-check misses (e.g. 404 lookup) and Jellyseerr
+        // does return its own 409, we should still classify it as AlreadyExists so the
+        // count of "new requests" stays accurate.
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            if (req.Method == HttpMethod.Post)
+                return new HttpResponseMessage(HttpStatusCode.Conflict)
+                {
+                    Content = new StringContent("{\"message\":\"REQUEST_EXISTS\"}")
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7);
+
+        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+    }
+
+    [Fact]
+    public async Task GetUserWatchlistTmdbIdsAsync_PaginatesViaPageParamAndFiltersToMovies()
+    {
+        // Jellyseerr paginates the user-watchlist endpoint with `page=N`, NOT take/skip
+        // (which it 400s on). Drive two pages, with totalPages=2 telling us when to stop.
+        var seenPageQueries = new List<string>();
+        var handler = new SeerrHandler(req =>
+        {
+            seenPageQueries.Add(req.RequestUri!.Query);
+            var path = req.RequestUri!.AbsolutePath;
+            if (!path.EndsWith("/watchlist")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            if (req.RequestUri!.Query.Contains("page=1"))
+                return JsonResponse(
+                    "{\"page\":1,\"totalPages\":2,\"totalResults\":3,\"results\":[" +
+                    "{\"tmdbId\":1,\"mediaType\":\"movie\"}," +
+                    "{\"tmdbId\":\"2\",\"mediaType\":\"movie\"}," +
+                    "{\"tmdbId\":3,\"mediaType\":\"tv\"}" +
+                    "]}");
+            if (req.RequestUri!.Query.Contains("page=2"))
+                return JsonResponse(
+                    "{\"page\":2,\"totalPages\":2,\"totalResults\":3,\"results\":[" +
+                    "{\"tmdbId\":4,\"mediaType\":\"movie\"}" +
+                    "]}");
+            return JsonResponse("{\"page\":99,\"totalPages\":2,\"results\":[]}");
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var ids = await client.GetUserWatchlistTmdbIdsAsync(7);
+
+        Assert.Equal(new HashSet<int> { 1, 2, 4 }, ids);
+        Assert.Contains(seenPageQueries, q => q.Contains("page=1"));
+        Assert.Contains(seenPageQueries, q => q.Contains("page=2"));
+        // Crucially, no take/skip — those would 400.
+        Assert.DoesNotContain(seenPageQueries, q => q.Contains("take=") || q.Contains("skip="));
+    }
+
+    [Fact]
+    public async Task GetUserWatchlistTmdbIdsAsync_SendsXApiUserHeader()
+    {
+        // The endpoint requires acting as the user being queried — without the impersonation
+        // header, Jellyseerr returns the calling key's default user (admin), which silently
+        // returns the wrong watchlist.
+        string? sentHeader = null;
+        var handler = new SeerrHandler(req =>
+        {
+            sentHeader = req.Headers.TryGetValues("X-API-User", out var v) ? string.Join(",", v) : null;
+            return JsonResponse("{\"page\":1,\"totalPages\":1,\"totalResults\":0,\"results\":[]}");
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        await client.GetUserWatchlistTmdbIdsAsync(42);
+        Assert.Equal("42", sentHeader);
+    }
+
+    [Fact]
+    public async Task AddToWatchlistAsync_SendsXApiUserHeaderAndCorrectBody()
+    {
+        string? sentBody = null;
+        string? sentHeader = null;
+
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/watchlist"))
+            {
+                sentBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                sentHeader = req.Headers.TryGetValues("X-API-User", out var v) ? string.Join(",", v) : null;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var ok = await client.AddToWatchlistAsync(42, 9);
+
+        Assert.True(ok);
+        Assert.Equal("9", sentHeader);
+        Assert.Contains("\"tmdbId\":42", sentBody);
+        Assert.Contains("\"mediaType\":\"movie\"", sentBody);
+    }
+
+    [Fact]
+    public async Task AddToWatchlistAsync_409Conflict_IsTreatedAsSuccess()
+    {
+        var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new StringContent("{\"message\":\"already exists on watchlist\"}")
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.True(await client.AddToWatchlistAsync(42, 9));
+    }
+
+    [Fact]
+    public async Task RemoveFromWatchlistAsync_404IsSuccess()
+    {
+        var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.True(await client.RemoveFromWatchlistAsync(42, 9));
+    }
+
+    [Fact]
+    public async Task RemoveFromWatchlistAsync_SendsCorrectUrlAndHeader()
+    {
+        string? sentPath = null;
+        string? sentQuery = null;
+        string? sentHeader = null;
+
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Delete)
+            {
+                sentPath = req.RequestUri!.AbsolutePath;
+                sentQuery = req.RequestUri!.Query;
+                sentHeader = req.Headers.TryGetValues("X-API-User", out var v) ? string.Join(",", v) : null;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+            return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.True(await client.RemoveFromWatchlistAsync(42, 9));
+        Assert.Equal("/api/v1/watchlist/42", sentPath);
+        Assert.Contains("mediaType=movie", sentQuery);
+        Assert.Equal("9", sentHeader);
+    }
+
+    private static HttpResponseMessage JsonResponse(string body)
+        => new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+
+    private class SeerrHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public SeerrHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) { _handler = handler; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_handler(request));
+    }
+}

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -24,6 +24,8 @@ public class AccountUpdateRequest
 
     public bool AutoRequestWatchlist { get; set; }
 
+    public bool MirrorJellyseerrWatchlist { get; set; }
+
     public bool SkipPreviouslySynced { get; set; } = true;
 
     public bool StopOnFailure { get; set; }

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -20,12 +20,18 @@ public class LetterboxdController : ControllerBase
     private readonly ILogger<LetterboxdController> _logger;
     private readonly IUserManager _userManager;
     private readonly LetterboxdSyncRunner _syncRunner;
+    private readonly WatchlistSyncRunner _watchlistRunner;
 
-    public LetterboxdController(ILogger<LetterboxdController> logger, IUserManager userManager, LetterboxdSyncRunner syncRunner)
+    public LetterboxdController(
+        ILogger<LetterboxdController> logger,
+        IUserManager userManager,
+        LetterboxdSyncRunner syncRunner,
+        WatchlistSyncRunner watchlistRunner)
     {
         _logger = logger;
         _userManager = userManager;
         _syncRunner = syncRunner;
+        _watchlistRunner = watchlistRunner;
     }
 
     private static PluginConfiguration Config => Plugin.Instance!.Configuration;
@@ -90,6 +96,47 @@ public class LetterboxdController : ControllerBase
         return Accepted(new { started = true });
     }
 
+    /// <summary>
+    /// Trigger a Letterboxd → Jellyfin playlist (and optional Jellyseerr) watchlist sync
+    /// for the calling user. Same shape as <see cref="StartSync"/>: 202 immediately,
+    /// 409 if any sync is in flight, 400 if the user has no watchlist-enabled account.
+    /// </summary>
+    [HttpPost("SyncWatchlist")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public ActionResult StartWatchlistSync()
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        if (LetterboxdSyncRunner.IsRunning)
+            return Conflict(new { error = "Sync already running" });
+
+        var account = Config.Accounts.FirstOrDefault(a => a.Enabled && a.UserJellyfinId == userId);
+        if (account == null)
+            return BadRequest(new { error = "No enabled Letterboxd account is configured for your user" });
+
+        if (!account.EnableWatchlistSync)
+            return BadRequest(new { error = "Watchlist sync is disabled for your account; enable it in Settings first" });
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _watchlistRunner.TryRunForUserAsync(userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "User-triggered watchlist sync for {UserId} crashed", userId);
+            }
+        });
+
+        return Accepted(new { started = true });
+    }
+
     [HttpGet("Stats")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult GetStats()
@@ -147,6 +194,7 @@ public class LetterboxdController : ControllerBase
                 enableWatchlistSync = false,
                 enableDiaryImport = false,
                 autoRequestWatchlist = false,
+                mirrorJellyseerrWatchlist = false,
                 skipPreviouslySynced = true,
                 stopOnFailure = false,
                 isConfigured = false
@@ -166,6 +214,7 @@ public class LetterboxdController : ControllerBase
             enableWatchlistSync = account.EnableWatchlistSync,
             enableDiaryImport = account.EnableDiaryImport,
             autoRequestWatchlist = account.AutoRequestWatchlist,
+            mirrorJellyseerrWatchlist = account.MirrorJellyseerrWatchlist,
             skipPreviouslySynced = account.SkipPreviouslySynced,
             stopOnFailure = account.StopOnFailure,
             isConfigured = true
@@ -199,6 +248,7 @@ public class LetterboxdController : ControllerBase
         account.EnableWatchlistSync = request.EnableWatchlistSync;
         account.EnableDiaryImport = request.EnableDiaryImport;
         account.AutoRequestWatchlist = request.AutoRequestWatchlist;
+        account.MirrorJellyseerrWatchlist = request.MirrorJellyseerrWatchlist;
         account.SkipPreviouslySynced = request.SkipPreviouslySynced;
         account.StopOnFailure = request.StopOnFailure;
 

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -28,6 +28,8 @@ public class Account
 
     public bool AutoRequestWatchlist { get; set; }
 
+    public bool MirrorJellyseerrWatchlist { get; set; }
+
     public bool SkipPreviouslySynced { get; set; } = true;
 
     public bool StopOnFailure { get; set; }

--- a/LetterboxdSync/JellyseerrClient.cs
+++ b/LetterboxdSync/JellyseerrClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -11,7 +12,7 @@ namespace LetterboxdSync;
 
 /// <summary>
 /// Lightweight Jellyseerr client for fetching the Jellyfin-user-to-Jellyseerr-user
-/// mapping and creating per-user movie requests by TMDb ID.
+/// mapping, creating per-user movie requests, and mirroring a user's watchlist.
 /// </summary>
 public class JellyseerrClient : IDisposable
 {
@@ -86,21 +87,85 @@ public class JellyseerrClient : IDisposable
     }
 
     /// <summary>
-    /// Creates a movie request in Jellyseerr for the given TMDb ID, attributed to the given Jellyseerr user.
-    /// Returns true on success or "already requested"; false on transient error.
+    /// Looks up the current MediaStatus for a TMDb movie in Jellyseerr.
+    /// Returns null when Jellyseerr has no record of the title (so it's safe to request),
+    /// or when the call fails (caller should fall through to attempting the request and
+    /// let Jellyseerr surface the real error). Status values follow Jellyseerr's enum:
+    /// 1=UNKNOWN, 2=PENDING, 3=PROCESSING, 4=PARTIALLY_AVAILABLE, 5=AVAILABLE,
+    /// 6=BLOCKLISTED, 7=DELETED.
     /// </summary>
-    public async Task<bool> RequestMovieAsync(int tmdbId, int jellyseerrUserId)
+    public async Task<int?> GetMovieMediaStatusAsync(int tmdbId)
     {
+        var url = $"{_baseUrl}/api/v1/movie/{tmdbId}";
+        try
+        {
+            using var response = await _http.GetAsync(url).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Jellyseerr movie lookup non-success for TMDb {TmdbId}: {Status}",
+                    tmdbId, (int)response.StatusCode);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("mediaInfo", out var mediaInfo) ||
+                mediaInfo.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (!mediaInfo.TryGetProperty("status", out var statusEl) ||
+                statusEl.ValueKind != JsonValueKind.Number)
+                return null;
+
+            return statusEl.GetInt32();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("Jellyseerr movie lookup errored for TMDb {TmdbId}: {Message}",
+                tmdbId, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Outcome of a request attempt. <see cref="AlreadyExists"/> means Jellyseerr already
+    /// had the title in some non-UNKNOWN state (pending, processing, available, blocklisted)
+    /// and we did NOT POST a new request; it should not be counted as a fresh request.
+    /// </summary>
+    public enum RequestResult
+    {
+        Requested,
+        AlreadyExists,
+        Failed
+    }
+
+    /// <summary>
+    /// Creates a movie request in Jellyseerr for the given TMDb ID, attributed to the given Jellyseerr user.
+    /// Pre-checks the media status and skips the POST when Jellyseerr already has a record of the title;
+    /// without this guard Jellyseerr cheerfully creates a duplicate request every run for items already
+    /// pending / processing / available, instead of returning 409.
+    /// </summary>
+    public async Task<RequestResult> RequestMovieAsync(int tmdbId, int jellyseerrUserId)
+    {
+        var existingStatus = await GetMovieMediaStatusAsync(tmdbId).ConfigureAwait(false);
+        // Re-request DELETED (7); skip everything else above UNKNOWN (1).
+        if (existingStatus.HasValue && existingStatus.Value > 1 && existingStatus.Value != 7)
+        {
+            _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: already has status {Status}",
+                tmdbId, existingStatus.Value);
+            return RequestResult.AlreadyExists;
+        }
+
         var url = $"{_baseUrl}/api/v1/request";
         var body = $"{{\"mediaType\":\"movie\",\"mediaId\":{tmdbId},\"userId\":{jellyseerrUserId}}}";
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
 
         using var response = await _http.PostAsync(url, content).ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
-            return true;
+            return RequestResult.Requested;
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        // Jellyseerr returns 409 when already requested; treat as a success (no-op).
+        // Belt-and-braces: Jellyseerr returns 409 when already requested; treat as a no-op.
         if ((int)response.StatusCode == 409 ||
             responseBody.Contains("REQUEST_EXISTS", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already requested", StringComparison.OrdinalIgnoreCase) ||
@@ -108,10 +173,131 @@ public class JellyseerrClient : IDisposable
         {
             _logger.LogDebug("Jellyseerr already has request for TMDb {TmdbId} (user {UserId}): {Body}",
                 tmdbId, jellyseerrUserId, Truncate(responseBody, 200));
-            return true;
+            return RequestResult.AlreadyExists;
         }
 
         _logger.LogWarning("Jellyseerr request failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+            tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
+        return RequestResult.Failed;
+    }
+
+    /// <summary>
+    /// Returns the set of TMDb IDs of <paramref name="mediaType"/> currently on the given Jellyseerr
+    /// user's watchlist. Pages through results until exhausted. Returns an empty set on failure
+    /// (caller should treat that as "unknown" and avoid destructive removals).
+    /// </summary>
+    public async Task<HashSet<int>> GetUserWatchlistTmdbIdsAsync(int jellyseerrUserId, string mediaType = "movie")
+    {
+        var ids = new HashSet<int>();
+        var page = 1;
+        var totalPages = 1; // Updated from the first response.
+
+        while (page <= totalPages)
+        {
+            // Jellyseerr's user/:id/watchlist endpoint paginates with `page=N`. It rejects
+            // unknown params with a 400, so do NOT pass take/skip here.
+            var url = $"{_baseUrl}/api/v1/user/{jellyseerrUserId}/watchlist?page={page}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("X-API-User",
+                jellyseerrUserId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            using var response = await _http.SendAsync(request).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                _logger.LogWarning("Jellyseerr watchlist fetch failed for user {UserId}: {Status} {Body}",
+                    jellyseerrUserId, (int)response.StatusCode, Truncate(errBody, 300));
+                return ids;
+            }
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+
+            if (doc.RootElement.TryGetProperty("totalPages", out var tp) && tp.ValueKind == JsonValueKind.Number)
+                totalPages = tp.GetInt32();
+
+            if (!doc.RootElement.TryGetProperty("results", out var results) || results.ValueKind != JsonValueKind.Array)
+                break;
+
+            var count = results.GetArrayLength();
+            if (count == 0) break;
+
+            foreach (var item in results.EnumerateArray())
+            {
+                if (item.TryGetProperty("mediaType", out var mt) && mt.ValueKind == JsonValueKind.String)
+                {
+                    if (!string.Equals(mt.GetString(), mediaType, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                }
+
+                // tmdbId can come back as either a number (DB shape) or a string (Plex shape).
+                if (!item.TryGetProperty("tmdbId", out var idEl)) continue;
+                int parsed;
+                if (idEl.ValueKind == JsonValueKind.Number)
+                {
+                    parsed = idEl.GetInt32();
+                }
+                else if (idEl.ValueKind == JsonValueKind.String && int.TryParse(idEl.GetString(), out var s))
+                {
+                    parsed = s;
+                }
+                else
+                {
+                    continue;
+                }
+
+                ids.Add(parsed);
+            }
+
+            page++;
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Adds a TMDb title to the given Jellyseerr user's watchlist. Acts as that user via
+    /// the X-API-User header so the entry is owned by them, not the API key's default admin.
+    /// Returns true on success or "already there"; false on transient error.
+    /// </summary>
+    public async Task<bool> AddToWatchlistAsync(int tmdbId, int jellyseerrUserId, string mediaType = "movie")
+    {
+        var url = $"{_baseUrl}/api/v1/watchlist";
+        var body = $"{{\"tmdbId\":{tmdbId},\"mediaType\":\"{mediaType}\"}}";
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+        request.Headers.TryAddWithoutValidation("X-API-User", jellyseerrUserId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        using var response = await _http.SendAsync(request).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+            return true;
+
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if ((int)response.StatusCode == 409 ||
+            responseBody.Contains("already exists", StringComparison.OrdinalIgnoreCase) ||
+            responseBody.Contains("already on", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        _logger.LogWarning("Jellyseerr watchlist add failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+            tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
+        return false;
+    }
+
+    /// <summary>
+    /// Removes a TMDb title from the given Jellyseerr user's watchlist. Acts as that user
+    /// via the X-API-User header. 404 is treated as success (the entry was already gone).
+    /// </summary>
+    public async Task<bool> RemoveFromWatchlistAsync(int tmdbId, int jellyseerrUserId, string mediaType = "movie")
+    {
+        var url = $"{_baseUrl}/api/v1/watchlist/{tmdbId}?mediaType={mediaType}";
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.TryAddWithoutValidation("X-API-User", jellyseerrUserId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        using var response = await _http.SendAsync(request).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
+            return true;
+
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        _logger.LogWarning("Jellyseerr watchlist remove failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
             tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
         return false;
     }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.9.1.0</AssemblyVersion>
-    <FileVersion>1.9.1.0</FileVersion>
+    <AssemblyVersion>1.10.0.0</AssemblyVersion>
+    <FileVersion>1.10.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -27,8 +27,6 @@ public class LetterboxdSyncRunner
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataManager;
 
-    private static readonly SemaphoreSlim _gate = new(1, 1);
-
     public LetterboxdSyncRunner(
         ILoggerFactory loggerFactory,
         ILibraryManager libraryManager,
@@ -42,13 +40,13 @@ public class LetterboxdSyncRunner
         _userDataManager = userDataManager;
     }
 
-    public static bool IsRunning => _gate.CurrentCount == 0;
+    public static bool IsRunning => SyncGate.IsRunning;
 
     private static PluginConfiguration Config => Plugin.Instance!.Configuration;
 
     public async Task RunForAllAsync(IProgress<double> progress, string source, CancellationToken cancellationToken)
     {
-        if (!await _gate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("Sync already running, skipping scheduled run");
             return;
@@ -77,7 +75,7 @@ public class LetterboxdSyncRunner
         }
         finally
         {
-            _gate.Release();
+            SyncGate.Instance.Release();
         }
     }
 
@@ -87,7 +85,7 @@ public class LetterboxdSyncRunner
     /// </summary>
     public async Task<bool> TryRunForUserAsync(string userJellyfinId, string source, IProgress<double> progress, CancellationToken cancellationToken)
     {
-        if (!await _gate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("Sync already running, refusing user-triggered start for {UserId}", userJellyfinId);
             return false;
@@ -116,7 +114,7 @@ public class LetterboxdSyncRunner
         }
         finally
         {
-            _gate.Release();
+            SyncGate.Instance.Release();
         }
     }
 

--- a/LetterboxdSync/ServiceRegistrator.cs
+++ b/LetterboxdSync/ServiceRegistrator.cs
@@ -9,6 +9,7 @@ public class ServiceRegistrator : IPluginServiceRegistrator
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
         serviceCollection.AddSingleton<LetterboxdSyncRunner>();
+        serviceCollection.AddSingleton<WatchlistSyncRunner>();
         serviceCollection.AddHostedService<PlaybackHandler>();
     }
 }

--- a/LetterboxdSync/SyncGate.cs
+++ b/LetterboxdSync/SyncGate.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Single global semaphore shared by every code path that scrapes Letterboxd: the diary
+/// runner, the watchlist runner, and any future on-demand task. Sharing it ensures we
+/// never run two scrapes concurrently against the same Cloudflare-protected origin and
+/// that <see cref="SyncProgress"/> (also a singleton) is only ever driven by one caller.
+/// </summary>
+internal static class SyncGate
+{
+    public static readonly SemaphoreSlim Instance = new(1, 1);
+
+    public static bool IsRunning => Instance.CurrentCount == 0;
+}

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using LetterboxdSync.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Playlists;
+using Microsoft.Extensions.Logging;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Performs the Letterboxd-watchlist → Jellyfin-playlist → Jellyseerr chain. Used by both
+/// the scheduled <see cref="WatchlistSyncTask"/> and the user-triggered API endpoint, gated
+/// behind <see cref="SyncGate"/> so it serialises with the diary sync.
+/// </summary>
+public class WatchlistSyncRunner
+{
+    private readonly ILogger<WatchlistSyncRunner> _logger;
+    private readonly ILibraryManager _libraryManager;
+    private readonly IUserManager _userManager;
+    private readonly IPlaylistManager _playlistManager;
+
+    public WatchlistSyncRunner(
+        ILoggerFactory loggerFactory,
+        ILibraryManager libraryManager,
+        IUserManager userManager,
+        IPlaylistManager playlistManager)
+    {
+        _logger = loggerFactory.CreateLogger<WatchlistSyncRunner>();
+        _libraryManager = libraryManager;
+        _userManager = userManager;
+        _playlistManager = playlistManager;
+    }
+
+    private static PluginConfiguration Config => Plugin.Instance!.Configuration;
+
+    public async Task RunForAllAsync(IProgress<double> progress, string source, CancellationToken cancellationToken)
+    {
+        if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Another sync is already running, skipping scheduled watchlist run");
+            return;
+        }
+
+        try
+        {
+            using var jellyseerr = CreateJellyseerrClient();
+
+            var users = _userManager.Users.ToList();
+            var processed = 0;
+            SyncProgress.Start("Letterboxd Watchlist", "Starting");
+
+            foreach (var user in users)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var account = Config.Accounts.FirstOrDefault(
+                    a => a.Enabled && a.EnableWatchlistSync && a.UserJellyfinId == user.Id.ToString("N"));
+                if (account == null) continue;
+
+                await SyncOneUserAsync(user, account, jellyseerr, source, cancellationToken).ConfigureAwait(false);
+
+                processed++;
+                progress.Report((double)processed / users.Count * 100);
+            }
+
+            progress.Report(100);
+            SyncProgress.Complete();
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    /// <summary>
+    /// Run watchlist sync for a single user. Returns false if another sync is already
+    /// running, the user is unknown, or they have no enabled-with-watchlist account.
+    /// </summary>
+    public async Task<bool> TryRunForUserAsync(string userJellyfinId, string source, IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Another sync is already running, refusing user-triggered watchlist start for {UserId}", userJellyfinId);
+            return false;
+        }
+
+        try
+        {
+            var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
+            if (user == null)
+            {
+                _logger.LogWarning("User {UserId} not found, cannot start watchlist sync", userJellyfinId);
+                return false;
+            }
+
+            var account = Config.Accounts.FirstOrDefault(
+                a => a.Enabled && a.EnableWatchlistSync && a.UserJellyfinId == userJellyfinId);
+            if (account == null)
+            {
+                _logger.LogWarning("No enabled watchlist-sync account for {Username}", user.Username);
+                return false;
+            }
+
+            using var jellyseerr = CreateJellyseerrClient();
+            SyncProgress.Start("Letterboxd Watchlist", "Starting");
+            await SyncOneUserAsync(user, account, jellyseerr, source, cancellationToken).ConfigureAwait(false);
+            progress.Report(100);
+            SyncProgress.Complete();
+            return true;
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    private JellyseerrClient? CreateJellyseerrClient()
+        => JellyseerrClient.IsConfigured(Config.JellyseerrUrl, Config.JellyseerrApiKey)
+            ? new JellyseerrClient(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger)
+            : null;
+
+    private async Task SyncOneUserAsync(User user, Account account, JellyseerrClient? jellyseerr, string source, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting watchlist sync for {Username} (source={Source})", user.Username, source);
+        SyncProgress.SetPhase($"Authenticating {user.Username}");
+
+        ILetterboxdService service;
+        try
+        {
+            service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
+            return;
+        }
+
+        using var _s = service;
+
+        SyncProgress.SetPhase($"Fetching watchlist for {user.Username}");
+        List<int> tmdbIds;
+        try
+        {
+            tmdbIds = await service.GetWatchlistTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
+            _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd watchlist",
+                tmdbIds.Count, account.LetterboxdUsername);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Failed to fetch watchlist for {Username}: {Message}", user.Username, ex.Message);
+            return;
+        }
+
+        SyncProgress.SetPhase($"Updating Jellyfin playlist for {user.Username}");
+        var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Movie },
+            IsVirtualItem = false,
+            Recursive = true
+        });
+
+        var watchlistItemIds = new HashSet<Guid>();
+        var matchedTmdbIds = new HashSet<int>();
+        foreach (var tmdbId in tmdbIds)
+        {
+            var match = allMovies.FirstOrDefault(m =>
+                m.GetProviderId(MetadataProvider.Tmdb) == tmdbId.ToString());
+
+            if (match != null)
+            {
+                watchlistItemIds.Add(match.Id);
+                matchedTmdbIds.Add(tmdbId);
+            }
+        }
+
+        _logger.LogInformation("Matched {Matched}/{Total} watchlist films to Jellyfin library",
+            watchlistItemIds.Count, tmdbIds.Count);
+
+        await UpdatePlaylistAsync(user, watchlistItemIds, tmdbIds.Count).ConfigureAwait(false);
+
+        // Jellyseerr integration: auto-request unmatched films and/or mirror the
+        // Letterboxd watchlist into the user's Jellyseerr watchlist.
+        var jellyseerrWanted = jellyseerr != null && (account.AutoRequestWatchlist || account.MirrorJellyseerrWatchlist);
+        if (!jellyseerrWanted) return;
+
+        int? jellyseerrUserId;
+        try
+        {
+            jellyseerrUserId = await jellyseerr!.GetJellyseerrUserIdAsync(account.UserJellyfinId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not fetch Jellyseerr user map for {Username}: {Message}",
+                user.Username, ex.Message);
+            return;
+        }
+
+        if (jellyseerrUserId == null)
+        {
+            _logger.LogWarning("No Jellyseerr user linked to Jellyfin user {Username}; skipping Jellyseerr sync",
+                user.Username);
+            return;
+        }
+
+        if (account.MirrorJellyseerrWatchlist)
+        {
+            SyncProgress.SetPhase($"Mirroring Jellyseerr watchlist for {user.Username}");
+            await MirrorJellyseerrWatchlistAsync(jellyseerr!, jellyseerrUserId.Value, tmdbIds, user.Username!, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (account.AutoRequestWatchlist)
+        {
+            SyncProgress.SetPhase($"Requesting missing films via Jellyseerr for {user.Username}");
+            var unmatchedTmdbIds = tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
+            if (unmatchedTmdbIds.Count == 0) return;
+
+            var requested = 0;
+            var alreadyExists = 0;
+            var failed = 0;
+            foreach (var tmdbId in unmatchedTmdbIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    var result = await jellyseerr!.RequestMovieAsync(tmdbId, jellyseerrUserId.Value).ConfigureAwait(false);
+                    switch (result)
+                    {
+                        case JellyseerrClient.RequestResult.Requested: requested++; break;
+                        case JellyseerrClient.RequestResult.AlreadyExists: alreadyExists++; break;
+                        default: failed++; break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Jellyseerr request errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                    failed++;
+                }
+            }
+            _logger.LogInformation(
+                "Jellyseerr auto-request for {Username}: {Requested} new, {Existing} already on Jellyseerr, {Failed} failed of {Total} unmatched",
+                user.Username, requested, alreadyExists, failed, unmatchedTmdbIds.Count);
+        }
+    }
+
+    private async Task UpdatePlaylistAsync(User user, HashSet<Guid> watchlistItemIds, int letterboxdCount)
+    {
+        const string playlistName = "Letterboxd Watchlist";
+
+        var existingPlaylists = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Playlist },
+            Recursive = true
+        });
+
+        var playlist = existingPlaylists.FirstOrDefault(p => p.Name == playlistName);
+
+        if (playlist == null)
+        {
+            if (watchlistItemIds.Count == 0) return;
+
+            await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
+            {
+                Name = playlistName,
+                UserId = user.Id,
+                MediaType = MediaType.Video,
+                ItemIdList = watchlistItemIds.ToArray()
+            }).ConfigureAwait(false);
+
+            _logger.LogInformation("Created playlist '{Name}' with {Count} films for {Username}",
+                playlistName, watchlistItemIds.Count, user.Username);
+            return;
+        }
+
+        // Source of truth: Playlist.LinkedChildren contains the wrapped media item IDs
+        // (the underlying Movie GUIDs). Querying ParentId returns playlist *entries* whose
+        // BaseItem.Id is the entry GUID, not the movie GUID — using that for dedup compared
+        // entry IDs against movie IDs and never matched, causing duplicates each run.
+        var playlistObj = (Playlist)playlist;
+        var existingIds = playlistObj.LinkedChildren
+            .Where(lc => lc.ItemId.HasValue)
+            .Select(lc => lc.ItemId!.Value)
+            .ToHashSet();
+
+        var newItems = watchlistItemIds.Where(id => !existingIds.Contains(id)).ToArray();
+        if (newItems.Length > 0)
+        {
+            await _playlistManager.AddItemToPlaylistAsync(playlist.Id, newItems, user.Id).ConfigureAwait(false);
+            _logger.LogInformation("Added {Count} new films to playlist '{Name}' for {Username}",
+                newItems.Length, playlistName, user.Username);
+        }
+
+        // Empty Letterboxd scrape probably means Cloudflare blocked us, not that the
+        // user wiped their watchlist; skip removal so we don't gut the playlist.
+        var removedIds = (letterboxdCount == 0 && existingIds.Count > 0)
+            ? Array.Empty<string>()
+            : existingIds
+                .Where(id => !watchlistItemIds.Contains(id))
+                .Select(id => id.ToString("N"))
+                .ToArray();
+
+        if (removedIds.Length > 0)
+        {
+            await _playlistManager.RemoveItemFromPlaylistAsync(playlist.Id.ToString("N"), removedIds).ConfigureAwait(false);
+            _logger.LogInformation("Removed {Count} films from playlist '{Name}' for {Username}",
+                removedIds.Length, playlistName, user.Username);
+        }
+
+        if (newItems.Length == 0 && removedIds.Length == 0)
+        {
+            _logger.LogInformation("Playlist '{Name}' already up to date for {Username}",
+                playlistName, user.Username);
+        }
+    }
+
+    private async Task MirrorJellyseerrWatchlistAsync(
+        JellyseerrClient jellyseerr,
+        int jellyseerrUserId,
+        List<int> letterboxdTmdbIds,
+        string jellyfinUsername,
+        CancellationToken cancellationToken)
+    {
+        if (letterboxdTmdbIds.Count == 0)
+        {
+            _logger.LogWarning(
+                "Empty Letterboxd watchlist for {Username}; skipping Jellyseerr mirror to avoid mass-deletion",
+                jellyfinUsername);
+            return;
+        }
+
+        HashSet<int> currentSeerr;
+        try
+        {
+            currentSeerr = await jellyseerr.GetUserWatchlistTmdbIdsAsync(jellyseerrUserId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Failed to fetch Jellyseerr watchlist for {Username}: {Message}",
+                jellyfinUsername, ex.Message);
+            return;
+        }
+
+        var letterboxdSet = new HashSet<int>(letterboxdTmdbIds);
+        var toAdd = letterboxdSet.Where(id => !currentSeerr.Contains(id)).ToList();
+        var toRemove = currentSeerr.Where(id => !letterboxdSet.Contains(id)).ToList();
+
+        var added = 0;
+        var addFailed = 0;
+        foreach (var tmdbId in toAdd)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (await jellyseerr.AddToWatchlistAsync(tmdbId, jellyseerrUserId).ConfigureAwait(false))
+                    added++;
+                else
+                    addFailed++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Jellyseerr watchlist add errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                addFailed++;
+            }
+        }
+
+        var removed = 0;
+        var removeFailed = 0;
+        foreach (var tmdbId in toRemove)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (await jellyseerr.RemoveFromWatchlistAsync(tmdbId, jellyseerrUserId).ConfigureAwait(false))
+                    removed++;
+                else
+                    removeFailed++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Jellyseerr watchlist remove errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                removeFailed++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Jellyseerr watchlist mirror for {Username}: +{Added} -{Removed} (add failures {AddFailed}, remove failures {RemoveFailed})",
+            jellyfinUsername, added, removed, addFailed, removeFailed);
+    }
+}

--- a/LetterboxdSync/WatchlistSyncTask.cs
+++ b/LetterboxdSync/WatchlistSyncTask.cs
@@ -1,252 +1,27 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Data.Enums;
-using LetterboxdSync.Configuration;
-using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Playlists;
-using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Playlists;
 using MediaBrowser.Model.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace LetterboxdSync;
 
 public class WatchlistSyncTask : IScheduledTask
 {
-    private readonly ILogger<WatchlistSyncTask> _logger;
-    private readonly ILibraryManager _libraryManager;
-    private readonly IUserManager _userManager;
-    private readonly IPlaylistManager _playlistManager;
+    private readonly WatchlistSyncRunner _runner;
 
-    public WatchlistSyncTask(
-        IUserManager userManager,
-        ILoggerFactory loggerFactory,
-        ILibraryManager libraryManager,
-        IPlaylistManager playlistManager)
+    public WatchlistSyncTask(WatchlistSyncRunner runner)
     {
-        _logger = loggerFactory.CreateLogger<WatchlistSyncTask>();
-        _userManager = userManager;
-        _libraryManager = libraryManager;
-        _playlistManager = playlistManager;
+        _runner = runner;
     }
-
-    private static PluginConfiguration Config => Plugin.Instance!.Configuration;
 
     public string Name => "Sync Letterboxd watchlist to playlist";
     public string Key => "LetterboxdWatchlistSync";
     public string Description => "Creates a Jellyfin playlist from your Letterboxd watchlist";
     public string Category => "Letterboxd";
 
-    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
-    {
-        var users = _userManager.Users.ToList();
-
-        JellyseerrClient? jellyseerr = null;
-        if (JellyseerrClient.IsConfigured(Config.JellyseerrUrl, Config.JellyseerrApiKey))
-        {
-            jellyseerr = new JellyseerrClient(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger);
-        }
-
-        foreach (var user in users)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.EnableWatchlistSync && a.UserJellyfinId == user.Id.ToString("N"));
-
-            if (account == null)
-                continue;
-
-            _logger.LogInformation("Starting watchlist sync for {Username}", user.Username);
-
-            ILetterboxdService service;
-            try
-            {
-                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
-                continue;
-            }
-
-            using var _s = service;
-
-            List<int> tmdbIds;
-            try
-            {
-                tmdbIds = await service.GetWatchlistTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
-                _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd watchlist",
-                    tmdbIds.Count, account.LetterboxdUsername);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Failed to fetch watchlist for {Username}: {Message}", user.Username, ex.Message);
-                continue;
-            }
-
-            // Find matching movies in Jellyfin library
-            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Movie },
-                IsVirtualItem = false,
-                Recursive = true
-            });
-
-            var watchlistItemIds = new HashSet<Guid>();
-            foreach (var tmdbId in tmdbIds)
-            {
-                var match = allMovies.FirstOrDefault(m =>
-                    m.GetProviderId(MetadataProvider.Tmdb) == tmdbId.ToString());
-
-                if (match != null)
-                    watchlistItemIds.Add(match.Id);
-            }
-
-            _logger.LogInformation("Matched {Matched}/{Total} watchlist films to Jellyfin library",
-                watchlistItemIds.Count, tmdbIds.Count);
-
-            // Find or create the playlist
-            var playlistName = "Letterboxd Watchlist";
-            var existingPlaylists = _libraryManager.GetItemList(new InternalItemsQuery(user)
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Playlist },
-                Recursive = true
-            });
-
-            var playlist = existingPlaylists.FirstOrDefault(p => p.Name == playlistName);
-
-            if (playlist == null)
-            {
-                if (watchlistItemIds.Count == 0)
-                    continue;
-
-                await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
-                {
-                    Name = playlistName,
-                    UserId = user.Id,
-                    MediaType = MediaType.Video,
-                    ItemIdList = watchlistItemIds.ToArray()
-                }).ConfigureAwait(false);
-
-                _logger.LogInformation("Created playlist '{Name}' with {Count} films for {Username}",
-                    playlistName, watchlistItemIds.Count, user.Username);
-            }
-            else
-            {
-                // Source of truth: Playlist.LinkedChildren contains the wrapped media item IDs
-                // (the underlying Movie GUIDs). Querying ParentId returns playlist *entries* whose
-                // BaseItem.Id is the entry GUID, not the movie GUID — using that for dedup compared
-                // entry IDs against movie IDs and never matched, causing duplicates each run.
-                var playlistObj = (Playlist)playlist;
-                var existingIds = playlistObj.LinkedChildren
-                    .Where(lc => lc.ItemId.HasValue)
-                    .Select(lc => lc.ItemId!.Value)
-                    .ToHashSet();
-
-                var newItems = watchlistItemIds.Where(id => !existingIds.Contains(id)).ToArray();
-                if (newItems.Length > 0)
-                {
-                    await _playlistManager.AddItemToPlaylistAsync(playlist.Id, newItems, user.Id)
-                        .ConfigureAwait(false);
-                    _logger.LogInformation("Added {Count} new films to playlist '{Name}' for {Username}",
-                        newItems.Length, playlistName, user.Username);
-                }
-
-                // Remove items no longer on watchlist.
-                // Guard: if the scrape returned zero results but the playlist has items,
-                // skip removal — an empty scrape result likely means Cloudflare blocked us,
-                // not that the user cleared their entire watchlist.
-                var removedIds = (tmdbIds.Count == 0 && existingIds.Count > 0)
-                    ? Array.Empty<string>()
-                    : existingIds
-                        .Where(id => !watchlistItemIds.Contains(id))
-                        .Select(id => id.ToString("N"))
-                        .ToArray();
-
-                if (removedIds.Length > 0)
-                {
-                    await _playlistManager.RemoveItemFromPlaylistAsync(playlist.Id.ToString("N"), removedIds)
-                        .ConfigureAwait(false);
-                    _logger.LogInformation("Removed {Count} films from playlist '{Name}' for {Username}",
-                        removedIds.Length, playlistName, user.Username);
-                }
-
-                if (newItems.Length == 0 && removedIds.Length == 0)
-                {
-                    _logger.LogInformation("Playlist '{Name}' already up to date for {Username}",
-                        playlistName, user.Username);
-                }
-            }
-
-            // Auto-request unmatched watchlist films via Jellyseerr.
-            if (account.AutoRequestWatchlist && jellyseerr != null)
-            {
-                var matchedTmdbIds = new HashSet<int>();
-                foreach (var tmdbId in tmdbIds)
-                {
-                    var match = allMovies.FirstOrDefault(m =>
-                        m.GetProviderId(MetadataProvider.Tmdb) == tmdbId.ToString());
-                    if (match != null) matchedTmdbIds.Add(tmdbId);
-                }
-                var unmatchedTmdbIds = tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
-
-                if (unmatchedTmdbIds.Count > 0)
-                {
-                    int? jellyseerrUserId;
-                    try
-                    {
-                        jellyseerrUserId = await jellyseerr.GetJellyseerrUserIdAsync(account.UserJellyfinId).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning("Could not fetch Jellyseerr user map for {Username}: {Message}",
-                            user.Username, ex.Message);
-                        jellyseerrUserId = null;
-                    }
-
-                    if (jellyseerrUserId == null)
-                    {
-                        _logger.LogWarning("No Jellyseerr user linked to Jellyfin user {Username}; skipping auto-request",
-                            user.Username);
-                    }
-                    else
-                    {
-                        var requested = 0;
-                        var failed = 0;
-                        foreach (var tmdbId in unmatchedTmdbIds)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            try
-                            {
-                                if (await jellyseerr.RequestMovieAsync(tmdbId, jellyseerrUserId.Value).ConfigureAwait(false))
-                                    requested++;
-                                else
-                                    failed++;
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogWarning("Jellyseerr request errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
-                                failed++;
-                            }
-                        }
-                        _logger.LogInformation("Jellyseerr auto-request for {Username}: {Requested} requested, {Failed} failed of {Total} unmatched",
-                            user.Username, requested, failed, unmatchedTmdbIds.Count);
-                    }
-                }
-            }
-        }
-
-        jellyseerr?.Dispose();
-
-        progress.Report(100);
-    }
+    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        => _runner.RunForAllAsync(progress, "scheduled", cancellationToken);
 
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => new[]
     {

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -74,8 +74,9 @@
 
                 <!-- DASHBOARD TAB -->
                 <div id="tab-stats" class="lb-tab-content">
-                    <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;">
+                    <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;flex-wrap:wrap;">
                         <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Jellyseerr if configured)">Sync Watchlist Now</button>
                         <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
                     </div>
                     <div id="syncProgressBar" style="display:none;margin-bottom:1.5em;">
@@ -242,7 +243,11 @@
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
-                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Jellyseerr (configure URL + API key above). Requests are attributed to this user\'s Jellyseerr account (matched by Jellyfin User ID). Requires Jellyseerr to be configured.</span>'
+                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Jellyseerr (configure URL + API key above). Requests are attributed to this user\'s Jellyseerr account (matched by Jellyfin User ID). Requires Jellyseerr to be configured. Skips titles Jellyseerr already has pending, processing, or available, so re-runs no longer create duplicates.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="mirrorJellyseerrWatchlist" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Jellyseerr watchlist</span>'
+                                + '<span class="lb-check-desc">Two-way mirror against your Jellyseerr user\'s own watchlist (the one shown in the Jellyseerr UI). Adds films you\'ve added on Letterboxd, removes films you\'ve taken off. Only touches movies, so manually-added Jellyseerr TV entries are left alone. Requires Jellyseerr to be configured.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
@@ -279,6 +284,7 @@
                                 entry.querySelector('.dateFilterDays').value = account.DateFilterDays || 7;
                                 entry.querySelector('.enableWatchlistSync').checked = account.EnableWatchlistSync === true;
                                 entry.querySelector('.autoRequestWatchlist').checked = account.AutoRequestWatchlist === true;
+                                entry.querySelector('.mirrorJellyseerrWatchlist').checked = account.MirrorJellyseerrWatchlist === true;
                                 entry.querySelector('.enableDiaryImport').checked = account.EnableDiaryImport === true;
                                 entry.querySelector('.skipPreviouslySynced').checked = account.SkipPreviouslySynced !== false;
                                 entry.querySelector('.stopOnFailure').checked = account.StopOnFailure === true;
@@ -308,6 +314,7 @@
                                     DateFilterDays: parseInt(entry.querySelector('.dateFilterDays').value, 10) || 7,
                                     EnableWatchlistSync: entry.querySelector('.enableWatchlistSync').checked,
                                     AutoRequestWatchlist: entry.querySelector('.autoRequestWatchlist').checked,
+                                    MirrorJellyseerrWatchlist: entry.querySelector('.mirrorJellyseerrWatchlist').checked,
                                     EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked,
                                     SkipPreviouslySynced: entry.querySelector('.skipPreviouslySynced').checked,
                                     StopOnFailure: entry.querySelector('.stopOnFailure').checked
@@ -454,15 +461,23 @@
                             this.loadHistory(false);
                         },
 
+                        setSyncButtons: function (disabled) {
+                            document.getElementById('runSyncBtn').disabled = disabled;
+                            var wl = document.getElementById('runWatchlistSyncBtn');
+                            if (wl) wl.disabled = disabled;
+                        },
+
                         checkSyncRunning: function () {
                             var self = this;
                             ApiClient.getJSON(ApiClient.getUrl('ScheduledTasks')).then(function (tasks) {
-                                var syncTask = tasks.find(function (t) { return t.Key === 'LetterboxdSync'; });
-                                var diaryTask = tasks.find(function (t) { return t.Key === 'LetterboxdDiaryImport'; });
-                                var running = (syncTask && syncTask.State === 'Running') ? syncTask :
-                                              (diaryTask && diaryTask.State === 'Running') ? diaryTask : null;
+                                var keys = ['LetterboxdSync', 'LetterboxdDiaryImport', 'LetterboxdWatchlistSync'];
+                                var running = null;
+                                for (var i = 0; i < keys.length; i++) {
+                                    var t = tasks.find(function (x) { return x.Key === keys[i]; });
+                                    if (t && t.State === 'Running') { running = t; break; }
+                                }
                                 if (running) {
-                                    document.getElementById('runSyncBtn').disabled = true;
+                                    self.setSyncButtons(true);
                                     document.getElementById('syncStatus').innerHTML = '<span class="c-green">Sync in progress...</span>';
                                     self.pollTask(running.Id);
                                 }
@@ -478,7 +493,7 @@
                                     if (t.State === 'Idle') {
                                         clearInterval(self.syncPoll);
                                         self.syncPoll = null;
-                                        document.getElementById('runSyncBtn').disabled = false;
+                                        self.setSyncButtons(false);
                                         document.getElementById('syncStatus').innerHTML = '<span class="c-green">Done!</span>';
                                         document.getElementById('syncProgressBar').style.display = 'none';
                                         self.loadStats();
@@ -523,6 +538,25 @@
                                 if (!task) { document.getElementById('syncStatus').innerHTML = '<span class="c-red">Task not found</span>'; btn.disabled = false; return; }
                                 ApiClient.ajax({ url: ApiClient.getUrl('ScheduledTasks/Running/' + task.Id), type: 'POST' }).then(function () {
                                     document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing...</span>';
+                                    self.pollTask(task.Id);
+                                });
+                            });
+                        },
+
+                        runWatchlistSync: function () {
+                            var self = this;
+                            self.setSyncButtons(true);
+                            document.getElementById('syncStatus').textContent = 'Starting watchlist sync...';
+
+                            ApiClient.getJSON(ApiClient.getUrl('ScheduledTasks')).then(function (tasks) {
+                                var task = tasks.find(function (t) { return t.Key === 'LetterboxdWatchlistSync'; });
+                                if (!task) {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-red">Watchlist task not found</span>';
+                                    self.setSyncButtons(false);
+                                    return;
+                                }
+                                ApiClient.ajax({ url: ApiClient.getUrl('ScheduledTasks/Running/' + task.Id), type: 'POST' }).then(function () {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing watchlist...</span>';
                                     self.pollTask(task.Id);
                                 });
                             });
@@ -605,6 +639,7 @@
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveSettings(); });
                             document.getElementById('testJellyseerrBtn').addEventListener('click', function () { self.testJellyseerr(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
+                            document.getElementById('runWatchlistSyncBtn').addEventListener('click', function () { self.runWatchlistSync(); });
                             document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
                             document.getElementById('historyPrev').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize)); });
                             document.getElementById('historyNext').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize) + 2); });

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -88,8 +88,9 @@
                 <!-- DASHBOARD TAB -->
                 <div id="tab-stats" class="lb-tab-content">
                     <div id="syncControls">
-                        <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;">
+                        <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;flex-wrap:wrap;">
                             <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
+                            <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Jellyseerr if configured)">Sync Watchlist Now</button>
                             <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
                         </div>
                         <div id="syncProgressBar" style="display:none;margin-bottom:1.5em;">
@@ -503,6 +504,12 @@
                             this.loadHistory(false);
                         },
 
+                        setSyncButtons: function (disabled) {
+                            document.getElementById('runSyncBtn').disabled = disabled;
+                            var wl = document.getElementById('runWatchlistSyncBtn');
+                            if (wl) wl.disabled = disabled;
+                        },
+
                         pollProgress: function () {
                             var self = this;
                             if (self.syncPoll) clearInterval(self.syncPoll);
@@ -513,7 +520,7 @@
                                     if (!p || !p.isRunning) {
                                         clearInterval(self.syncPoll);
                                         self.syncPoll = null;
-                                        document.getElementById('runSyncBtn').disabled = false;
+                                        self.setSyncButtons(false);
                                         document.getElementById('syncStatus').innerHTML = '<span class="c-green">Done!</span>';
                                         document.getElementById('syncProgressBar').style.display = 'none';
                                         self.loadStats();
@@ -542,8 +549,7 @@
 
                         runSync: function () {
                             var self = this;
-                            var btn = document.getElementById('runSyncBtn');
-                            btn.disabled = true;
+                            self.setSyncButtons(true);
                             document.getElementById('syncStatus').textContent = 'Starting...';
 
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/Sync', {})
@@ -556,14 +562,40 @@
                                 if (!r.ok) {
                                     return r.json().then(function (data) {
                                         document.getElementById('syncStatus').innerHTML = '<span class="c-red">' + (data.error || 'Failed to start sync') + '</span>';
-                                        btn.disabled = false;
+                                        self.setSyncButtons(false);
                                     });
                                 }
                                 document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing...</span>';
                                 self.pollProgress();
                             }).catch(function (err) {
                                 document.getElementById('syncStatus').innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
-                                btn.disabled = false;
+                                self.setSyncButtons(false);
+                            });
+                        },
+
+                        runWatchlistSync: function () {
+                            var self = this;
+                            self.setSyncButtons(true);
+                            document.getElementById('syncStatus').textContent = 'Starting watchlist sync...';
+
+                            self.apiPost('Jellyfin.Plugin.LetterboxdSync/SyncWatchlist', {})
+                            .then(function (r) {
+                                if (r.status === 409) {
+                                    document.getElementById('syncStatus').innerHTML = '<span class="c-blue">Sync already running, polling...</span>';
+                                    self.pollProgress();
+                                    return;
+                                }
+                                if (!r.ok) {
+                                    return r.json().then(function (data) {
+                                        document.getElementById('syncStatus').innerHTML = '<span class="c-red">' + (data.error || 'Failed to start watchlist sync') + '</span>';
+                                        self.setSyncButtons(false);
+                                    });
+                                }
+                                document.getElementById('syncStatus').innerHTML = '<span class="c-green">Syncing watchlist...</span>';
+                                self.pollProgress();
+                            }).catch(function (err) {
+                                document.getElementById('syncStatus').innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
+                                self.setSyncButtons(false);
                             });
                         },
 
@@ -648,7 +680,7 @@
                             .then(function (r) { return r.json(); })
                             .then(function (p) {
                                 if (p && p.isRunning) {
-                                    document.getElementById('runSyncBtn').disabled = true;
+                                    self.setSyncButtons(true);
                                     document.getElementById('syncStatus').innerHTML = '<span class="c-green">Sync in progress...</span>';
                                     self.pollProgress();
                                 }
@@ -663,6 +695,7 @@
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveAccount(); });
                             document.getElementById('testBtn').addEventListener('click', function () { self.testConnection(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
+                            document.getElementById('runWatchlistSyncBtn').addEventListener('click', function () { self.runWatchlistSync(); });
                             document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
                             document.getElementById('historyPrev').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize)); });
                             document.getElementById('historyNext').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize) + 2); });

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.10.0.0",
+        "changelog": "Mirror Letterboxd watchlist into Jellyseerr's user watchlist (per-account toggle, two-way sync, movies-only so manually-added Jellyseerr TV is safe). On-demand 'Sync Watchlist Now' button on the plugin dashboard so you don't have to wait for the daily run. Pre-flight check against Jellyseerr's media status eliminates duplicate requests on every run (was creating fresh requests for already-pending/processing/available titles). Per-user watchlist sync runner extracted with a shared SyncGate so diary and watchlist syncs serialise.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.10.0/jellyfin-plugin-letterboxd-v1.10.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-04-30T00:00:00Z"
+      },
+      {
         "version": "1.9.1.0",
         "changelog": "Local-history duplicate backstop: refuse to MarkAsWatched when sync history shows a recent successful sync that does not pass the rewatch threshold, fixes the Cloudflare-failed-validator path that was creating real Letterboxd diary duplicates. Paginated dashboard history table (100 per page) now that the 500-entry cap is gone. Addresses #21.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
- **Mirror Letterboxd watchlist into Jellyseerr's user watchlist** as a new per-account toggle. Two-way diff (adds new, removes gone), movies-only so manually-added Jellyseerr TV is left alone, empty-LB-scrape guard prevents mass-deletion under Cloudflare.
- **Sync Watchlist Now** button on both the admin config page and the per-user page. Per-user page calls a new `POST /Jellyfin.Plugin.LetterboxdSync/SyncWatchlist` endpoint and reuses the existing progress poller.
- **Eliminate duplicate Jellyseerr requests.** Before POSTing `/api/v1/request`, the plugin now GETs `/api/v1/movie/{tmdbId}` and inspects `mediaInfo.status`. Anything pending/processing/partially-available/available/blocklisted is skipped; only UNKNOWN and DELETED proceed. New `RequestResult` enum so dashboards/log lines can show `requested / already on Jellyseerr / failed`.
- **Refactor.** Extracted `WatchlistSyncRunner` from `WatchlistSyncTask` mirroring the existing `LetterboxdSyncRunner` shape (`RunForAllAsync`, `TryRunForUserAsync`). New `SyncGate` shared semaphore so diary and watchlist syncs serialise across the same Cloudflare-protected origin and can't fight over `SyncProgress`.
- **Pagination fix:** Jellyseerr's `/api/v1/user/{id}/watchlist` paginates by `?page=N` and 400s on `take`/`skip`. Was previously sending `take`/`skip`, which made the GET fail and the diff think the Jellyseerr watchlist was empty (so it re-POSTed everything every run).
- **Tests:** 9 new `JellyseerrClient` tests cover the dedup pre-check across all status branches, the 409 fallback, page-based pagination, X-API-User header on GET/POST/DELETE, and 404-as-success on remove. 184 total tests, all passing.

## Test plan
- [ ] Plugin manifest update PR: CI fills in the `PLACEHOLDER` checksum after building the v1.10.0 release ZIP.
- [ ] Settings → tick **Mirror Letterboxd watchlist into Jellyseerr watchlist** on at least one account.
- [ ] Click **Sync Watchlist Now** on the user page. Verify spinner clears, log shows `+N -M` mirror counts and `requested / already / failed` request counts.
- [ ] Trigger a second time within a minute: the `requested` count should be 0 (everything already there).
- [ ] Manually remove a film from Letterboxd watchlist, run sync, verify Jellyseerr drops it too.
- [ ] Manually add a TV show to Jellyseerr watchlist, run sync, verify it's NOT removed.