### PR TITLE
chore: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with Astro
         uses: withastro/action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 
@@ -34,7 +34,7 @@ jobs:
           zip -j /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip LetterboxdSync.dll HtmlAgilityPack.dll
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary
GitHub announced Node 20 deprecation on Actions runners with default switch to Node 24 on **June 2nd, 2026** and full removal of Node 20 on **September 16th, 2026**. The v1.10.0 release run already started warning about it. Bumping the three actions we use to majors that ship a Node 24-compatible runtime:

- `actions/checkout`: **v4 → v6**
- `actions/setup-dotnet`: **v4 → v5**
- `softprops/action-gh-release`: **v2 → v3**

Touches `ci.yml`, `release.yml`, and `deploy-docs.yml`. No other workflow logic changed.

## Test plan
- [ ] CI workflow builds and tests pass on this PR with the new action versions.
- [ ] (After merge) Next tag push exercises the bumped `release.yml` end-to-end (build → ZIP → release → manifest checksum commit).
- [ ] (After merge) Next push touching `site/**` exercises bumped `deploy-docs.yml`.