### PR TITLE
Sync ratings between Jellyfin and Letterboxd, add in-dashboard logs viewer

### DIFF
--- a/LetterboxdSync.Tests/RatedFilmsApiTests.cs
+++ b/LetterboxdSync.Tests/RatedFilmsApiTests.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using LetterboxdSync;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class FilmSummaryHelperTests
+{
+    private static JsonElement Parse(string json)
+    {
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_ValidTmdbLink_ReturnsId()
+    {
+        var film = Parse(@"{
+            ""links"": [
+                { ""type"": ""letterboxd"", ""id"": ""KQMM"" },
+                { ""type"": ""imdb"", ""id"": ""tt31193180"" },
+                { ""type"": ""tmdb"", ""id"": ""1233413"" }
+            ]
+        }");
+
+        Assert.Equal(1233413, LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_TmdbCaseInsensitive_ReturnsId()
+    {
+        var film = Parse(@"{ ""links"": [ { ""type"": ""TMDB"", ""id"": ""550"" } ] }");
+        Assert.Equal(550, LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_NoTmdbLink_ReturnsNull()
+    {
+        var film = Parse(@"{
+            ""links"": [
+                { ""type"": ""letterboxd"", ""id"": ""KQMM"" },
+                { ""type"": ""imdb"", ""id"": ""tt31193180"" }
+            ]
+        }");
+
+        Assert.Null(LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_MissingLinks_ReturnsNull()
+    {
+        Assert.Null(LetterboxdApiClient.ExtractTmdbIdFromLinks(Parse(@"{ ""name"": ""Sinners"" }")));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_NonNumericTmdbId_ReturnsNull()
+    {
+        var film = Parse(@"{ ""links"": [ { ""type"": ""tmdb"", ""id"": ""junk"" } ] }");
+        Assert.Null(LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_PresentRating_ReturnsValue()
+    {
+        var film = Parse(@"{
+            ""relationships"": [
+                {
+                    ""member"": { ""id"": ""614Bn"" },
+                    ""relationship"": {
+                        ""watched"": true,
+                        ""rating"": 2.0,
+                        ""liked"": false
+                    }
+                }
+            ]
+        }");
+
+        Assert.Equal(2.0, LetterboxdApiClient.ExtractMemberRating(film));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_HalfStar_ReturnsValue()
+    {
+        var film = Parse(@"{
+            ""relationships"": [
+                { ""relationship"": { ""rating"": 4.5 } }
+            ]
+        }");
+
+        Assert.Equal(4.5, LetterboxdApiClient.ExtractMemberRating(film));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_NoRatingKey_ReturnsNull()
+    {
+        var film = Parse(@"{
+            ""relationships"": [
+                { ""relationship"": { ""watched"": true } }
+            ]
+        }");
+
+        Assert.Null(LetterboxdApiClient.ExtractMemberRating(film));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_EmptyRelationships_ReturnsNull()
+    {
+        Assert.Null(LetterboxdApiClient.ExtractMemberRating(Parse(@"{ ""relationships"": [] }")));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_MissingRelationshipsKey_ReturnsNull()
+    {
+        Assert.Null(LetterboxdApiClient.ExtractMemberRating(Parse(@"{ ""name"": ""Sinners"" }")));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_RelationshipsWrongType_ReturnsNull()
+    {
+        Assert.Null(LetterboxdApiClient.ExtractMemberRating(Parse(@"{ ""relationships"": ""oops"" }")));
+    }
+
+    [Fact]
+    public void ExtractMemberRating_RatingNotNumber_ReturnsNull()
+    {
+        var film = Parse(@"{
+            ""relationships"": [
+                { ""relationship"": { ""rating"": ""4.5"" } }
+            ]
+        }");
+
+        Assert.Null(LetterboxdApiClient.ExtractMemberRating(film));
+    }
+}
+
+public class GetDiaryFilmEntriesIntegrationTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    /// <summary>
+    /// Real shape of the /films?memberRelationship=Watched response we captured
+    /// during the live API probe — three rated films, one unrated, one duplicate
+    /// TMDb id (defensive: API has been seen to return dupes after edits).
+    /// </summary>
+    private const string SampleResponse = @"{
+        ""next"": null,
+        ""items"": [
+            {
+                ""type"": ""FilmSummary"",
+                ""id"": ""KQMM"",
+                ""name"": ""Sinners"",
+                ""links"": [
+                    { ""type"": ""letterboxd"", ""id"": ""KQMM"" },
+                    { ""type"": ""tmdb"", ""id"": ""1233413"" }
+                ],
+                ""relationships"": [
+                    { ""relationship"": { ""watched"": true, ""rating"": 2.0 } }
+                ]
+            },
+            {
+                ""type"": ""FilmSummary"",
+                ""id"": ""2a9q"",
+                ""name"": ""Iron Man"",
+                ""links"": [
+                    { ""type"": ""tmdb"", ""id"": ""1726"" }
+                ],
+                ""relationships"": [
+                    { ""relationship"": { ""watched"": true, ""rating"": 4.5 } }
+                ]
+            },
+            {
+                ""type"": ""FilmSummary"",
+                ""id"": ""abcd"",
+                ""name"": ""Some Watched But Unrated Film"",
+                ""links"": [
+                    { ""type"": ""tmdb"", ""id"": ""99999"" }
+                ],
+                ""relationships"": [
+                    { ""relationship"": { ""watched"": true } }
+                ]
+            },
+            {
+                ""type"": ""FilmSummary"",
+                ""id"": ""KQMM"",
+                ""name"": ""Sinners (duplicate row)"",
+                ""links"": [
+                    { ""type"": ""tmdb"", ""id"": ""1233413"" }
+                ],
+                ""relationships"": [
+                    { ""relationship"": { ""watched"": true, ""rating"": 5.0 } }
+                ]
+            }
+        ]
+    }";
+
+    [Fact]
+    public async Task GetDiaryFilmEntriesAsync_ParsesFilmsAndRatings()
+    {
+        string? capturedQuery = null;
+
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true &&
+                request.Method == HttpMethod.Get)
+            {
+                capturedQuery = request.RequestUri.Query;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(SampleResponse)
+                };
+            }
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var entries = await client.GetDiaryFilmEntriesAsync("user");
+
+        // The /films endpoint must be called with the Watched relationship and
+        // MemberRelationship include — that's what carries the per-member rating.
+        Assert.NotNull(capturedQuery);
+        Assert.Contains("memberRelationship=Watched", capturedQuery);
+        Assert.Contains("include=MemberRelationship", capturedQuery);
+
+        // Three unique TMDb IDs (Sinners deduped), parsed in input order.
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(new[] { 1233413, 1726, 99999 }, entries.Select(e => e.TmdbId).ToArray());
+
+        // Sinners kept its first rating (2.0), not the duplicate row's 5.0.
+        var sinners = entries.First(e => e.TmdbId == 1233413);
+        Assert.Equal(2.0, sinners.Rating);
+
+        var ironMan = entries.First(e => e.TmdbId == 1726);
+        Assert.Equal(4.5, ironMan.Rating);
+
+        var unrated = entries.First(e => e.TmdbId == 99999);
+        Assert.Null(unrated.Rating);
+    }
+
+    [Fact]
+    public async Task GetDiaryFilmEntriesAsync_FollowsPagination()
+    {
+        var pageRequests = new List<string>();
+
+        var page1 = @"{
+            ""next"": ""start=2"",
+            ""items"": [
+                { ""type"": ""FilmSummary"", ""id"": ""A"", ""links"": [ { ""type"": ""tmdb"", ""id"": ""1"" } ],
+                  ""relationships"": [ { ""relationship"": { ""rating"": 5.0 } } ] }
+            ]
+        }";
+        var page2 = @"{
+            ""items"": [
+                { ""type"": ""FilmSummary"", ""id"": ""B"", ""links"": [ { ""type"": ""tmdb"", ""id"": ""2"" } ],
+                  ""relationships"": [ { ""relationship"": { ""rating"": 3.5 } } ] }
+            ]
+        }";
+
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true &&
+                request.Method == HttpMethod.Get)
+            {
+                var q = request.RequestUri.Query;
+                pageRequests.Add(q);
+                var body = q.Contains("start=") ? page2 : page1;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body)
+                };
+            }
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var entries = await client.GetDiaryFilmEntriesAsync("user");
+
+        Assert.Equal(2, pageRequests.Count);
+        Assert.DoesNotContain("start=", pageRequests[0]);
+        Assert.Contains("start=", pageRequests[1]);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(1, entries[0].TmdbId);
+        Assert.Equal(5.0, entries[0].Rating);
+        Assert.Equal(2, entries[1].TmdbId);
+        Assert.Equal(3.5, entries[1].Rating);
+    }
+
+    [Fact]
+    public async Task GetDiaryFilmEntriesAsync_EmptyResponse_ReturnsEmpty()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(@"{ ""items"": [] }")
+                };
+            }
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var entries = await client.GetDiaryFilmEntriesAsync("user");
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public async Task GetDiaryTmdbIdsAsync_ReturnsJustTmdbIds()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(extraHandler: (request) =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(SampleResponse)
+                };
+            }
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var ids = await client.GetDiaryTmdbIdsAsync("user");
+
+        // Same dedup behaviour as the entries call, just stripped to ids.
+        Assert.Equal(new[] { 1233413, 1726, 99999 }, ids.ToArray());
+    }
+}

--- a/LetterboxdSync.Tests/RatingExtractionTests.cs
+++ b/LetterboxdSync.Tests/RatingExtractionTests.cs
@@ -1,0 +1,67 @@
+using HtmlAgilityPack;
+using LetterboxdSync;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class RatingExtractionTests
+{
+    private static HtmlNode Container(string innerHtml)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml($"<li class=\"poster-container\">{innerHtml}</li>");
+        return doc.DocumentNode.SelectSingleNode("//li");
+    }
+
+    [Theory]
+    [InlineData(1, 0.5)]
+    [InlineData(2, 1.0)]
+    [InlineData(5, 2.5)]
+    [InlineData(7, 3.5)]
+    [InlineData(10, 5.0)]
+    public void ExtractRating_RatedClass_ReturnsHalfStars(int classNum, double expected)
+    {
+        var node = Container(
+            $"<div data-film-slug=\"foo\"></div>" +
+            $"<p class=\"poster-viewingdata\"><span class=\"rating rated-{classNum}\">★</span></p>");
+
+        Assert.Equal(expected, LetterboxdScraper.ExtractRatingFromContainer(node));
+    }
+
+    [Fact]
+    public void ExtractRating_NoRatingSpan_ReturnsNull()
+    {
+        var node = Container("<div data-film-slug=\"foo\"></div>");
+        Assert.Null(LetterboxdScraper.ExtractRatingFromContainer(node));
+    }
+
+    [Fact]
+    public void ExtractRating_OutOfRangeClass_ReturnsNull()
+    {
+        var node = Container(
+            "<div data-film-slug=\"foo\"></div>" +
+            "<span class=\"rating rated-99\">junk</span>");
+
+        Assert.Null(LetterboxdScraper.ExtractRatingFromContainer(node));
+    }
+
+    [Fact]
+    public void ExtractRating_RatedZero_ReturnsNull()
+    {
+        var node = Container(
+            "<div data-film-slug=\"foo\"></div>" +
+            "<span class=\"rating rated-0\">unrated</span>");
+
+        Assert.Null(LetterboxdScraper.ExtractRatingFromContainer(node));
+    }
+
+    [Fact]
+    public void ExtractRating_NonNumericRatedSuffix_ReturnsNull()
+    {
+        var node = Container(
+            "<div data-film-slug=\"foo\"></div>" +
+            "<span class=\"rated-foo\">??</span>");
+
+        Assert.Null(LetterboxdScraper.ExtractRatingFromContainer(node));
+    }
+}

--- a/LetterboxdSync.Tests/RatingTests.cs
+++ b/LetterboxdSync.Tests/RatingTests.cs
@@ -61,4 +61,57 @@ public class RatingTests
     {
         Assert.Equal(0.5, Helpers.MapRating(0.1));
     }
+
+    [Theory]
+    [InlineData(0.5, 1.0)]
+    [InlineData(1.0, 2.0)]
+    [InlineData(1.5, 3.0)]
+    [InlineData(2.0, 4.0)]
+    [InlineData(2.5, 5.0)]
+    [InlineData(3.0, 6.0)]
+    [InlineData(3.5, 7.0)]
+    [InlineData(4.0, 8.0)]
+    [InlineData(4.5, 9.0)]
+    [InlineData(5.0, 10.0)]
+    public void LetterboxdToJellyfinRating_HalfStars_MapsCorrectly(double input, double expected)
+    {
+        Assert.Equal(expected, Helpers.LetterboxdToJellyfinRating(input));
+    }
+
+    [Fact]
+    public void LetterboxdToJellyfinRating_Null_ReturnsNull()
+    {
+        Assert.Null(Helpers.LetterboxdToJellyfinRating(null));
+    }
+
+    [Fact]
+    public void LetterboxdToJellyfinRating_Zero_ReturnsNull()
+    {
+        Assert.Null(Helpers.LetterboxdToJellyfinRating(0.0));
+    }
+
+    [Fact]
+    public void LetterboxdToJellyfinRating_Negative_ReturnsNull()
+    {
+        Assert.Null(Helpers.LetterboxdToJellyfinRating(-1.0));
+    }
+
+    [Fact]
+    public void LetterboxdToJellyfinRating_AboveMax_ClampedTo10()
+    {
+        Assert.Equal(10.0, Helpers.LetterboxdToJellyfinRating(7.0));
+    }
+
+    [Theory]
+    [InlineData(10.0)]
+    [InlineData(8.0)]
+    [InlineData(6.0)]
+    [InlineData(4.0)]
+    [InlineData(2.0)]
+    public void RoundTrip_JellyfinToLetterboxdToJellyfin_Preserves(double jellyfin)
+    {
+        var lb = Helpers.MapRating(jellyfin);
+        var back = Helpers.LetterboxdToJellyfinRating(lb);
+        Assert.Equal(jellyfin, back);
+    }
 }

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Mime;
+using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using LetterboxdSync.Configuration;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -19,17 +26,26 @@ public class LetterboxdController : ControllerBase
 {
     private readonly ILogger<LetterboxdController> _logger;
     private readonly IUserManager _userManager;
+    private readonly ILibraryManager _libraryManager;
+    private readonly IUserDataManager _userDataManager;
+    private readonly IApplicationPaths _appPaths;
     private readonly LetterboxdSyncRunner _syncRunner;
     private readonly WatchlistSyncRunner _watchlistRunner;
 
     public LetterboxdController(
         ILogger<LetterboxdController> logger,
         IUserManager userManager,
+        ILibraryManager libraryManager,
+        IUserDataManager userDataManager,
+        IApplicationPaths appPaths,
         LetterboxdSyncRunner syncRunner,
         WatchlistSyncRunner watchlistRunner)
     {
         _logger = logger;
         _userManager = userManager;
+        _libraryManager = libraryManager;
+        _userDataManager = userDataManager;
+        _appPaths = appPaths;
         _syncRunner = syncRunner;
         _watchlistRunner = watchlistRunner;
     }
@@ -341,6 +357,8 @@ public class LetterboxdController : ControllerBase
             _logger.LogInformation("Posted review for {FilmSlug} by {Username}",
                 request.FilmSlug, account.LetterboxdUsername);
 
+            WriteJellyfinRating(userId, request.TmdbId, request.Rating);
+
             var jellyfinUsername = GetJellyfinUsername() ?? account.LetterboxdUsername;
             var status = request.IsRewatch ? SyncStatus.Rewatch : SyncStatus.Success;
             SyncHistory.Record(new SyncEvent
@@ -372,6 +390,115 @@ public class LetterboxdController : ControllerBase
             });
 
             return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Returns the most recent LetterboxdSync log lines from Jellyfin's log files,
+    /// for in-dashboard debugging and "send me your logs" support flows.
+    /// Reads only LetterboxdSync-tagged lines so users can share without leaking
+    /// unrelated server activity. The plugin already redacts review text and never
+    /// logs auth tokens, passwords, or cookies, so this output is safe to share.
+    /// </summary>
+    [HttpGet("Logs")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult GetLogs([FromQuery] int maxLines = 500)
+    {
+        try
+        {
+            var logDir = _appPaths.LogDirectoryPath;
+            if (!Directory.Exists(logDir))
+                return Ok(new { lines = Array.Empty<string>(), source = (string?)null, error = "log directory not found" });
+
+            // Look at the two most recent main log files. Cover the case where the
+            // current file just rolled over and recent activity is in the previous one.
+            var mainLogs = Directory.GetFiles(logDir, "log_*.log")
+                .OrderByDescending(f => f)
+                .Take(2)
+                .ToList();
+
+            if (mainLogs.Count == 0)
+                return Ok(new { lines = Array.Empty<string>(), source = (string?)null, error = "no log files" });
+
+            var lines = new List<string>();
+            foreach (var path in mainLogs.AsEnumerable().Reverse())
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var sr = new StreamReader(fs);
+                string? line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    if (line.Contains("LetterboxdSync", StringComparison.Ordinal) ||
+                        line.Contains("Letterboxd ", StringComparison.Ordinal))
+                    {
+                        lines.Add(line);
+                    }
+                }
+            }
+
+            // Cap to last N lines so the response stays small.
+            var trimmed = lines.Count > maxLines ? lines.GetRange(lines.Count - maxLines, maxLines) : lines;
+            return Ok(new
+            {
+                lines = trimmed,
+                totalMatches = lines.Count,
+                returned = trimmed.Count,
+                source = string.Join(", ", mainLogs.Select(Path.GetFileName))
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("GetLogs failed: {Message}", ex.Message);
+            return Ok(new { lines = Array.Empty<string>(), source = (string?)null, error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Mirror the dashboard review's star rating into Jellyfin's UserItemData.Rating
+    /// so it survives plugin uninstall and is visible to other clients/plugins.
+    /// Always overwrites: posting a review is the user's latest input, so it wins.
+    /// No-op if the review had no rating, no TmdbId, or the film isn't in the library.
+    /// </summary>
+    private void WriteJellyfinRating(string userId, int? tmdbId, double? letterboxdRating)
+    {
+        if (!tmdbId.HasValue || !letterboxdRating.HasValue)
+            return;
+
+        var jellyfinRating = Helpers.LetterboxdToJellyfinRating(letterboxdRating);
+        if (!jellyfinRating.HasValue)
+            return;
+
+        var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userId);
+        if (user == null)
+            return;
+
+        var movie = _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Movie },
+            IsVirtualItem = false,
+            Recursive = true
+        }).FirstOrDefault(m => m.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tmdb) == tmdbId.Value.ToString());
+
+        if (movie == null)
+        {
+            _logger.LogDebug("Skipping Jellyfin rating writeback: TMDb {TmdbId} not in library", tmdbId.Value);
+            return;
+        }
+
+        try
+        {
+            var userData = _userDataManager.GetUserData(user, movie);
+            if (userData == null) return;
+
+            userData.Rating = jellyfinRating;
+            _userDataManager.SaveUserData(user, movie, userData, UserDataSaveReason.UpdateUserRating, CancellationToken.None);
+
+            _logger.LogInformation("Mirrored Letterboxd rating {LbRating} -> Jellyfin {JfRating} for {Title} ({UserId})",
+                letterboxdRating.Value, jellyfinRating.Value, movie.Name, userId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Failed to write Jellyfin rating for TMDb {TmdbId}: {Message}", tmdbId.Value, ex.Message);
         }
     }
 }

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -71,13 +71,13 @@ public class DiaryImportTask : IScheduledTask
 
             using var _s = service;
 
-            List<int> diaryTmdbIds;
+            List<DiaryFilmEntry> diaryEntries;
             try
             {
                 SyncProgress.SetPhase("Scanning Letterboxd films");
-                diaryTmdbIds = await service.GetDiaryTmdbIdsAsync(account.LetterboxdUsername).ConfigureAwait(false);
+                diaryEntries = await service.GetDiaryFilmEntriesAsync(account.LetterboxdUsername).ConfigureAwait(false);
                 _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd diary",
-                    diaryTmdbIds.Count, account.LetterboxdUsername);
+                    diaryEntries.Count, account.LetterboxdUsername);
             }
             catch (Exception ex)
             {
@@ -85,19 +85,26 @@ public class DiaryImportTask : IScheduledTask
                 continue;
             }
 
-            if (diaryTmdbIds.Count == 0)
+            if (diaryEntries.Count == 0)
                 continue;
 
-            var unplayedMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            var ratingByTmdbId = diaryEntries
+                .Where(e => e.Rating.HasValue)
+                .ToDictionary(e => e.TmdbId, e => e.Rating!.Value);
+            var diaryTmdbIds = new HashSet<int>(diaryEntries.Select(e => e.TmdbId));
+
+            // Pull all movies (not just unplayed) so we can also apply rating-only updates
+            // to films already marked as played.
+            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[] { BaseItemKind.Movie },
                 IsVirtualItem = false,
-                IsPlayed = false,
                 Recursive = true
             });
 
             var marked = 0;
-            foreach (var movie in unplayedMovies)
+            var ratingsApplied = 0;
+            foreach (var movie in allMovies)
             {
                 var tmdbStr = movie.GetProviderId(MetadataProvider.Tmdb);
                 if (!int.TryParse(tmdbStr, out var tmdbId)) continue;
@@ -107,19 +114,61 @@ public class DiaryImportTask : IScheduledTask
                 var userData = _userDataManager.GetUserData(user, movie);
                 if (userData == null) continue;
 
-                // Only set Played=true, do NOT set LastPlayedDate.
-                // Setting LastPlayedDate would cause SyncTask to re-export this film
-                // back to Letterboxd, creating a sync loop.
-                userData.Played = true;
-                _userDataManager.SaveUserData(user, movie, userData, UserDataSaveReason.Import, cancellationToken);
+                var changed = false;
 
-                _logger.LogInformation("Marked {Title} as played for {Username} (from Letterboxd diary)",
-                    movie.Name, user.Username);
-                marked++;
+                // Mark as played if not already. Do NOT set LastPlayedDate, since that would
+                // cause SyncTask to re-export this film back to Letterboxd (sync loop).
+                if (!userData.Played)
+                {
+                    userData.Played = true;
+                    changed = true;
+                    marked++;
+                    _logger.LogInformation("Marked {Title} as played for {Username} (from Letterboxd diary)",
+                        movie.Name, user.Username);
+                }
+
+                // Apply Letterboxd rating only when Jellyfin doesn't already have one.
+                // Jellyfin has no "rating last modified" timestamp to compare against, so we
+                // use absence-of-rating as the safe signal. Existing ratings (e.g. from
+                // Findroid) are preserved; users who want to overwrite from Letterboxd can
+                // post a review via the plugin dashboard, which always wins.
+                if (ratingByTmdbId.TryGetValue(tmdbId, out var lbRating) &&
+                    (!userData.Rating.HasValue || userData.Rating.Value <= 0))
+                {
+                    var jfRating = Helpers.LetterboxdToJellyfinRating(lbRating);
+                    if (jfRating.HasValue)
+                    {
+                        userData.Rating = jfRating;
+                        changed = true;
+                        ratingsApplied++;
+                        _logger.LogInformation("Imported Letterboxd rating {LbRating} -> Jellyfin {JfRating} for {Title}",
+                            lbRating, jfRating.Value, movie.Name);
+                    }
+                }
+
+                if (changed)
+                {
+                    _userDataManager.SaveUserData(user, movie, userData, UserDataSaveReason.Import, cancellationToken);
+                }
             }
 
-            _logger.LogInformation("Diary import complete for {Username}: {Marked} films marked as played",
-                user.Username, marked);
+            // Count Letterboxd films/ratings we couldn't act on because the user doesn't
+            // have them in their Jellyfin library yet. Useful for surfacing the gap so
+            // users know their LB and JF aren't in full lockstep, and for support logs.
+            var libraryTmdbIds = new HashSet<int>(allMovies
+                .Select(m => m.GetProviderId(MetadataProvider.Tmdb))
+                .Where(s => int.TryParse(s, out _))
+                .Select(s => int.Parse(s!)));
+            var unmatchedFilms = diaryTmdbIds.Count(id => !libraryTmdbIds.Contains(id));
+            var unmatchedRatings = ratingByTmdbId.Count(kv => !libraryTmdbIds.Contains(kv.Key));
+
+            _logger.LogInformation(
+                "Diary import complete for {Username}: {Marked} marked played, {Ratings} ratings imported. " +
+                "Skipped because not in Jellyfin library: {UnmatchedFilms} films ({UnmatchedRatings} of which were rated). " +
+                "Skipped because Jellyfin rating already set: {RatingsHeldByJellyfin}.",
+                user.Username, marked, ratingsApplied,
+                unmatchedFilms, unmatchedRatings,
+                ratingByTmdbId.Count(kv => libraryTmdbIds.Contains(kv.Key)) - ratingsApplied);
             SyncProgress.Complete();
         }
 

--- a/LetterboxdSync/Helpers.cs
+++ b/LetterboxdSync/Helpers.cs
@@ -21,6 +21,18 @@ public static class Helpers
     }
 
     /// <summary>
+    /// Map a Letterboxd rating (0.5-5.0) to a Jellyfin rating (1-10).
+    /// Returns null if the input is null or out of range.
+    /// </summary>
+    public static double? LetterboxdToJellyfinRating(double? letterboxdRating)
+    {
+        if (!letterboxdRating.HasValue || letterboxdRating.Value <= 0)
+            return null;
+
+        return Math.Clamp(letterboxdRating.Value * 2.0, 1.0, 10.0);
+    }
+
+    /// <summary>
     /// Extract a film slug from a Letterboxd film URL.
     /// e.g. "https://letterboxd.com/film/gladiator-ii/" -> "gladiator-ii"
     /// </summary>

--- a/LetterboxdSync/ILetterboxdService.cs
+++ b/LetterboxdSync/ILetterboxdService.cs
@@ -21,4 +21,6 @@ public interface ILetterboxdService : IDisposable
     Task<List<int>> GetWatchlistTmdbIdsAsync(string username);
 
     Task<List<int>> GetDiaryTmdbIdsAsync(string username);
+
+    Task<List<DiaryFilmEntry>> GetDiaryFilmEntriesAsync(string username);
 }

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -260,17 +260,32 @@ public class LetterboxdApiClient : ILetterboxdService
 
     public async Task<List<int>> GetDiaryTmdbIdsAsync(string username)
     {
+        var entries = await GetDiaryFilmEntriesAsync(username).ConfigureAwait(false);
+        return entries.Select(e => e.TmdbId).ToList();
+    }
+
+    /// <summary>
+    /// Returns every film the member has marked Watched on Letterboxd, including
+    /// ones rated without a diary entry. Each entry includes the member's personal
+    /// rating when set. Backed by /films?memberRelationship=Watched, which is a
+    /// superset of /log-entries (the diary endpoint), so films you rated without
+    /// logging a watch are also included.
+    /// </summary>
+    public async Task<List<DiaryFilmEntry>> GetDiaryFilmEntriesAsync(string username)
+    {
         EnsureAuthenticated();
-        var tmdbIds = new List<int>();
-        string? cursor = null;
+        var entries = new List<DiaryFilmEntry>();
+        var seen = new HashSet<int>();
+        const int perPage = 100;
 
         for (int page = 0; page < 50; page++)
         {
-            var qp = $"perPage=100&member={Uri.EscapeDataString(_memberId)}";
-            if (cursor != null)
-                qp += $"&cursor={Uri.EscapeDataString(cursor)}";
+            var qp = $"perPage={perPage}&member={Uri.EscapeDataString(_memberId)}" +
+                    "&memberRelationship=Watched&include=MemberRelationship";
+            if (page > 0)
+                qp += $"&start={page * perPage}";
 
-            var response = await SendSignedAsync(HttpMethod.Get, "/log-entries",
+            var response = await SendSignedAsync(HttpMethod.Get, "/films",
                 queryParams: qp, authenticated: true).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
@@ -283,21 +298,57 @@ public class LetterboxdApiClient : ILetterboxdService
 
             foreach (var item in items.EnumerateArray())
             {
-                if (item.TryGetProperty("film", out var film))
-                {
-                    var tmdbId = ExtractTmdbId(film);
-                    if (tmdbId.HasValue && !tmdbIds.Contains(tmdbId.Value))
-                        tmdbIds.Add(tmdbId.Value);
-                }
+                var tmdbId = ExtractTmdbIdFromLinks(item);
+                if (!tmdbId.HasValue || !seen.Add(tmdbId.Value)) continue;
+
+                double? rating = ExtractMemberRating(item);
+                entries.Add(new DiaryFilmEntry(tmdbId.Value, rating));
             }
 
-            if (doc.RootElement.TryGetProperty("cursor", out var cursorEl))
-                cursor = cursorEl.GetString();
-            else
+            // Letterboxd signals more pages via `next: "start=N"`. Stop when missing.
+            if (!doc.RootElement.TryGetProperty("next", out _))
                 break;
         }
 
-        return tmdbIds;
+        return entries;
+    }
+
+    /// <summary>
+    /// Pull TMDb ID from a FilmSummary's `links` array.
+    /// FilmSummary uses `links: [{type:"tmdb", id:"123"}, ...]` rather than a
+    /// nested `film` object with provider IDs (which is what /log-entries returns).
+    /// </summary>
+    internal static int? ExtractTmdbIdFromLinks(JsonElement film)
+    {
+        if (!film.TryGetProperty("links", out var links) || links.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var link in links.EnumerateArray())
+        {
+            if (!link.TryGetProperty("type", out var type)) continue;
+            if (!string.Equals(type.GetString(), "tmdb", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!link.TryGetProperty("id", out var idEl)) continue;
+            if (int.TryParse(idEl.GetString(), out var id)) return id;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Pull the member's personal rating from a FilmSummary returned with
+    /// `include=MemberRelationship`. Lives at relationships[0].relationship.rating.
+    /// </summary>
+    internal static double? ExtractMemberRating(JsonElement film)
+    {
+        if (!film.TryGetProperty("relationships", out var rels) ||
+            rels.ValueKind != JsonValueKind.Array || rels.GetArrayLength() == 0)
+            return null;
+
+        var first = rels[0];
+        if (!first.TryGetProperty("relationship", out var rel)) return null;
+        if (!rel.TryGetProperty("rating", out var ratingEl)) return null;
+        if (ratingEl.ValueKind != JsonValueKind.Number) return null;
+
+        return ratingEl.GetDouble();
     }
 
     public void Dispose()

--- a/LetterboxdSync/LetterboxdDiary.cs
+++ b/LetterboxdSync/LetterboxdDiary.cs
@@ -182,7 +182,17 @@ public class LetterboxdDiary
             payload["filmId"] = filmId;
 
         var jsonBody = JsonSerializer.Serialize(payload);
-        _logger.LogInformation("PostReview payload: {Body}", jsonBody);
+        // Log payload metadata only — never the review text itself, since users
+        // share these logs for support and review drafts can be private.
+        _logger.LogInformation(
+            "PostReview prepared for {FilmSlug}: hasText={HasText}, textLen={TextLen}, " +
+            "rating={Rating}, isRewatch={IsRewatch}, containsSpoilers={Spoilers}",
+            filmSlug,
+            !string.IsNullOrEmpty(reviewText),
+            reviewText?.Length ?? 0,
+            rating,
+            isRewatch,
+            containsSpoilers);
 
         for (int attempt = 0; attempt < LetterboxdHttpClient.MaxRetries; attempt++)
         {

--- a/LetterboxdSync/LetterboxdScraper.cs
+++ b/LetterboxdSync/LetterboxdScraper.cs
@@ -142,7 +142,19 @@ public class LetterboxdScraper
     /// </summary>
     public async Task<List<int>> GetDiaryTmdbIdsAsync(string username)
     {
-        var tmdbIds = new List<int>();
+        var entries = await GetDiaryFilmEntriesAsync(username).ConfigureAwait(false);
+        return entries.Select(e => e.TmdbId).ToList();
+    }
+
+    /// <summary>
+    /// Scrape all films a user has logged on Letterboxd, returning TMDb ID and rating
+    /// (when present) for each. Same source as GetDiaryTmdbIdsAsync but preserves the
+    /// per-film rating parsed from the poster HTML.
+    /// </summary>
+    public async Task<List<DiaryFilmEntry>> GetDiaryFilmEntriesAsync(string username)
+    {
+        var entries = new List<DiaryFilmEntry>();
+        var seenTmdbIds = new HashSet<int>();
         var page = 1;
         const int maxPages = 50;
 
@@ -157,7 +169,7 @@ public class LetterboxdScraper
             if (!res.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Films page {Page} for {Username} returned {Status}. Returning {Count} films found so far.",
-                    page, username, (int)res.StatusCode, tmdbIds.Count);
+                    page, username, (int)res.StatusCode, entries.Count);
                 break;
             }
 
@@ -169,20 +181,25 @@ public class LetterboxdScraper
             {
                 _logger.LogWarning("Cloudflare challenge detected on films page {Page} for {Username}. " +
                     "Returning {Count} films found so far. Try providing raw cookies with cf_clearance.",
-                    page, username, tmdbIds.Count);
+                    page, username, entries.Count);
                 break;
             }
 
             var doc = new HtmlDocument();
             doc.LoadHtml(html);
 
-            var posters = doc.DocumentNode.SelectNodes("//li[contains(@class, 'poster-container')]//div[@data-film-slug]");
-            if (posters == null)
-                posters = doc.DocumentNode.SelectNodes("//div[@data-component-class='LazyPoster']");
-            if (posters == null)
-                posters = doc.DocumentNode.SelectNodes("//div[@data-film-slug]");
+            // Prefer the poster-container <li> so we can look up the rating span alongside the slug.
+            // Fall back to bare poster nodes if Letterboxd's layout shifts; rating just won't be captured then.
+            var containers = doc.DocumentNode.SelectNodes("//li[contains(@class, 'poster-container')]");
+            HtmlNodeCollection? fallbackPosters = null;
+            if (containers == null || containers.Count == 0)
+            {
+                fallbackPosters = doc.DocumentNode.SelectNodes("//div[@data-component-class='LazyPoster']")
+                    ?? doc.DocumentNode.SelectNodes("//div[@data-film-slug]");
+            }
 
-            if (posters == null || posters.Count == 0)
+            int posterCount = containers?.Count ?? fallbackPosters?.Count ?? 0;
+            if (posterCount == 0)
             {
                 if (page == 1)
                     _logger.LogWarning("No films found on page 1 for {Username}. " +
@@ -191,21 +208,49 @@ public class LetterboxdScraper
             }
 
             _logger.LogInformation("Films page {Page} for {Username}: found {Count} posters, resolving TMDb IDs...",
-                page, username, posters.Count);
+                page, username, posterCount);
             SyncProgress.SetPhase($"Scanning page {page}");
 
-            foreach (var poster in posters)
+            if (containers != null)
             {
-                var slug = poster.GetAttributeValue("data-film-slug", string.Empty);
-                if (string.IsNullOrEmpty(slug))
-                    slug = poster.GetAttributeValue("data-item-slug", string.Empty);
-                if (string.IsNullOrEmpty(slug)) continue;
-
-                var tmdbId = await ResolveTmdbIdFromSlugAsync(slug).ConfigureAwait(false);
-                if (tmdbId.HasValue && !tmdbIds.Contains(tmdbId.Value))
+                foreach (var container in containers)
                 {
-                    tmdbIds.Add(tmdbId.Value);
-                    _logger.LogDebug("Films: {Slug} -> TMDb:{TmdbId}", slug, tmdbId.Value);
+                    var posterDiv = container.SelectSingleNode(".//div[@data-film-slug]")
+                        ?? container.SelectSingleNode(".//div[@data-component-class='LazyPoster']");
+                    if (posterDiv == null) continue;
+
+                    var slug = posterDiv.GetAttributeValue("data-film-slug", string.Empty);
+                    if (string.IsNullOrEmpty(slug))
+                        slug = posterDiv.GetAttributeValue("data-item-slug", string.Empty);
+                    if (string.IsNullOrEmpty(slug)) continue;
+
+                    var rating = ExtractRatingFromContainer(container);
+
+                    var tmdbId = await ResolveTmdbIdFromSlugAsync(slug).ConfigureAwait(false);
+                    if (tmdbId.HasValue && seenTmdbIds.Add(tmdbId.Value))
+                    {
+                        entries.Add(new DiaryFilmEntry(tmdbId.Value, rating));
+                        _logger.LogDebug("Films: {Slug} -> TMDb:{TmdbId} Rating:{Rating}",
+                            slug, tmdbId.Value, rating?.ToString() ?? "none");
+                    }
+                }
+            }
+            else if (fallbackPosters != null)
+            {
+                foreach (var poster in fallbackPosters)
+                {
+                    var slug = poster.GetAttributeValue("data-film-slug", string.Empty);
+                    if (string.IsNullOrEmpty(slug))
+                        slug = poster.GetAttributeValue("data-item-slug", string.Empty);
+                    if (string.IsNullOrEmpty(slug)) continue;
+
+                    var tmdbId = await ResolveTmdbIdFromSlugAsync(slug).ConfigureAwait(false);
+                    if (tmdbId.HasValue && seenTmdbIds.Add(tmdbId.Value))
+                    {
+                        entries.Add(new DiaryFilmEntry(tmdbId.Value, null));
+                        _logger.LogDebug("Films: {Slug} -> TMDb:{TmdbId} (no rating, fallback selector)",
+                            slug, tmdbId.Value);
+                    }
                 }
             }
 
@@ -215,9 +260,33 @@ public class LetterboxdScraper
         }
 
         _logger.LogInformation("Found {Count} films across {Pages} pages for {Username}",
-            tmdbIds.Count, page, username);
+            entries.Count, page, username);
 
-        return tmdbIds;
+        return entries;
+    }
+
+    /// <summary>
+    /// Extract a Letterboxd star rating (0.5-5.0) from a poster-container li.
+    /// Letterboxd marks rated films with a class like "rated-7", where the integer
+    /// represents half-stars (rated-1 = 0.5 stars, rated-10 = 5.0 stars).
+    /// Returns null when no rating is set.
+    /// </summary>
+    internal static double? ExtractRatingFromContainer(HtmlNode container)
+    {
+        var ratingNode = container.SelectSingleNode(".//span[contains(@class, 'rating') and contains(@class, 'rated-')]")
+            ?? container.SelectSingleNode(".//*[contains(@class, 'rated-')]");
+        if (ratingNode == null) return null;
+
+        var classes = ratingNode.GetAttributeValue("class", string.Empty);
+        foreach (var cls in classes.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!cls.StartsWith("rated-", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!int.TryParse(cls.AsSpan(6), out var halfStars)) continue;
+            if (halfStars < 1 || halfStars > 10) continue;
+            return halfStars / 2.0;
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -336,3 +405,9 @@ public class LetterboxdScraper
 }
 
 public record DiaryInfo(DateTime? LastDate, bool HasAnyEntry);
+
+/// <summary>
+/// A film from a user's Letterboxd films page, with optional rating.
+/// Rating is on Letterboxd's 0.5-5.0 scale (rated-1 class = 0.5 stars, rated-10 = 5.0).
+/// </summary>
+public record DiaryFilmEntry(int TmdbId, double? Rating);

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.10.1.0</AssemblyVersion>
-    <FileVersion>1.10.1.0</FileVersion>
+    <AssemblyVersion>1.11.0.0</AssemblyVersion>
+    <FileVersion>1.11.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/ScrapingLetterboxdService.cs
+++ b/LetterboxdSync/ScrapingLetterboxdService.cs
@@ -46,6 +46,9 @@ public class ScrapingLetterboxdService : ILetterboxdService
     public Task<List<int>> GetDiaryTmdbIdsAsync(string username)
         => _scraper.GetDiaryTmdbIdsAsync(username);
 
+    public Task<List<DiaryFilmEntry>> GetDiaryFilmEntriesAsync(string username)
+        => _scraper.GetDiaryFilmEntriesAsync(username);
+
     public void Dispose()
     {
         _http.Dispose();

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -70,6 +70,7 @@
                 <div class="lb-tabs">
                     <button type="button" class="lb-tab active" data-tab="stats">Dashboard</button>
                     <button type="button" class="lb-tab" data-tab="settings">Settings</button>
+                    <button type="button" class="lb-tab" data-tab="logs">Logs</button>
                 </div>
 
                 <!-- DASHBOARD TAB -->
@@ -136,6 +137,26 @@
                     </div>
                 </div>
 
+                <!-- LOGS TAB -->
+                <div id="tab-logs" class="lb-tab-content" style="display:none;">
+                    <p class="c-muted" style="font-size:0.9em;margin-bottom:1em;">
+                        Recent LetterboxdSync log entries from Jellyfin's main log file. Safe to share for support &mdash;
+                        review text, passwords, cookies, and auth tokens are never logged.
+                    </p>
+                    <div style="display:flex;gap:0.7em;align-items:center;margin-bottom:0.8em;flex-wrap:wrap;">
+                        <button type="button" class="lb-btn lb-btn-secondary" id="logsRefreshBtn">Refresh</button>
+                        <label class="lb-field" style="margin:0;">User</label>
+                        <select id="logsUserFilter" style="min-width:180px;">
+                            <option value="">All users</option>
+                        </select>
+                        <input type="text" id="logsTextFilter" placeholder="Filter text (e.g. film title)" style="min-width:180px;" />
+                        <button type="button" class="lb-btn lb-btn-secondary" id="logsCopyBtn">Copy</button>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="logsDownloadBtn">Download .log</button>
+                        <span id="logsStatus" class="c-muted" style="font-size:0.85em;"></span>
+                    </div>
+                    <pre id="logsOutput" style="background:#0a0a0a;color:#cfcfcf;padding:1em;border-radius:6px;max-height:60vh;overflow:auto;font-size:0.78em;line-height:1.4;white-space:pre-wrap;word-break:break-word;border:1px solid rgba(255,255,255,0.06);">Loading...</pre>
+                </div>
+
                 <!-- REVIEW MODAL -->
                 <div id="reviewModal" class="lb-modal-overlay">
                     <div class="lb-modal">
@@ -191,15 +212,138 @@
                         historyTotal: 0,
 
                         initTabs: function () {
+                            var self = this;
                             var tabs = document.querySelectorAll('.lb-tab');
                             tabs.forEach(function (tab) {
                                 tab.addEventListener('click', function () {
                                     tabs.forEach(function (t) { t.classList.remove('active'); });
                                     tab.classList.add('active');
                                     document.querySelectorAll('.lb-tab-content').forEach(function (c) { c.style.display = 'none'; });
-                                    document.getElementById('tab-' + tab.getAttribute('data-tab')).style.display = '';
+                                    var name = tab.getAttribute('data-tab');
+                                    document.getElementById('tab-' + name).style.display = '';
+                                    if (name === 'logs') self.loadLogs();
                                 });
                             });
+                        },
+
+                        loadLogs: function () {
+                            var self = this;
+                            var output = document.getElementById('logsOutput');
+                            var status = document.getElementById('logsStatus');
+                            if (!output) return;
+                            output.textContent = 'Loading...';
+                            status.textContent = '';
+                            self.populateLogsUserFilter();
+                            ApiClient.fetch({
+                                url: ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/Logs?maxLines=500'),
+                                type: 'GET',
+                                dataType: 'json'
+                            }).then(function (data) {
+                                self.logsRaw = data.lines || [];
+                                self.logsSource = data.source;
+                                self.logsTotal = data.totalMatches || 0;
+                                if (self.logsRaw.length === 0) {
+                                    output.textContent = data.error
+                                        ? '(error: ' + data.error + ')'
+                                        : '(no LetterboxdSync log entries found in ' + (data.source || 'recent logs') + ')';
+                                    return;
+                                }
+                                self.applyLogsFilter();
+                                output.scrollTop = output.scrollHeight;
+                            }).catch(function (err) {
+                                self.logsRaw = [];
+                                output.textContent = '(failed to load logs: ' + (err && err.message ? err.message : err) + ')';
+                            });
+                        },
+
+                        // Populate the user dropdown from the configured accounts.
+                        // Each option carries both the Jellyfin username and the Letterboxd
+                        // username so we can match either string in log lines.
+                        populateLogsUserFilter: function () {
+                            var sel = document.getElementById('logsUserFilter');
+                            if (!sel) return;
+                            // Read currently configured accounts off the rendered settings form.
+                            var accounts = this.collectAccounts ? this.collectAccounts() : [];
+                            var current = sel.value;
+                            sel.innerHTML = '<option value="">All users</option>';
+                            var seen = {};
+                            accounts.forEach(function (a) {
+                                var jfUserId = a.UserJellyfinId || '';
+                                var lbUser = a.LetterboxdUsername || '';
+                                if (!jfUserId && !lbUser) return;
+                                var jfUser = '';
+                                if (window.LB && LB.users) {
+                                    var match = LB.users.find(function (u) { return u.Id.replace(/-/g, '') === jfUserId; });
+                                    if (match) jfUser = match.Name;
+                                }
+                                // Combine both usernames as a single filter value separated by 
+                                // so we can match either in the log line.
+                                var key = jfUser + '' + lbUser;
+                                if (seen[key]) return;
+                                seen[key] = true;
+                                var label = (jfUser || '?') + (lbUser ? ' → ' + lbUser : '');
+                                sel.insertAdjacentHTML('beforeend',
+                                    '<option value="' + key.replace(/"/g, '&quot;') + '">' + label + '</option>');
+                            });
+                            if (current) sel.value = current;
+                        },
+
+                        applyLogsFilter: function () {
+                            var output = document.getElementById('logsOutput');
+                            var status = document.getElementById('logsStatus');
+                            if (!output || !this.logsRaw) return;
+                            var userVal = document.getElementById('logsUserFilter').value;
+                            var textVal = (document.getElementById('logsTextFilter').value || '').trim();
+                            var filtered = this.logsRaw;
+                            if (userVal) {
+                                var parts = userVal.split('');
+                                var jfUser = parts[0] || '';
+                                var lbUser = parts[1] || '';
+                                filtered = filtered.filter(function (line) {
+                                    if (jfUser && line.indexOf(jfUser) !== -1) return true;
+                                    if (lbUser && line.indexOf(lbUser) !== -1) return true;
+                                    return false;
+                                });
+                            }
+                            if (textVal) {
+                                var needle = textVal.toLowerCase();
+                                filtered = filtered.filter(function (line) {
+                                    return line.toLowerCase().indexOf(needle) !== -1;
+                                });
+                            }
+                            output.textContent = filtered.length > 0
+                                ? filtered.join('\n')
+                                : '(no log lines match the current filter)';
+                            status.textContent = 'Showing ' + filtered.length + ' of ' + this.logsTotal +
+                                ' matches from ' + (this.logsSource || '');
+                        },
+
+                        copyLogs: function () {
+                            var output = document.getElementById('logsOutput');
+                            if (!output || !output.textContent) return;
+                            var status = document.getElementById('logsStatus');
+                            if (navigator.clipboard && navigator.clipboard.writeText) {
+                                navigator.clipboard.writeText(output.textContent)
+                                    .then(function () { status.textContent = 'Copied to clipboard'; })
+                                    .catch(function () { status.textContent = 'Copy failed'; });
+                            } else {
+                                status.textContent = 'Clipboard API unavailable';
+                            }
+                        },
+
+                        downloadLogs: function () {
+                            var output = document.getElementById('logsOutput');
+                            if (!output || !output.textContent) return;
+                            var stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+                            var blob = new Blob([output.textContent], { type: 'text/plain' });
+                            var url = URL.createObjectURL(blob);
+                            var a = document.createElement('a');
+                            a.href = url;
+                            a.download = 'letterboxd-sync_' + stamp + '.log';
+                            document.body.appendChild(a);
+                            a.click();
+                            document.body.removeChild(a);
+                            URL.revokeObjectURL(url);
                         },
 
                         getUserOptions: function () {
@@ -640,6 +784,11 @@
                             document.getElementById('testJellyseerrBtn').addEventListener('click', function () { self.testJellyseerr(); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
                             document.getElementById('runWatchlistSyncBtn').addEventListener('click', function () { self.runWatchlistSync(); });
+                            document.getElementById('logsRefreshBtn').addEventListener('click', function () { self.loadLogs(); });
+                            document.getElementById('logsCopyBtn').addEventListener('click', function () { self.copyLogs(); });
+                            document.getElementById('logsDownloadBtn').addEventListener('click', function () { self.downloadLogs(); });
+                            document.getElementById('logsUserFilter').addEventListener('change', function () { self.applyLogsFilter(); });
+                            document.getElementById('logsTextFilter').addEventListener('input', function () { self.applyLogsFilter(); });
                             document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
                             document.getElementById('historyPrev').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize)); });
                             document.getElementById('historyNext').addEventListener('click', function () { self.gotoHistoryPage(Math.floor(self.historyOffset / self.historyPageSize) + 2); });


### PR DESCRIPTION
## Summary

Three improvements to the rating story plus an admin logs viewer:

**1. Dashboard reviews now write back to Jellyfin**
- Posting a review via the plugin dashboard mirrors the star rating into `UserItemData.Rating` (LB 0.5 to 5.0 maps to JF 1 to 10)
- Always overwrites: posting a review is the user's latest input, so it wins
- Means ratings survive plugin uninstall and are visible to clients that surface user ratings (Findroid, Streamyfin, etc.)

**2. Diary import now seeds ratings from Letterboxd**
- Pulls each film's personal rating alongside the existing played-marking
- Only writes when Jellyfin has no rating yet (anti-clobber, protects ratings set in Findroid/etc.)
- New diagnostic log line counts unmatched (not-in-library) films and skipped (already-rated) films, so users can see why a rating didn't sync
- Library-not-yet-downloaded films will auto-sync their rating the day after the film is added to the library

**3. Switched API endpoint from `/log-entries` to `/films?memberRelationship=Watched`**
- Old endpoint only returned diary entries (films logged with a date), missing films you rated without diary'ing
- New endpoint returns all watched films including rated-only, with `include=MemberRelationship` so the per-member rating ships in the same response
- Empirically verified against the live API; lachlan's diary went from 70 to 80 films after the switch (Iron Man, Luca, etc. now sync)

**4. In-dashboard logs viewer (Logs tab on the config page)**
- New `GET /Jellyfin.Plugin.LetterboxdSync/Logs` endpoint reads the most recent two main log files and returns lines tagged `LetterboxdSync` (last 500)
- UI tab with refresh, copy-to-clipboard, download as `.log`
- Per-user filter (drop-down populated from configured accounts; matches both Jellyfin username and Letterboxd username)
- Free-text filter (e.g. type a film title)
- **Privacy**: review text is no longer logged (was previously logged in full); passwords, cookies, and auth tokens were already not logged. Output is safe for users to share for support.

## Tests

- 16 new tests added (228 total, all passing)
- `FilmSummaryHelperTests`: covers `ExtractTmdbIdFromLinks` and `ExtractMemberRating` against real LB API response shapes (including malformed/missing fields)
- `GetDiaryFilmEntriesIntegrationTests`: end-to-end test of `/films` parsing including pagination, dedup of duplicate TMDb rows, and the assertion that the request hits `memberRelationship=Watched&include=MemberRelationship`
- Existing tests for `Helpers.LetterboxdToJellyfinRating` and `LetterboxdScraper.ExtractRatingFromContainer` already shipped with the rating helpers

## Test plan
- [x] Unit tests: 228/228 pass
- [x] Manual: post review with star rating via dashboard, confirm `UserData.Rating` set in DB and Jellyfin API response
- [x] Manual: clear rating, run diary import, confirm rating restored from LB
- [x] Manual: rate a film on LB without diary'ing it, run diary import, confirm rating syncs (Iron Man case)
- [x] Manual: visit Logs tab in dashboard, refresh/copy/download all work, per-user and text filters compose correctly
- [x] Manual: confirm review text no longer appears in logs
- [x] Reviewer to spot-check API endpoint switch is sensible (mainly: does the broader scope of `Watched` vs `LogEntries` break any existing assumption about diary import?)