### PR TITLE
Multi-account support: one Jellyfin user, many Letterboxd accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
       - name: Test
         # XPlat Code Coverage uses coverlet.collector (already a test-project dep)
         # to emit Cobertura XML under TestResults/<guid>/coverage.cobertura.xml.
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        # Integration tests are filtered out: they hit live Letterboxd and would
+        # skip silently here without secrets, but excluding them keeps the run
+        # honest about what was exercised. The integration.yml workflow runs them
+        # on demand with credentials wired in.
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults --filter "Category!=Integration"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,16 +1,22 @@
 name: Integration tests (live Letterboxd)
 
-# Manual-only. These tests hit real letterboxd.com using a dedicated test
-# account, write to its diary, and clean up after themselves. Cost is low but
-# non-zero (Cloudflare quota, account-side log entries that briefly exist).
-# Wire credentials at:
-#   Settings → Secrets and variables → Actions → New repository secret
-# Secrets used:
-#   LETTERBOXD_TEST_USERNAME  — required
-#   LETTERBOXD_TEST_PASSWORD  — required
-#   LETTERBOXD_TEST_RAW_COOKIES  — optional, only if Cloudflare 403s without them
+# Runs on every push to main, every PR, and on demand. Hits real letterboxd.com
+# using a dedicated test account, writes to its diary, and cleans up after itself.
+# Cost is low but non-zero (Cloudflare quota, brief diary residue mid-run).
+#
+# Secrets used (configure under Settings → Secrets and variables → Actions):
+#   LETTERBOXD_TEST_USERNAME    — required to actually run the tests
+#   LETTERBOXD_TEST_PASSWORD    — required to actually run the tests
+#   LETTERBOXD_TEST_RAW_COOKIES — optional, only if Cloudflare 403s without them
 #   LETTERBOXD_TEST_USER_AGENT  — optional, must match the browser the cookies came from
+#
+# Fork PRs do not have access to repo secrets and would otherwise fail the
+# workflow. The job below detects missing credentials up front and skips
+# (success exit) so external contributors aren't blocked.
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -31,16 +37,24 @@ jobs:
       - name: Build
         run: dotnet build -c Release --no-restore
 
+      - name: Check for credentials
+        id: creds
+        env:
+          LETTERBOXD_TEST_USERNAME: ${{ secrets.LETTERBOXD_TEST_USERNAME }}
+          LETTERBOXD_TEST_PASSWORD: ${{ secrets.LETTERBOXD_TEST_PASSWORD }}
+        run: |
+          if [ -n "$LETTERBOXD_TEST_USERNAME" ] && [ -n "$LETTERBOXD_TEST_PASSWORD" ]; then
+            echo "have_creds=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_creds=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Letterboxd test credentials not configured for this run (likely a fork PR or missing repo secrets). Integration tests skipped."
+          fi
+
       - name: Run integration tests
+        if: steps.creds.outputs.have_creds == 'true'
         env:
           LETTERBOXD_TEST_USERNAME: ${{ secrets.LETTERBOXD_TEST_USERNAME }}
           LETTERBOXD_TEST_PASSWORD: ${{ secrets.LETTERBOXD_TEST_PASSWORD }}
           LETTERBOXD_TEST_RAW_COOKIES: ${{ secrets.LETTERBOXD_TEST_RAW_COOKIES }}
           LETTERBOXD_TEST_USER_AGENT: ${{ secrets.LETTERBOXD_TEST_USER_AGENT }}
-        run: |
-          if [ -z "$LETTERBOXD_TEST_USERNAME" ] || [ -z "$LETTERBOXD_TEST_PASSWORD" ]; then
-            echo "::error::LETTERBOXD_TEST_USERNAME and LETTERBOXD_TEST_PASSWORD secrets are required."
-            echo "Set them under Settings → Secrets and variables → Actions on this repo."
-            exit 1
-          fi
-          dotnet test -c Release --no-build --verbosity normal --filter "Category=Integration"
+        run: dotnet test -c Release --no-build --verbosity normal --filter "Category=Integration"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,46 @@
+name: Integration tests (live Letterboxd)
+
+# Manual-only. These tests hit real letterboxd.com using a dedicated test
+# account, write to its diary, and clean up after themselves. Cost is low but
+# non-zero (Cloudflare quota, account-side log entries that briefly exist).
+# Wire credentials at:
+#   Settings → Secrets and variables → Actions → New repository secret
+# Secrets used:
+#   LETTERBOXD_TEST_USERNAME  — required
+#   LETTERBOXD_TEST_PASSWORD  — required
+#   LETTERBOXD_TEST_RAW_COOKIES  — optional, only if Cloudflare 403s without them
+#   LETTERBOXD_TEST_USER_AGENT  — optional, must match the browser the cookies came from
+on:
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore
+
+      - name: Run integration tests
+        env:
+          LETTERBOXD_TEST_USERNAME: ${{ secrets.LETTERBOXD_TEST_USERNAME }}
+          LETTERBOXD_TEST_PASSWORD: ${{ secrets.LETTERBOXD_TEST_PASSWORD }}
+          LETTERBOXD_TEST_RAW_COOKIES: ${{ secrets.LETTERBOXD_TEST_RAW_COOKIES }}
+          LETTERBOXD_TEST_USER_AGENT: ${{ secrets.LETTERBOXD_TEST_USER_AGENT }}
+        run: |
+          if [ -z "$LETTERBOXD_TEST_USERNAME" ] || [ -z "$LETTERBOXD_TEST_PASSWORD" ]; then
+            echo "::error::LETTERBOXD_TEST_USERNAME and LETTERBOXD_TEST_PASSWORD secrets are required."
+            echo "Set them under Settings → Secrets and variables → Actions on this repo."
+            exit 1
+          fi
+          dotnet test -c Release --no-build --verbosity normal --filter "Category=Integration"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ obj/
 *.nupkg
 release/
 .gstack/
+
+# Local-only secrets for integration tests. The integration test suite reads
+# Letterboxd credentials from environment variables; never commit them.
+.env
+.env.local
+*.env.local

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.11.3.0</Version>
-        <AssemblyVersion>1.11.3.0</AssemblyVersion>
-        <FileVersion>1.11.3.0</FileVersion>
+        <Version>1.12.0.0</Version>
+        <AssemblyVersion>1.12.0.0</AssemblyVersion>
+        <FileVersion>1.12.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/AccountExtensionsTests.cs
+++ b/LetterboxdSync.Tests/AccountExtensionsTests.cs
@@ -1,0 +1,255 @@
+using System.Linq;
+using LetterboxdSync.Configuration;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+public class AccountExtensionsTests
+{
+    private static PluginConfiguration MakeConfig(params Account[] accounts)
+    {
+        var c = new PluginConfiguration();
+        c.Accounts.AddRange(accounts);
+        return c;
+    }
+
+    private static Account MakeAccount(string userId, string lbUser, bool enabled = true, bool primary = false)
+        => new Account
+        {
+            UserJellyfinId = userId,
+            LetterboxdUsername = lbUser,
+            Enabled = enabled,
+            IsPrimary = primary
+        };
+
+    [Fact]
+    public void GetEnabledAccountsForUser_ReturnsOnlyEnabledMatching()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob", enabled: false),
+            MakeAccount("u2", "carol"),
+            MakeAccount("u1", "dan"));
+
+        var result = config.GetEnabledAccountsForUser("u1").ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, a => a.LetterboxdUsername == "alice");
+        Assert.Contains(result, a => a.LetterboxdUsername == "dan");
+    }
+
+    [Fact]
+    public void GetEnabledAccountsForUser_PrimaryFirst()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob"),
+            MakeAccount("u1", "carol", primary: true));
+
+        var ordered = config.GetEnabledAccountsForUser("u1").ToList();
+
+        Assert.Equal("carol", ordered[0].LetterboxdUsername);
+    }
+
+    [Fact]
+    public void GetEnabledAccountsForUser_UnknownUser_ReturnsEmpty()
+    {
+        var config = MakeConfig(MakeAccount("u1", "alice"));
+        Assert.Empty(config.GetEnabledAccountsForUser("u-other"));
+    }
+
+    [Fact]
+    public void GetEnabledAccountsForUser_EmptyUserId_ReturnsEmpty()
+    {
+        var config = MakeConfig(MakeAccount("u1", "alice"));
+        Assert.Empty(config.GetEnabledAccountsForUser(""));
+    }
+
+    [Fact]
+    public void GetPrimaryAccountForUser_ExplicitPrimary_Returned()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob", primary: true));
+
+        var primary = config.GetPrimaryAccountForUser("u1");
+
+        Assert.NotNull(primary);
+        Assert.Equal("bob", primary!.LetterboxdUsername);
+    }
+
+    [Fact]
+    public void GetPrimaryAccountForUser_NoExplicitPrimary_FallsBackToFirstEnabled()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice", enabled: false),
+            MakeAccount("u1", "bob"),
+            MakeAccount("u1", "carol"));
+
+        var primary = config.GetPrimaryAccountForUser("u1");
+
+        Assert.NotNull(primary);
+        Assert.Equal("bob", primary!.LetterboxdUsername);
+    }
+
+    [Fact]
+    public void GetPrimaryAccountForUser_NoAccounts_ReturnsNull()
+    {
+        var config = MakeConfig();
+        Assert.Null(config.GetPrimaryAccountForUser("u1"));
+    }
+
+    [Fact]
+    public void FindAccount_MatchingUsername_Returned()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob"));
+
+        var found = config.FindAccount("u1", "bob");
+
+        Assert.NotNull(found);
+        Assert.Equal("bob", found!.LetterboxdUsername);
+    }
+
+    [Fact]
+    public void FindAccount_CaseInsensitive()
+    {
+        var config = MakeConfig(MakeAccount("u1", "Alice"));
+        Assert.NotNull(config.FindAccount("u1", "alice"));
+        Assert.NotNull(config.FindAccount("u1", "ALICE"));
+    }
+
+    [Fact]
+    public void FindAccount_DisabledAccount_NotReturned()
+    {
+        var config = MakeConfig(MakeAccount("u1", "alice", enabled: false));
+        Assert.Null(config.FindAccount("u1", "alice"));
+    }
+
+    [Fact]
+    public void FindAccount_WrongUser_NotReturned()
+    {
+        var config = MakeConfig(MakeAccount("u1", "alice"));
+        Assert.Null(config.FindAccount("u2", "alice"));
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_NoPrimaryMarked_AutoPromotesFirst()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob"));
+
+        var changed = config.NormalisePrimaryFlags();
+
+        Assert.True(changed);
+        Assert.True(config.Accounts[0].IsPrimary);
+        Assert.False(config.Accounts[1].IsPrimary);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_OneAlreadyPrimary_NoChange()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u1", "bob", primary: true));
+
+        var changed = config.NormalisePrimaryFlags();
+
+        Assert.False(changed);
+        Assert.False(config.Accounts[0].IsPrimary);
+        Assert.True(config.Accounts[1].IsPrimary);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_MultiplePrimaries_DemotesExtras()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice", primary: true),
+            MakeAccount("u1", "bob", primary: true),
+            MakeAccount("u1", "carol", primary: true));
+
+        var changed = config.NormalisePrimaryFlags();
+
+        Assert.True(changed);
+        Assert.True(config.Accounts[0].IsPrimary);
+        Assert.False(config.Accounts[1].IsPrimary);
+        Assert.False(config.Accounts[2].IsPrimary);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_PerUserScoping_DoesNotCrossUsers()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice", primary: true),
+            MakeAccount("u2", "bob"),
+            MakeAccount("u2", "carol"));
+
+        config.NormalisePrimaryFlags();
+
+        Assert.True(config.Accounts[0].IsPrimary);
+        // u2 had no primary, so u2's first account should now be primary.
+        Assert.True(config.Accounts[1].IsPrimary);
+        Assert.False(config.Accounts[2].IsPrimary);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_DisabledAccountsIgnored()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice", enabled: false, primary: true),
+            MakeAccount("u1", "bob"));
+
+        config.NormalisePrimaryFlags();
+
+        // Only the enabled account is considered for the per-user primary check,
+        // so bob (the only enabled one) becomes primary.
+        Assert.True(config.Accounts[1].IsPrimary);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_Idempotent()
+    {
+        var config = MakeConfig(
+            MakeAccount("u1", "alice"),
+            MakeAccount("u2", "bob"));
+
+        var firstRun = config.NormalisePrimaryFlags();
+        var secondRun = config.NormalisePrimaryFlags();
+
+        Assert.True(firstRun);
+        Assert.False(secondRun);
+    }
+
+    [Fact]
+    public void GetPlaylistName_DefaultPattern()
+    {
+        var account = MakeAccount("u1", "8bitproxy");
+        Assert.Equal("Letterboxd Watchlist (8bitproxy)", account.GetPlaylistName());
+    }
+
+    [Fact]
+    public void GetPlaylistName_OverrideUsed()
+    {
+        var account = MakeAccount("u1", "8bitproxy");
+        account.PlaylistName = "My Movies";
+        Assert.Equal("My Movies", account.GetPlaylistName());
+    }
+
+    [Fact]
+    public void GetPlaylistName_OverrideTrimmed()
+    {
+        var account = MakeAccount("u1", "8bitproxy");
+        account.PlaylistName = "  Padded  ";
+        Assert.Equal("Padded", account.GetPlaylistName());
+    }
+
+    [Fact]
+    public void GetPlaylistName_BlankOverrideFallsBackToDefault()
+    {
+        var account = MakeAccount("u1", "8bitproxy");
+        account.PlaylistName = "   ";
+        Assert.Equal("Letterboxd Watchlist (8bitproxy)", account.GetPlaylistName());
+    }
+}

--- a/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
+++ b/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
@@ -1,24 +1,56 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace LetterboxdSync.Tests.Integration;
 
 /// <summary>
-/// Live integration tests that talk to letterboxd.com using a real account. Skipped
+/// Live integration tests against letterboxd.com using a real account. Skipped
 /// unless LETTERBOXD_TEST_USERNAME and LETTERBOXD_TEST_PASSWORD are set on the
-/// environment — see Integration/README.md for setup. Tests are read-only so they
-/// can be rerun without polluting the account's diary. Network-dependent and slower
-/// than the unit suite: run with `dotnet test --filter Category=Integration`.
+/// environment — see Integration/README.md for setup. Read tests are residue-free;
+/// write tests use a self-cleanup helper on LetterboxdApiClient (see
+/// DeleteAllLogEntriesForFilmAsync) so the test account stays predictable across
+/// runs. Network-dependent and slower than the unit suite: run with
+/// `dotnet test --filter Category=Integration`.
 /// </summary>
 [Trait("Category", "Integration")]
 public class LetterboxdLiveTests
 {
+    private readonly ITestOutputHelper _output;
+    private readonly ILogger _logger;
+
+    public LetterboxdLiveTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _logger = new XunitLogger(output);
+    }
+
+    private sealed class XunitLogger : ILogger
+    {
+        private readonly ITestOutputHelper _output;
+        public XunitLogger(ITestOutputHelper output) { _output = output; }
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            try { _output.WriteLine($"[{logLevel}] {formatter(state, exception)}"); } catch { }
+        }
+        private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
+    }
+
     private const string EnvUser = "LETTERBOXD_TEST_USERNAME";
     private const string EnvPass = "LETTERBOXD_TEST_PASSWORD";
     private const string EnvCookies = "LETTERBOXD_TEST_RAW_COOKIES";
     private const string EnvUserAgent = "LETTERBOXD_TEST_USER_AGENT";
+
+    // Stable, well-known films used as fixtures. If Letterboxd ever stops mapping
+    // these TMDb IDs we have bigger problems than these tests.
+    private const int TmdbPulpFiction = 680;       // movie/680
+    private const int TmdbHijack = 198102;          // tv/198102 — same numeric id as a niche movie; see issue #34
 
     private static (string user, string pass, string? cookies, string? ua) RequireCreds()
     {
@@ -31,12 +63,37 @@ public class LetterboxdLiveTests
             Environment.GetEnvironmentVariable(EnvUserAgent));
     }
 
-    private static async Task<ILetterboxdService> AuthenticateAsync()
+    private async Task<ILetterboxdService> AuthenticateAsync()
     {
         var (user, pass, cookies, ua) = RequireCreds();
         return await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-            user, pass, cookies, NullLogger.Instance, ua).ConfigureAwait(false);
+            user, pass, cookies, _logger, ua).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Construct a LetterboxdApiClient directly (bypassing the factory) so write tests
+    /// can call the internal DeleteAllLogEntriesForFilmAsync cleanup helper. Skips the
+    /// caller if the test account can't authenticate via the API path (would fall back
+    /// to scraping in production; the helper isn't available there).
+    /// </summary>
+    private async Task<LetterboxdApiClient> AuthenticateApiClientAsync()
+    {
+        var (user, pass, _, _) = RequireCreds();
+        var client = new LetterboxdApiClient(_logger);
+        try
+        {
+            await client.AuthenticateAsync(user, pass).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            client.Dispose();
+            Skip.If(true, $"Skipping write test: API auth failed for the test account ({ex.Message}). " +
+                          "Write tests need the API path; the scraping fallback doesn't expose a delete helper.");
+        }
+        return client;
+    }
+
+    // ----- Read-only tests (residue-free) -----
 
     [SkippableFact]
     public async Task Authenticate_ValidCredentials_ReturnsUsableService()
@@ -46,19 +103,80 @@ public class LetterboxdLiveTests
     }
 
     /// <summary>
-    /// Pulp Fiction (TMDb 680) is a stable, well-known film. If Letterboxd's mapping
-    /// ever changes for it we have bigger problems than this test failing.
+    /// API auth with bad credentials throws. The factory wraps this in a silent
+    /// fallback to scraping (documented behavior), so this asserts against the
+    /// API client directly. Uses a fresh nonexistent username on every run so the
+    /// client's static TokenCache (which is keyed by username) can't hide the
+    /// failure with a leftover good token from another test.
     /// </summary>
+    [SkippableFact]
+    public async Task ApiClient_AuthenticateWithBadCredentials_Throws()
+    {
+        RequireCreds(); // Still gate on the env var pair being present.
+        using var client = new LetterboxdApiClient(_logger);
+        var noSuchUser = "integration-test-noexist-" + Guid.NewGuid().ToString("N");
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            client.AuthenticateAsync(noSuchUser, "irrelevant"));
+    }
+
     [SkippableFact]
     public async Task LookupFilmByTmdbId_KnownFilm_ReturnsSlug()
     {
         using var service = await AuthenticateAsync().ConfigureAwait(false);
 
-        var film = await service.LookupFilmByTmdbIdAsync(680).ConfigureAwait(false);
+        var film = await service.LookupFilmByTmdbIdAsync(TmdbPulpFiction).ConfigureAwait(false);
 
         Assert.NotNull(film);
         Assert.False(string.IsNullOrWhiteSpace(film.Slug), "Slug should be populated");
         Assert.Contains("pulp-fiction", film.Slug, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task LookupFilmByTmdbId_UnknownId_ThrowsOrReturnsEmpty()
+    {
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        // 999_999_999 is well outside TMDb's allocated id range. Letterboxd should
+        // either return no match (FilmResult with empty slug) or throw. Either is
+        // a valid signal to upstream callers; this asserts we don't silently return
+        // a real film.
+        try
+        {
+            var film = await service.LookupFilmByTmdbIdAsync(999_999_999).ConfigureAwait(false);
+            Assert.True(string.IsNullOrWhiteSpace(film?.Slug),
+                "Lookup of unknown TMDb id should not return a real film slug");
+        }
+        catch (Exception)
+        {
+            // Throw is also acceptable — production callers wrap and log.
+        }
+    }
+
+    /// <summary>
+    /// Regression for issue #34: TMDb has independent id namespaces for movies and
+    /// TV. tmdb id 198102 is the TV show "Hijack" but also exists as a different
+    /// movie. The lookup is movie-scoped; either it returns the matching movie or
+    /// it returns no match. It MUST NOT silently return a TV show as a film.
+    /// </summary>
+    [SkippableFact]
+    public async Task LookupFilmByTmdbId_TvShowId_DoesNotReturnTvShow()
+    {
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        try
+        {
+            var film = await service.LookupFilmByTmdbIdAsync(TmdbHijack).ConfigureAwait(false);
+            // If a result comes back, the slug must not look like the Apple TV+ show.
+            // The TV show is "Hijack (2023 TV series)"; if Letterboxd returns it,
+            // the slug would contain "hijack" with a year that matches the TV release.
+            // Stronger assertion: the slug should not equal the TV show's known slug.
+            if (film != null && !string.IsNullOrWhiteSpace(film.Slug))
+                Assert.DoesNotContain("hijack-2023", film.Slug, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            // No-match throw is fine.
+        }
     }
 
     [SkippableFact]
@@ -68,9 +186,6 @@ public class LetterboxdLiveTests
         using var service = await AuthenticateAsync().ConfigureAwait(false);
 
         var ids = await service.GetWatchlistTmdbIdsAsync(user).ConfigureAwait(false);
-
-        // Test account watchlist may be empty; we only assert the call succeeds and
-        // returns a non-null list. Membership is the next test's job.
         Assert.NotNull(ids);
     }
 
@@ -81,24 +196,116 @@ public class LetterboxdLiveTests
         using var service = await AuthenticateAsync().ConfigureAwait(false);
 
         var entries = await service.GetDiaryFilmEntriesAsync(user).ConfigureAwait(false);
-
         Assert.NotNull(entries);
     }
 
-    /// <summary>
-    /// Diary info for a known film returns a well-formed shape even when the user
-    /// has never logged the film (LastDate is null in that case). Exercises the
-    /// same code path that the same-day duplicate check uses in production.
-    /// </summary>
+    [SkippableFact]
+    public async Task GetDiaryTmdbIds_ReturnsListWithoutThrowing()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        var ids = await service.GetDiaryTmdbIdsAsync(user).ConfigureAwait(false);
+        Assert.NotNull(ids);
+    }
+
     [SkippableFact]
     public async Task GetDiaryInfo_KnownFilm_ReturnsShape()
     {
         var (user, _, _, _) = RequireCreds();
         using var service = await AuthenticateAsync().ConfigureAwait(false);
 
-        var film = await service.LookupFilmByTmdbIdAsync(680).ConfigureAwait(false);
+        var film = await service.LookupFilmByTmdbIdAsync(TmdbPulpFiction).ConfigureAwait(false);
         var info = await service.GetDiaryInfoAsync(film.FilmId, user).ConfigureAwait(false);
 
         Assert.NotNull(info);
+    }
+
+    // ----- Write tests with self-cleanup (API path only) -----
+
+    /// <summary>
+    /// Marks Pulp Fiction as watched, asserts it appears in the diary, then deletes
+    /// every log entry for that film via the internal cleanup helper. Combined,
+    /// this exercises the full write+read+delete loop the production sync depends on.
+    /// </summary>
+    [SkippableFact]
+    public async Task MarkAsWatched_KnownFilm_AppearsInDiaryThenCleansUp()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var client = await AuthenticateApiClientAsync().ConfigureAwait(false);
+
+        var film = await client.LookupFilmByTmdbIdAsync(TmdbPulpFiction).ConfigureAwait(false);
+        try
+        {
+            await client.MarkAsWatchedAsync(
+                filmSlug: film.Slug,
+                filmId: film.FilmId,
+                date: DateTime.Now,
+                liked: false,
+                productionId: null,
+                rewatch: false,
+                rating: null).ConfigureAwait(false);
+
+            // Letterboxd's diary is eventually consistent on read; give it a moment.
+            await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+            var info = await client.GetDiaryInfoAsync(film.FilmId, user).ConfigureAwait(false);
+            Assert.NotNull(info);
+            Assert.True(info.LastDate.HasValue,
+                $"Expected diary entry to be visible after MarkAsWatched (LastDate was null for {film.Slug})");
+            Assert.Equal(DateTime.Now.Date, info.LastDate!.Value.Date);
+        }
+        finally
+        {
+            // Always clean up, even on assertion failure, so the next run starts fresh.
+            await client.DeleteAllLogEntriesForFilmAsync(film.FilmId).ConfigureAwait(false);
+        }
+
+        // Confirm cleanup actually removed the entry.
+        await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        var afterCleanup = await client.GetDiaryInfoAsync(film.FilmId, user).ConfigureAwait(false);
+        Assert.False(afterCleanup.LastDate.HasValue,
+            $"Cleanup should have removed all diary entries for {film.Slug}");
+    }
+
+    /// <summary>
+    /// Posts a review with a unique marker in the text, asserts it appears in the
+    /// user's diary entries with that exact text, then cleans up. Exercises both
+    /// the review-write path and the diary-read path together.
+    /// </summary>
+    [SkippableFact]
+    public async Task PostReview_KnownFilm_AppearsInDiaryThenCleansUp()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var client = await AuthenticateApiClientAsync().ConfigureAwait(false);
+
+        var film = await client.LookupFilmByTmdbIdAsync(TmdbPulpFiction).ConfigureAwait(false);
+        var marker = $"integration-test-{Guid.NewGuid():N}";
+
+        try
+        {
+            await client.PostReviewAsync(
+                filmSlug: film.Slug,
+                reviewText: marker,
+                containsSpoilers: false,
+                isRewatch: false,
+                date: null,
+                rating: 3.5,
+                tmdbId: TmdbPulpFiction).ConfigureAwait(false);
+
+            await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+            var entries = await client.GetDiaryFilmEntriesAsync(user).ConfigureAwait(false);
+            var ours = entries.FirstOrDefault(e => e.TmdbId == TmdbPulpFiction);
+            Assert.NotNull(ours);
+            // We don't assert on the review text contents because GetDiaryFilmEntriesAsync
+            // returns metadata-only DiaryFilmEntry (no review body); the round-trip is
+            // validated by the entry being present and the rating being applied.
+            Assert.Equal(3.5, ours!.Rating);
+        }
+        finally
+        {
+            await client.DeleteAllLogEntriesForFilmAsync(film.FilmId).ConfigureAwait(false);
+        }
     }
 }

--- a/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
+++ b/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests.Integration;
+
+/// <summary>
+/// Live integration tests that talk to letterboxd.com using a real account. Skipped
+/// unless LETTERBOXD_TEST_USERNAME and LETTERBOXD_TEST_PASSWORD are set on the
+/// environment — see Integration/README.md for setup. Tests are read-only so they
+/// can be rerun without polluting the account's diary. Network-dependent and slower
+/// than the unit suite: run with `dotnet test --filter Category=Integration`.
+/// </summary>
+[Trait("Category", "Integration")]
+public class LetterboxdLiveTests
+{
+    private const string EnvUser = "LETTERBOXD_TEST_USERNAME";
+    private const string EnvPass = "LETTERBOXD_TEST_PASSWORD";
+    private const string EnvCookies = "LETTERBOXD_TEST_RAW_COOKIES";
+    private const string EnvUserAgent = "LETTERBOXD_TEST_USER_AGENT";
+
+    private static (string user, string pass, string? cookies, string? ua) RequireCreds()
+    {
+        var user = Environment.GetEnvironmentVariable(EnvUser);
+        var pass = Environment.GetEnvironmentVariable(EnvPass);
+        Skip.If(string.IsNullOrWhiteSpace(user) || string.IsNullOrWhiteSpace(pass),
+            $"Skipping live test: set {EnvUser} and {EnvPass} to run. See LetterboxdSync.Tests/Integration/README.md");
+        return (user!, pass!,
+            Environment.GetEnvironmentVariable(EnvCookies),
+            Environment.GetEnvironmentVariable(EnvUserAgent));
+    }
+
+    private static async Task<ILetterboxdService> AuthenticateAsync()
+    {
+        var (user, pass, cookies, ua) = RequireCreds();
+        return await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+            user, pass, cookies, NullLogger.Instance, ua).ConfigureAwait(false);
+    }
+
+    [SkippableFact]
+    public async Task Authenticate_ValidCredentials_ReturnsUsableService()
+    {
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+        Assert.NotNull(service);
+    }
+
+    /// <summary>
+    /// Pulp Fiction (TMDb 680) is a stable, well-known film. If Letterboxd's mapping
+    /// ever changes for it we have bigger problems than this test failing.
+    /// </summary>
+    [SkippableFact]
+    public async Task LookupFilmByTmdbId_KnownFilm_ReturnsSlug()
+    {
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        var film = await service.LookupFilmByTmdbIdAsync(680).ConfigureAwait(false);
+
+        Assert.NotNull(film);
+        Assert.False(string.IsNullOrWhiteSpace(film.Slug), "Slug should be populated");
+        Assert.Contains("pulp-fiction", film.Slug, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task GetWatchlistTmdbIds_ReturnsListWithoutThrowing()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        var ids = await service.GetWatchlistTmdbIdsAsync(user).ConfigureAwait(false);
+
+        // Test account watchlist may be empty; we only assert the call succeeds and
+        // returns a non-null list. Membership is the next test's job.
+        Assert.NotNull(ids);
+    }
+
+    [SkippableFact]
+    public async Task GetDiaryFilmEntries_ReturnsListWithoutThrowing()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        var entries = await service.GetDiaryFilmEntriesAsync(user).ConfigureAwait(false);
+
+        Assert.NotNull(entries);
+    }
+
+    /// <summary>
+    /// Diary info for a known film returns a well-formed shape even when the user
+    /// has never logged the film (LastDate is null in that case). Exercises the
+    /// same code path that the same-day duplicate check uses in production.
+    /// </summary>
+    [SkippableFact]
+    public async Task GetDiaryInfo_KnownFilm_ReturnsShape()
+    {
+        var (user, _, _, _) = RequireCreds();
+        using var service = await AuthenticateAsync().ConfigureAwait(false);
+
+        var film = await service.LookupFilmByTmdbIdAsync(680).ConfigureAwait(false);
+        var info = await service.GetDiaryInfoAsync(film.FilmId, user).ConfigureAwait(false);
+
+        Assert.NotNull(info);
+    }
+}

--- a/LetterboxdSync.Tests/Integration/README.md
+++ b/LetterboxdSync.Tests/Integration/README.md
@@ -65,16 +65,20 @@ themselves if the API auth fails for the test account.
 
 ## CI
 
-A manual-only GitHub Actions workflow lives at
-`.github/workflows/integration.yml`. It runs on `workflow_dispatch` (Actions
-tab → "Integration tests (live Letterboxd)" → Run workflow), pulling
-`LETTERBOXD_TEST_USERNAME`/`PASSWORD` from repository secrets. The default
-`ci.yml` workflow filters integration tests out so push/PR runs stay green
-without secrets.
+A GitHub Actions workflow at `.github/workflows/integration.yml` runs the
+suite on every push to `main`, every PR, and on demand
+(`workflow_dispatch`). Credentials come from repository secrets. The default
+`ci.yml` workflow filters integration tests out so the unit run stays the
+fast-feedback path.
 
 To wire up:
 
 1. Repo Settings → Secrets and variables → Actions → New repository secret
 2. Add `LETTERBOXD_TEST_USERNAME` and `LETTERBOXD_TEST_PASSWORD` (and
    optionally `LETTERBOXD_TEST_RAW_COOKIES` / `LETTERBOXD_TEST_USER_AGENT`)
-3. Trigger via the Actions tab when you want a live run
+3. Push or open a PR — the workflow runs automatically
+
+If the secrets aren't configured (e.g. on a fork PR, where GitHub doesn't
+forward repo secrets), the workflow detects the missing credentials and
+skips with a notice instead of failing. External contributors aren't
+blocked.

--- a/LetterboxdSync.Tests/Integration/README.md
+++ b/LetterboxdSync.Tests/Integration/README.md
@@ -51,17 +51,30 @@ are for pre-release sanity checks and reproducing live bugs.
 - Do not paste credentials into commit messages, PR descriptions, issues, or
   any markdown that lands in the repo or its history.
 
-## Why no write tests yet
+## Write tests
 
-`ILetterboxdService` has no `DeleteDiaryEntry` API, so a test that posts a
-diary entry leaves residue on the test account between runs. Write coverage is
-deferred until either (a) we add a delete path, or (b) we accept periodic
-manual cleanup on the test account. Until then, the live tests are read-only
-(`Authenticate`, `LookupFilmByTmdbId`, `GetWatchlistTmdbIds`,
-`GetDiaryFilmEntries`, `GetDiaryInfo`).
+Write coverage uses an internal cleanup helper (`LetterboxdApiClient.
+DeleteAllLogEntriesForFilmAsync`, exposed via `InternalsVisibleTo`) that
+removes the diary entries the test created via `DELETE /log-entry/{id}`.
+Tests are wrapped in `try/finally` so cleanup runs even on assertion failure.
+The test account stays predictable across runs.
+
+Note: cleanup is API-only. The scraping fallback path in
+`ScrapingLetterboxdService` does not implement delete; write tests will skip
+themselves if the API auth fails for the test account.
 
 ## CI
 
-These tests do **not** run in GitHub Actions today. Wiring them up requires
-adding the credentials as repository secrets and adjusting `release.yml` /
-the CI workflow. Treat that as a separate change.
+A manual-only GitHub Actions workflow lives at
+`.github/workflows/integration.yml`. It runs on `workflow_dispatch` (Actions
+tab → "Integration tests (live Letterboxd)" → Run workflow), pulling
+`LETTERBOXD_TEST_USERNAME`/`PASSWORD` from repository secrets. The default
+`ci.yml` workflow filters integration tests out so push/PR runs stay green
+without secrets.
+
+To wire up:
+
+1. Repo Settings → Secrets and variables → Actions → New repository secret
+2. Add `LETTERBOXD_TEST_USERNAME` and `LETTERBOXD_TEST_PASSWORD` (and
+   optionally `LETTERBOXD_TEST_RAW_COOKIES` / `LETTERBOXD_TEST_USER_AGENT`)
+3. Trigger via the Actions tab when you want a live run

--- a/LetterboxdSync.Tests/Integration/README.md
+++ b/LetterboxdSync.Tests/Integration/README.md
@@ -1,0 +1,67 @@
+# Integration tests
+
+These talk to a real Letterboxd account over the network and are **skipped by
+default**. They exist so a tagged-by-hand `dotnet test` run can verify the
+plugin's auth, lookup, and read paths still work end-to-end against
+production Letterboxd HTML/API surfaces that the unit suite mocks out.
+
+## Why they're skipped by default
+
+- Network-dependent and slow (Cloudflare warm-up, real HTTP round-trips).
+- Require a Letterboxd account credential, which can't live in the public repo.
+- Sometimes throttled by Cloudflare; we don't want CI to redden over that.
+
+The unit suite (currently ~470 tests) gives the routine feedback loop; these
+are for pre-release sanity checks and reproducing live bugs.
+
+## Setup
+
+1. Create or pick a Letterboxd account dedicated to testing (do not use a real
+   personal account — these tests are read-only today, but the credential will
+   end up in shell history / env state on whatever machine you run them on).
+2. Export the credentials in the shell that will run `dotnet test`:
+
+   ```bash
+   export LETTERBOXD_TEST_USERNAME="your-test-account"
+   export LETTERBOXD_TEST_PASSWORD="your-test-password"
+
+   # Optional — supply if Cloudflare 403s on raw login
+   export LETTERBOXD_TEST_RAW_COOKIES="cf_clearance=...; letterboxd.session=..."
+   export LETTERBOXD_TEST_USER_AGENT="Mozilla/5.0 ..."
+   ```
+
+3. Run the integration suite:
+
+   ```bash
+   dotnet test -c Release --filter Category=Integration
+   ```
+
+   Run everything except integration tests:
+
+   ```bash
+   dotnet test -c Release --filter "Category!=Integration"
+   ```
+
+## Security posture
+
+- Credentials are read from environment variables only. There is **no** code
+  path in this repo that loads them from a file checked into git.
+- `.env`, `.env.local`, and `*.env.local` are gitignored at the repo root in
+  case you want to source a local file (e.g. `set -a && source .env && set +a`).
+- Do not paste credentials into commit messages, PR descriptions, issues, or
+  any markdown that lands in the repo or its history.
+
+## Why no write tests yet
+
+`ILetterboxdService` has no `DeleteDiaryEntry` API, so a test that posts a
+diary entry leaves residue on the test account between runs. Write coverage is
+deferred until either (a) we add a delete path, or (b) we accept periodic
+manual cleanup on the test account. Until then, the live tests are read-only
+(`Authenticate`, `LookupFilmByTmdbId`, `GetWatchlistTmdbIds`,
+`GetDiaryFilmEntries`, `GetDiaryInfo`).
+
+## CI
+
+These tests do **not** run in GitHub Actions today. Wiring them up requires
+adding the credentials as repository secrets and adjusting `release.yml` /
+the CI workflow. Treat that as a separate change.

--- a/LetterboxdSync.Tests/LetterboxdControllerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdControllerTests.cs
@@ -303,7 +303,11 @@ public class LetterboxdControllerTests
         var result = h.Controller.StartWatchlistSync();
 
         Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Contains("Watchlist sync is disabled", Prop<string>(result, "error") ?? string.Empty);
+        // Without a specific letterboxdUsername, the multi-account controller returns
+        // the broader "no eligible accounts" error rather than the per-account
+        // "Watchlist sync is disabled" message.
+        Assert.Contains("No enabled accounts with watchlist sync",
+            Prop<string>(result, "error") ?? string.Empty);
     }
 
     [Fact]
@@ -375,7 +379,9 @@ public class LetterboxdControllerTests
         });
 
         Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Contains("No Letterboxd account configured", Prop<string>(result, "error") ?? string.Empty);
+        // Multi-account controller pluralises ("No Letterboxd accounts configured"),
+        // singular form remained on main pre-multi-account; assert on the shared prefix.
+        Assert.Contains("No Letterboxd account", Prop<string>(result, "error") ?? string.Empty);
     }
 
     [Fact]

--- a/LetterboxdSync.Tests/LetterboxdControllerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdControllerTests.cs
@@ -235,6 +235,184 @@ public class LetterboxdControllerTests
         Assert.True(other.Enabled);
     }
 
+    // ----- GetAccounts / PutAccounts (multi-account, per-user) -----
+
+    [Fact]
+    public void GetAccounts_NoUserClaim_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: null);
+
+        var result = h.Controller.GetAccounts();
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetAccounts_ReturnsOnlyCallingUsersAccounts()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "mine-a");
+        h.AddAccount(UserId, "mine-b");
+        h.AddAccount(OtherUserId, "someone-else");
+
+        var result = h.Controller.GetAccounts();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var accounts = Prop<System.Collections.IEnumerable>(ok, "accounts")!;
+        var list = accounts.Cast<object>().ToList();
+        Assert.Equal(2, list.Count);
+        var usernames = list.Select(a => a.GetType().GetProperty("letterboxdUsername")!.GetValue(a)?.ToString()).ToHashSet();
+        Assert.Contains("mine-a", usernames);
+        Assert.Contains("mine-b", usernames);
+        Assert.DoesNotContain("someone-else", usernames);
+    }
+
+    [Fact]
+    public void GetAccounts_OrdersPrimaryFirst()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "secondary");
+        var primary = h.AddAccount(UserId, "primary");
+        primary.IsPrimary = true;
+
+        var result = h.Controller.GetAccounts();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var accounts = Prop<System.Collections.IEnumerable>(ok, "accounts")!;
+        var first = accounts.Cast<object>().First();
+        Assert.Equal("primary", first.GetType().GetProperty("letterboxdUsername")!.GetValue(first));
+    }
+
+    [Fact]
+    public void PutAccounts_NoUserClaim_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: null);
+
+        var result = h.Controller.PutAccounts(new AccountsUpdateRequest());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void PutAccounts_NullAccountsList_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        var result = h.Controller.PutAccounts(new AccountsUpdateRequest { Accounts = null! });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void PutAccounts_EmptyUsername_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        var result = h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new()
+            {
+                new AccountUpdateRequest { LetterboxdUsername = "ok" },
+                new AccountUpdateRequest { LetterboxdUsername = "   " }
+            }
+        });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("#2", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    [Fact]
+    public void PutAccounts_ReplacesCallingUsersAccounts()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "old-a");
+        h.AddAccount(UserId, "old-b");
+
+        var result = h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new()
+            {
+                new AccountUpdateRequest { LetterboxdUsername = "new-1", Enabled = true, IsPrimary = true },
+                new AccountUpdateRequest { LetterboxdUsername = "new-2", Enabled = true }
+            }
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+        var mine = h.Config.Accounts.Where(a => a.UserJellyfinId == UserId).ToList();
+        Assert.Equal(2, mine.Count);
+        var names = mine.Select(a => a.LetterboxdUsername).ToHashSet();
+        Assert.Equal(new[] { "new-1", "new-2" }.ToHashSet(), names);
+    }
+
+    [Fact]
+    public void PutAccounts_PreservesOtherUsersAccounts()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(OtherUserId, "untouched", enabled: true);
+
+        h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new() { new AccountUpdateRequest { LetterboxdUsername = "mine", Enabled = true } }
+        });
+
+        var other = h.Config.Accounts.Single(a => a.UserJellyfinId == OtherUserId);
+        Assert.Equal("untouched", other.LetterboxdUsername);
+        Assert.True(other.Enabled);
+    }
+
+    [Fact]
+    public void PutAccounts_StampsCallingUserIdOntoEveryRow()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        // The request shape doesn't even carry UserJellyfinId, but a hostile or
+        // confused client might try to spoof one via reflection or a custom payload.
+        // The endpoint must overwrite to the calling user's id regardless.
+        h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new() { new AccountUpdateRequest { LetterboxdUsername = "mine", Enabled = true } }
+        });
+
+        var mine = h.Config.Accounts.Single(a => a.LetterboxdUsername == "mine");
+        Assert.Equal(UserId, mine.UserJellyfinId);
+    }
+
+    [Fact]
+    public void PutAccounts_NormalisesPrimaryFlag_AutoPromotesFirstWhenNoneMarked()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new()
+            {
+                new AccountUpdateRequest { LetterboxdUsername = "a", Enabled = true },
+                new AccountUpdateRequest { LetterboxdUsername = "b", Enabled = true }
+            }
+        });
+
+        var mine = h.Config.Accounts.Where(a => a.UserJellyfinId == UserId).ToList();
+        Assert.Single(mine.Where(a => a.IsPrimary));
+    }
+
+    [Fact]
+    public void PutAccounts_NormalisesPrimaryFlag_DemotesExtras()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        h.Controller.PutAccounts(new AccountsUpdateRequest
+        {
+            Accounts = new()
+            {
+                new AccountUpdateRequest { LetterboxdUsername = "a", Enabled = true, IsPrimary = true },
+                new AccountUpdateRequest { LetterboxdUsername = "b", Enabled = true, IsPrimary = true }
+            }
+        });
+
+        var mine = h.Config.Accounts.Where(a => a.UserJellyfinId == UserId).ToList();
+        Assert.Single(mine.Where(a => a.IsPrimary));
+    }
+
     // ----- StartSync -----
 
     [Fact]

--- a/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
+++ b/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LetterboxdSync.Tests/MultiAccountContractTests.cs
+++ b/LetterboxdSync.Tests/MultiAccountContractTests.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using LetterboxdSync.Api;
+using LetterboxdSync.Configuration;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Wiring contracts for the multi-account feature: data fields propagate end-to-end
+/// across the Account model, the API request DTOs, and the review fan-out request.
+/// These are intentionally simple, since the runtime fan-out behaviour relies on
+/// Jellyfin services that are awkward to mock at unit-test scope.
+/// </summary>
+public class MultiAccountContractTests
+{
+    [Fact]
+    public void Account_IsPrimary_DefaultsFalse()
+    {
+        var account = new Account();
+        Assert.False(account.IsPrimary);
+    }
+
+    [Fact]
+    public void Account_PlaylistName_DefaultsNull()
+    {
+        var account = new Account();
+        Assert.Null(account.PlaylistName);
+    }
+
+    [Fact]
+    public void AccountUpdateRequest_HasIsPrimaryField()
+    {
+        var props = typeof(AccountUpdateRequest).GetProperties();
+        Assert.Contains(props, p => p.Name == "IsPrimary" && p.PropertyType == typeof(bool));
+    }
+
+    [Fact]
+    public void AccountUpdateRequest_HasPlaylistNameField()
+    {
+        var props = typeof(AccountUpdateRequest).GetProperties();
+        Assert.Contains(props, p => p.Name == "PlaylistName" && p.PropertyType == typeof(string));
+    }
+
+    [Fact]
+    public void ReviewRequest_HasLetterboxdUsernameField()
+    {
+        // The dashboard's "Post as" dropdown sends LetterboxdUsername; the controller
+        // uses it to target a single account. Without this field the dropdown would
+        // silently always fan out, breaking the per-account selection promise.
+        var props = typeof(ReviewRequest).GetProperties();
+        Assert.Contains(props, p => p.Name == "LetterboxdUsername" && p.PropertyType == typeof(string));
+    }
+
+    [Fact]
+    public void GetEnabledAccountsForUser_PrimaryWinsConflict()
+    {
+        // Models the diary-import merge contract: walking the helper's output in order
+        // and taking the first non-null rating for each TMDb ID gives "primary wins".
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account
+        {
+            UserJellyfinId = "u1", LetterboxdUsername = "secondary", Enabled = true
+        });
+        config.Accounts.Add(new Account
+        {
+            UserJellyfinId = "u1", LetterboxdUsername = "primary", Enabled = true, IsPrimary = true
+        });
+
+        var ordered = config.GetEnabledAccountsForUser("u1").ToList();
+
+        // Primary always emitted first, regardless of insertion order.
+        Assert.Equal("primary", ordered[0].LetterboxdUsername);
+        Assert.Equal("secondary", ordered[1].LetterboxdUsername);
+    }
+
+    [Fact]
+    public void NormalisePrimaryFlags_RunsOnPutAccountSemantics()
+    {
+        // Sanity-check: the controller's PutAccount calls NormalisePrimaryFlags after
+        // applying request fields. Two enabled accounts with no primary marked should
+        // collapse to exactly one primary on the next save cycle.
+        var config = new PluginConfiguration();
+        config.Accounts.Add(new Account { UserJellyfinId = "u1", LetterboxdUsername = "a", Enabled = true });
+        config.Accounts.Add(new Account { UserJellyfinId = "u1", LetterboxdUsername = "b", Enabled = true });
+
+        config.NormalisePrimaryFlags();
+
+        Assert.Single(config.Accounts.Where(a => a.IsPrimary));
+    }
+}

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -29,6 +29,10 @@ public class AccountUpdateRequest
     public bool SkipPreviouslySynced { get; set; } = true;
 
     public bool StopOnFailure { get; set; }
+
+    public bool IsPrimary { get; set; }
+
+    public string? PlaylistName { get; set; }
 }
 
 public class TestConnectionRequest

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace LetterboxdSync.Api;
 
 public class AccountUpdateRequest
@@ -33,6 +35,16 @@ public class AccountUpdateRequest
     public bool IsPrimary { get; set; }
 
     public string? PlaylistName { get; set; }
+}
+
+/// <summary>
+/// Bulk-replace payload for the per-user multi-account endpoint. The caller submits
+/// the full set of accounts they want for themselves; the server ignores any
+/// UserJellyfinId in the request and stamps every entry with the calling user.
+/// </summary>
+public class AccountsUpdateRequest
+{
+    public List<AccountUpdateRequest> Accounts { get; set; } = new List<AccountUpdateRequest>();
 }
 
 public class TestConnectionRequest

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -82,7 +82,7 @@ public class LetterboxdController : ControllerBase
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public ActionResult StartSync()
+    public ActionResult StartSync([FromQuery] string? letterboxdUsername = null)
     {
         var userId = GetCurrentUserId();
         if (string.IsNullOrEmpty(userId))
@@ -91,17 +91,26 @@ public class LetterboxdController : ControllerBase
         if (LetterboxdSyncRunner.IsRunning)
             return Conflict(new { error = "Sync already running" });
 
-        var account = Config.Accounts.FirstOrDefault(a => a.Enabled && a.UserJellyfinId == userId);
-        if (account == null)
-            return BadRequest(new { error = "No enabled Letterboxd account is configured for your user" });
+        // When letterboxdUsername is supplied, target only that account. Otherwise the
+        // runner fans out across all enabled accounts for this Jellyfin user.
+        if (!string.IsNullOrEmpty(letterboxdUsername))
+        {
+            if (Config.FindAccount(userId, letterboxdUsername) == null)
+                return BadRequest(new { error = $"No enabled Letterboxd account '{letterboxdUsername}' for your user" });
+        }
+        else if (!Config.GetEnabledAccountsForUser(userId).Any())
+        {
+            return BadRequest(new { error = "No enabled Letterboxd accounts are configured for your user" });
+        }
 
         // Fire and forget. Errors during the run are logged by the runner; the UI polls /Progress.
         _ = Task.Run(async () =>
         {
             try
             {
-                await _syncRunner.TryRunForUserAsync(userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None)
-                    .ConfigureAwait(false);
+                await _syncRunner.TryRunForUserAsync(
+                    userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None,
+                    letterboxdUsername).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -121,7 +130,7 @@ public class LetterboxdController : ControllerBase
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public ActionResult StartWatchlistSync()
+    public ActionResult StartWatchlistSync([FromQuery] string? letterboxdUsername = null)
     {
         var userId = GetCurrentUserId();
         if (string.IsNullOrEmpty(userId))
@@ -130,19 +139,29 @@ public class LetterboxdController : ControllerBase
         if (LetterboxdSyncRunner.IsRunning)
             return Conflict(new { error = "Sync already running" });
 
-        var account = Config.Accounts.FirstOrDefault(a => a.Enabled && a.UserJellyfinId == userId);
-        if (account == null)
-            return BadRequest(new { error = "No enabled Letterboxd account is configured for your user" });
-
-        if (!account.EnableWatchlistSync)
-            return BadRequest(new { error = "Watchlist sync is disabled for your account; enable it in Settings first" });
+        // Validate up front so we can return a 400 instead of starting an empty run.
+        if (!string.IsNullOrEmpty(letterboxdUsername))
+        {
+            var account = Config.FindAccount(userId, letterboxdUsername);
+            if (account == null)
+                return BadRequest(new { error = $"No enabled Letterboxd account '{letterboxdUsername}' for your user" });
+            if (!account.EnableWatchlistSync)
+                return BadRequest(new { error = $"Watchlist sync is disabled for '{letterboxdUsername}'; enable it in Settings first" });
+        }
+        else
+        {
+            var enabled = Config.GetEnabledAccountsForUser(userId).Where(a => a.EnableWatchlistSync).ToList();
+            if (enabled.Count == 0)
+                return BadRequest(new { error = "No enabled accounts with watchlist sync turned on for your user" });
+        }
 
         _ = Task.Run(async () =>
         {
             try
             {
-                await _watchlistRunner.TryRunForUserAsync(userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None)
-                    .ConfigureAwait(false);
+                await _watchlistRunner.TryRunForUserAsync(
+                    userId, "manual", new Progress<double>(), System.Threading.CancellationToken.None,
+                    letterboxdUsername).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -344,58 +363,88 @@ public class LetterboxdController : ControllerBase
         if (string.IsNullOrEmpty(userId))
             return BadRequest(new { error = "Could not determine user" });
 
-        var account = Config.Accounts.FirstOrDefault(
-            a => a.Enabled && a.UserJellyfinId == userId);
-
-        if (account == null)
-            return BadRequest(new { error = "No Letterboxd account configured for this user" });
-
-        try
+        // When LetterboxdUsername is set, post under that single account. When it's
+        // null/empty, fan out to every enabled account for this Jellyfin user, so
+        // shared TV-user setups (e.g. Lachlan + Deb) get the review on both diaries.
+        List<Account> accounts;
+        if (!string.IsNullOrWhiteSpace(request.LetterboxdUsername))
         {
-            using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
-                .ConfigureAwait(false);
+            var single = Config.FindAccount(userId, request.LetterboxdUsername!);
+            if (single == null)
+                return BadRequest(new { error = $"No enabled Letterboxd account '{request.LetterboxdUsername}' for this user" });
+            accounts = new List<Account> { single };
+        }
+        else
+        {
+            accounts = Config.GetEnabledAccountsForUser(userId).ToList();
+            if (accounts.Count == 0)
+                return BadRequest(new { error = "No Letterboxd accounts configured for this user" });
+        }
 
-            await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating, request.TmdbId)
-                .ConfigureAwait(false);
+        var jellyfinUsername = GetJellyfinUsername() ?? userId;
+        var perAccount = new List<object>();
+        var anySuccess = false;
+        Exception? lastError = null;
 
-            _logger.LogInformation("Posted review for {FilmSlug} by {Username}",
-                request.FilmSlug, account.LetterboxdUsername);
+        foreach (var account in accounts)
+        {
+            try
+            {
+                using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
+                    .ConfigureAwait(false);
 
+                await service.PostReviewAsync(request.FilmSlug, request.ReviewText, request.ContainsSpoilers, request.IsRewatch, request.Date, request.Rating, request.TmdbId)
+                    .ConfigureAwait(false);
+
+                _logger.LogInformation("Posted review for {FilmSlug} by {Username}",
+                    request.FilmSlug, account.LetterboxdUsername);
+
+                var status = request.IsRewatch ? SyncStatus.Rewatch : SyncStatus.Success;
+                SyncHistory.Record(new SyncEvent
+                {
+                    FilmTitle = request.FilmSlug.Replace("-", " "),
+                    FilmSlug = request.FilmSlug,
+                    Username = jellyfinUsername,
+                    Timestamp = DateTime.UtcNow,
+                    Status = status,
+                    Source = "review"
+                });
+
+                perAccount.Add(new { letterboxdUsername = account.LetterboxdUsername, success = true });
+                anySuccess = true;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                _logger.LogError("Failed to post review for {FilmSlug} as {LbUser}: {Message}",
+                    request.FilmSlug, account.LetterboxdUsername, ex.Message);
+
+                SyncHistory.Record(new SyncEvent
+                {
+                    FilmTitle = request.FilmSlug.Replace("-", " "),
+                    FilmSlug = request.FilmSlug,
+                    Username = jellyfinUsername,
+                    Timestamp = DateTime.UtcNow,
+                    Status = SyncStatus.Failed,
+                    Error = ex.Message,
+                    Source = "review"
+                });
+
+                perAccount.Add(new { letterboxdUsername = account.LetterboxdUsername, success = false, error = ex.Message });
+            }
+        }
+
+        // Mirror the rating to Jellyfin once if any account accepted it; the rating
+        // belongs to the Jellyfin user, not to a specific Letterboxd account, so a
+        // single writeback is correct regardless of how many accounts we posted to.
+        if (anySuccess)
             WriteJellyfinRating(userId, request.TmdbId, request.Rating);
 
-            var jellyfinUsername = GetJellyfinUsername() ?? account.LetterboxdUsername;
-            var status = request.IsRewatch ? SyncStatus.Rewatch : SyncStatus.Success;
-            SyncHistory.Record(new SyncEvent
-            {
-                FilmTitle = request.FilmSlug.Replace("-", " "),
-                FilmSlug = request.FilmSlug,
-                Username = jellyfinUsername,
-                Timestamp = DateTime.UtcNow,
-                Status = status,
-                Source = "review"
-            });
+        if (!anySuccess && lastError != null)
+            return BadRequest(new { error = lastError.Message, accounts = perAccount });
 
-            return Ok(new { success = true });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to post review for {FilmSlug}: {Message}", request.FilmSlug, ex.Message);
-
-            var jellyfinUsernameForError = GetJellyfinUsername() ?? account.LetterboxdUsername;
-            SyncHistory.Record(new SyncEvent
-            {
-                FilmTitle = request.FilmSlug.Replace("-", " "),
-                FilmSlug = request.FilmSlug,
-                Username = jellyfinUsernameForError,
-                Timestamp = DateTime.UtcNow,
-                Status = SyncStatus.Failed,
-                Error = ex.Message,
-                Source = "review"
-            });
-
-            return BadRequest(new { error = ex.Message });
-        }
+        return Ok(new { success = true, accounts = perAccount });
     }
 
     /// <summary>
@@ -517,4 +566,11 @@ public class ReviewRequest
     public string? Date { get; set; }
     public double? Rating { get; set; }
     public int? TmdbId { get; set; }
+
+    /// <summary>
+    /// Optional. When set, the review is posted only to that Letterboxd account.
+    /// When null/empty, the review is fanned out to every enabled Letterboxd account
+    /// for the calling Jellyfin user.
+    /// </summary>
+    public string? LetterboxdUsername { get; set; }
 }

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -267,6 +267,11 @@ public class LetterboxdController : ControllerBase
         account.MirrorJellyseerrWatchlist = request.MirrorJellyseerrWatchlist;
         account.SkipPreviouslySynced = request.SkipPreviouslySynced;
         account.StopOnFailure = request.StopOnFailure;
+        account.IsPrimary = request.IsPrimary;
+        account.PlaylistName = request.PlaylistName;
+
+        // Keep the single-primary-per-user invariant after the user toggles flags.
+        Config.NormalisePrimaryFlags();
 
         Plugin.Instance!.SaveConfiguration();
         _logger.LogInformation("User {UserId} saved their Letterboxd account settings", userId);

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -300,6 +300,116 @@ public class LetterboxdController : ControllerBase
         return Ok(new { success = true });
     }
 
+    /// <summary>
+    /// Returns every Letterboxd account belonging to the calling Jellyfin user, in
+    /// config order with primary first. Multi-account companion to the single-account
+    /// /Account endpoint: the userPage uses this to render the full list of accounts
+    /// the user can edit on their own sidebar page.
+    /// </summary>
+    [HttpGet("Accounts")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult GetAccounts()
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        var accounts = Config.Accounts
+            .Where(a => a.UserJellyfinId == userId)
+            .OrderByDescending(a => a.IsPrimary)
+            .Select(a => new
+            {
+                letterboxdUsername = a.LetterboxdUsername,
+                letterboxdPassword = a.LetterboxdPassword,
+                rawCookies = a.RawCookies,
+                userAgent = a.UserAgent,
+                enabled = a.Enabled,
+                syncFavorites = a.SyncFavorites,
+                enableDateFilter = a.EnableDateFilter,
+                dateFilterDays = a.DateFilterDays,
+                enableWatchlistSync = a.EnableWatchlistSync,
+                enableDiaryImport = a.EnableDiaryImport,
+                autoRequestWatchlist = a.AutoRequestWatchlist,
+                mirrorJellyseerrWatchlist = a.MirrorJellyseerrWatchlist,
+                skipPreviouslySynced = a.SkipPreviouslySynced,
+                stopOnFailure = a.StopOnFailure,
+                isPrimary = a.IsPrimary,
+                playlistName = a.PlaylistName
+            })
+            .ToList();
+
+        return Ok(new { accounts });
+    }
+
+    /// <summary>
+    /// Bulk-replace the calling user's set of Letterboxd accounts. Accounts owned by
+    /// other Jellyfin users are preserved (security: a non-admin user cannot touch
+    /// another user's row). Each submitted account is stamped with the calling user's
+    /// id regardless of what the request body claimed. NormalisePrimaryFlags runs after
+    /// so the single-primary-per-user invariant holds across the save.
+    /// </summary>
+    [HttpPut("Accounts")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult PutAccounts([FromBody] AccountsUpdateRequest request)
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        if (request?.Accounts == null)
+            return BadRequest(new { error = "accounts is required" });
+
+        // Reject empty username up front so a malformed row doesn't silently produce
+        // a half-broken account that fails authentication later.
+        for (var i = 0; i < request.Accounts.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(request.Accounts[i].LetterboxdUsername))
+                return BadRequest(new { error = $"Account #{i + 1} is missing a Letterboxd username" });
+        }
+
+        // Preserve every account that doesn't belong to the calling user. The admin
+        // page is the only path that should touch other users' rows; this endpoint
+        // is per-user scope.
+        var preserved = Config.Accounts.Where(a => a.UserJellyfinId != userId).ToList();
+
+        var mine = new List<Account>();
+        foreach (var req in request.Accounts)
+        {
+            mine.Add(new Account
+            {
+                UserJellyfinId = userId,
+                LetterboxdUsername = req.LetterboxdUsername,
+                LetterboxdPassword = req.LetterboxdPassword,
+                RawCookies = req.RawCookies,
+                UserAgent = req.UserAgent,
+                Enabled = req.Enabled,
+                SyncFavorites = req.SyncFavorites,
+                EnableDateFilter = req.EnableDateFilter,
+                DateFilterDays = req.DateFilterDays,
+                EnableWatchlistSync = req.EnableWatchlistSync,
+                EnableDiaryImport = req.EnableDiaryImport,
+                AutoRequestWatchlist = req.AutoRequestWatchlist,
+                MirrorJellyseerrWatchlist = req.MirrorJellyseerrWatchlist,
+                SkipPreviouslySynced = req.SkipPreviouslySynced,
+                StopOnFailure = req.StopOnFailure,
+                IsPrimary = req.IsPrimary,
+                PlaylistName = string.IsNullOrWhiteSpace(req.PlaylistName) ? null : req.PlaylistName.Trim()
+            });
+        }
+
+        Config.Accounts.Clear();
+        Config.Accounts.AddRange(preserved);
+        Config.Accounts.AddRange(mine);
+
+        Config.NormalisePrimaryFlags();
+        Plugin.Instance!.SaveConfiguration();
+
+        _logger.LogInformation("User {UserId} saved {Count} Letterboxd account(s) via /Accounts", userId, mine.Count);
+        return Ok(new { success = true, count = mine.Count });
+    }
+
     [HttpPost("TestConnection")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -286,10 +286,12 @@ public class LetterboxdController : ControllerBase
         account.MirrorJellyseerrWatchlist = request.MirrorJellyseerrWatchlist;
         account.SkipPreviouslySynced = request.SkipPreviouslySynced;
         account.StopOnFailure = request.StopOnFailure;
-        account.IsPrimary = request.IsPrimary;
-        account.PlaylistName = request.PlaylistName;
 
-        // Keep the single-primary-per-user invariant after the user toggles flags.
+        // IsPrimary and PlaylistName are deliberately NOT copied from the request.
+        // The userPage form does not expose them; deserialisation would set them to
+        // their type defaults (false / null) and clobber values that only the admin
+        // config page sets. Treat them as admin-managed and let NormalisePrimaryFlags
+        // promote a new account to primary when it's the user's only enabled one.
         Config.NormalisePrimaryFlags();
 
         Plugin.Instance!.SaveConfiguration();

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -33,4 +33,20 @@ public class Account
     public bool SkipPreviouslySynced { get; set; } = true;
 
     public bool StopOnFailure { get; set; }
+
+    /// <summary>
+    /// When a Jellyfin user has multiple Letterboxd accounts, the primary one is used to:
+    /// (1) resolve rating conflicts on diary import (primary's rating wins), and
+    /// (2) preselect the default option in manual UI dropdowns (review modal, sync buttons).
+    /// Auto-sync paths still fan out to all enabled accounts; this flag does not narrow them.
+    /// At most one account per UserJellyfinId should be primary; the loader auto-promotes
+    /// the first enabled account if none is marked.
+    /// </summary>
+    public bool IsPrimary { get; set; }
+
+    /// <summary>
+    /// Optional override for the watchlist playlist name. When null, defaults to
+    /// "Letterboxd Watchlist ({LetterboxdUsername})" so each account gets its own playlist.
+    /// </summary>
+    public string? PlaylistName { get; set; }
 }

--- a/LetterboxdSync/Configuration/AccountExtensions.cs
+++ b/LetterboxdSync/Configuration/AccountExtensions.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LetterboxdSync.Configuration;
+
+/// <summary>
+/// Centralised helpers for picking accounts off the configuration. Every sync path
+/// goes through one of these so account-selection rules (enabled, primary, by user,
+/// by username) can't drift apart across files.
+/// </summary>
+public static class AccountExtensions
+{
+    /// <summary>
+    /// All enabled accounts for a Jellyfin user, in config order. Primary first
+    /// (when one is marked) so callers that walk the list and stop at the first
+    /// match get primary-wins semantics for free.
+    /// </summary>
+    public static IEnumerable<Account> GetEnabledAccountsForUser(this PluginConfiguration config, string userJellyfinId)
+    {
+        if (config?.Accounts == null || string.IsNullOrEmpty(userJellyfinId))
+            return Array.Empty<Account>();
+
+        var matches = config.Accounts
+            .Where(a => a.Enabled && a.UserJellyfinId == userJellyfinId)
+            .ToList();
+
+        // Stable sort: primary first, otherwise preserve config order.
+        return matches.OrderByDescending(a => a.IsPrimary);
+    }
+
+    /// <summary>
+    /// The primary enabled account for a Jellyfin user, or the first enabled
+    /// account if none is explicitly marked primary (defensive default).
+    /// </summary>
+    public static Account? GetPrimaryAccountForUser(this PluginConfiguration config, string userJellyfinId)
+    {
+        var enabled = config.GetEnabledAccountsForUser(userJellyfinId).ToList();
+        if (enabled.Count == 0) return null;
+        return enabled.FirstOrDefault(a => a.IsPrimary) ?? enabled[0];
+    }
+
+    /// <summary>
+    /// Look up a specific enabled account by Jellyfin user + Letterboxd username.
+    /// Used by manual API paths when the caller specifies which account to target.
+    /// </summary>
+    public static Account? FindAccount(this PluginConfiguration config, string userJellyfinId, string letterboxdUsername)
+    {
+        if (string.IsNullOrEmpty(letterboxdUsername)) return null;
+        return config.GetEnabledAccountsForUser(userJellyfinId)
+            .FirstOrDefault(a => string.Equals(a.LetterboxdUsername, letterboxdUsername, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// One-time normalisation: ensures every Jellyfin user with at least one enabled
+    /// account has exactly one primary. Auto-promotes the first enabled account when
+    /// none is marked, and demotes extras when more than one is marked. Idempotent;
+    /// safe to call on every config save. Returns true when something was changed.
+    /// </summary>
+    public static bool NormalisePrimaryFlags(this PluginConfiguration config)
+    {
+        if (config?.Accounts == null || config.Accounts.Count == 0)
+            return false;
+
+        var changed = false;
+        var byUser = config.Accounts
+            .Where(a => a.Enabled && !string.IsNullOrEmpty(a.UserJellyfinId))
+            .GroupBy(a => a.UserJellyfinId);
+
+        foreach (var group in byUser)
+        {
+            var primaries = group.Where(a => a.IsPrimary).ToList();
+            if (primaries.Count == 1) continue;
+
+            if (primaries.Count == 0)
+            {
+                // Auto-promote: first enabled account becomes primary.
+                group.First().IsPrimary = true;
+                changed = true;
+            }
+            else
+            {
+                // More than one primary: keep the first, demote the rest.
+                foreach (var extra in primaries.Skip(1))
+                {
+                    extra.IsPrimary = false;
+                    changed = true;
+                }
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Default playlist name for an account: "Letterboxd Watchlist ({username})".
+    /// Falls back to the configured override if set.
+    /// </summary>
+    public static string GetPlaylistName(this Account account)
+    {
+        if (!string.IsNullOrWhiteSpace(account.PlaylistName))
+            return account.PlaylistName!.Trim();
+        return $"Letterboxd Watchlist ({account.LetterboxdUsername})";
+    }
+}

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -47,51 +47,73 @@ public class DiaryImportTask : IScheduledTask
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.EnableDiaryImport && a.UserJellyfinId == user.Id.ToString("N"));
+            // Collect entries from every enabled-with-diary-import account belonging to this
+            // Jellyfin user. GetEnabledAccountsForUser returns primary first, so the merge
+            // below naturally gives primary's rating priority on conflicts.
+            var accounts = Config.GetEnabledAccountsForUser(user.Id.ToString("N"))
+                .Where(a => a.EnableDiaryImport)
+                .ToList();
 
-            if (account == null)
+            if (accounts.Count == 0)
                 continue;
 
-            _logger.LogInformation("Starting diary import for {Username}", user.Username);
+            _logger.LogInformation("Starting diary import for {Username} ({AccountCount} account(s))",
+                user.Username, accounts.Count);
             SyncProgress.Start("Diary Import", "Authenticating");
 
-            ILetterboxdService service;
-            try
+            // Merge across accounts:
+            //  - diaryTmdbIds: union (any account watched it = mark played)
+            //  - ratingByTmdbId: first non-null wins, primary first (per OrderByDescending(IsPrimary))
+            var diaryTmdbIds = new HashSet<int>();
+            var ratingByTmdbId = new Dictionary<int, double>();
+            var ratingSourceByTmdbId = new Dictionary<int, string>();
+
+            foreach (var account in accounts)
             {
-                service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
-                    .ConfigureAwait(false);
+                ILetterboxdService service;
+                try
+                {
+                    service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                        account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError("Auth failed for {Username} as {LbUser}: {Message}",
+                        user.Username, account.LetterboxdUsername, ex.Message);
+                    continue;
+                }
+
+                using var _s = service;
+
+                List<DiaryFilmEntry> entries;
+                try
+                {
+                    SyncProgress.SetPhase($"Scanning Letterboxd films for {account.LetterboxdUsername}");
+                    entries = await service.GetDiaryFilmEntriesAsync(account.LetterboxdUsername).ConfigureAwait(false);
+                    _logger.LogInformation("Found {Count} films in {LbUser}'s Letterboxd diary",
+                        entries.Count, account.LetterboxdUsername);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError("Failed to fetch diary for {Username} as {LbUser}: {Message}",
+                        user.Username, account.LetterboxdUsername, ex.Message);
+                    continue;
+                }
+
+                foreach (var entry in entries)
+                {
+                    diaryTmdbIds.Add(entry.TmdbId);
+                    if (entry.Rating.HasValue && !ratingByTmdbId.ContainsKey(entry.TmdbId))
+                    {
+                        ratingByTmdbId[entry.TmdbId] = entry.Rating.Value;
+                        ratingSourceByTmdbId[entry.TmdbId] = account.LetterboxdUsername;
+                    }
+                }
             }
-            catch (Exception ex)
-            {
-                _logger.LogError("Auth failed for {Username}: {Message}", user.Username, ex.Message);
+
+            if (diaryTmdbIds.Count == 0)
                 continue;
-            }
-
-            using var _s = service;
-
-            List<DiaryFilmEntry> diaryEntries;
-            try
-            {
-                SyncProgress.SetPhase("Scanning Letterboxd films");
-                diaryEntries = await service.GetDiaryFilmEntriesAsync(account.LetterboxdUsername).ConfigureAwait(false);
-                _logger.LogInformation("Found {Count} films in {Username}'s Letterboxd diary",
-                    diaryEntries.Count, account.LetterboxdUsername);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Failed to fetch diary for {Username}: {Message}", user.Username, ex.Message);
-                continue;
-            }
-
-            if (diaryEntries.Count == 0)
-                continue;
-
-            var ratingByTmdbId = diaryEntries
-                .Where(e => e.Rating.HasValue)
-                .ToDictionary(e => e.TmdbId, e => e.Rating!.Value);
-            var diaryTmdbIds = new HashSet<int>(diaryEntries.Select(e => e.TmdbId));
 
             // Pull all movies (not just unplayed) so we can also apply rating-only updates
             // to films already marked as played.
@@ -148,7 +170,9 @@ public class DiaryImportTask : IScheduledTask
                 // Jellyfin has no "rating last modified" timestamp to compare against, so we
                 // use absence-of-rating as the safe signal. Existing ratings (e.g. from
                 // Findroid) are preserved; users who want to overwrite from Letterboxd can
-                // post a review via the plugin dashboard, which always wins.
+                // post a review via the plugin dashboard, which always wins. With multiple
+                // Letterboxd accounts, the merge above already picked primary's rating first
+                // so primary wins on conflict.
                 if (ratingByTmdbId.TryGetValue(tmdbId, out var lbRating) &&
                     (!userData.Rating.HasValue || userData.Rating.Value <= 0))
                 {
@@ -158,8 +182,9 @@ public class DiaryImportTask : IScheduledTask
                         userData.Rating = jfRating;
                         changed = true;
                         ratingsApplied++;
-                        _logger.LogInformation("Imported Letterboxd rating {LbRating} -> Jellyfin {JfRating} for {Title}",
-                            lbRating, jfRating.Value, movie.Name);
+                        var ratingSource = ratingSourceByTmdbId.TryGetValue(tmdbId, out var src) ? src : "letterboxd";
+                        _logger.LogInformation("Imported Letterboxd rating {LbRating} -> Jellyfin {JfRating} for {Title} (from {Source})",
+                            lbRating, jfRating.Value, movie.Name, ratingSource);
                     }
                 }
 

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -365,6 +365,52 @@ public class LetterboxdApiClient : ILetterboxdService
         _http.Dispose();
     }
 
+    // --- Test-only helpers (InternalsVisibleTo LetterboxdSync.Tests) ---
+
+    /// <summary>
+    /// Deletes every diary log entry the authenticated user has for the given film LID.
+    /// Used by the integration test suite to clean up after a write so the test account
+    /// stays predictable across runs. Best-effort: per-entry failures are swallowed and
+    /// logged but the loop continues. Not on ILetterboxdService because production sync
+    /// paths never want to delete user data.
+    /// </summary>
+    internal async Task DeleteAllLogEntriesForFilmAsync(string filmLid)
+    {
+        EnsureAuthenticated();
+
+        var listResponse = await SendSignedAsync(HttpMethod.Get, "/log-entries",
+            queryParams: $"member={Uri.EscapeDataString(_memberId)}&film={Uri.EscapeDataString(filmLid)}&perPage=50",
+            authenticated: true).ConfigureAwait(false);
+
+        if (!listResponse.IsSuccessStatusCode) return;
+
+        var json = await listResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("items", out var items)) return;
+
+        foreach (var item in items.EnumerateArray())
+        {
+            if (!item.TryGetProperty("id", out var idEl)) continue;
+            var entryId = idEl.GetString();
+            if (string.IsNullOrEmpty(entryId)) continue;
+
+            try
+            {
+                // Letterboxd splits the resource path: /log-entries (collection, GET/POST)
+                // vs /log-entry/{id} (individual, GET/PATCH/DELETE). Plural-DELETE returns 404.
+                var del = await SendSignedAsync(HttpMethod.Delete,
+                    $"/log-entry/{Uri.EscapeDataString(entryId)}", authenticated: true)
+                    .ConfigureAwait(false);
+                if (!del.IsSuccessStatusCode)
+                    _logger.LogWarning("Cleanup: DELETE /log-entry/{Id} returned {Status}", entryId, del.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Cleanup: DELETE /log-entries/{Id} threw: {Message}", entryId, ex.Message);
+            }
+        }
+    }
+
     // --- Private helpers ---
 
     private async Task<HttpResponseMessage> SendSignedAsync(HttpMethod method, string path,

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.11.3.0</AssemblyVersion>
-    <FileVersion>1.11.3.0</FileVersion>
+    <AssemblyVersion>1.12.0.0</AssemblyVersion>
+    <FileVersion>1.12.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -54,21 +54,21 @@ public class LetterboxdSyncRunner
 
         try
         {
-            var users = _userManager.Users.ToList();
-            var processedUsers = 0;
+            // Fan out across every (user, account) pair. Each account's sync is
+            // independent so one failing or rate-limited account never blocks the others.
+            var pairs = _userManager.Users
+                .SelectMany(u => Config.GetEnabledAccountsForUser(u.Id.ToString("N"))
+                    .Select(a => (User: u, Account: a)))
+                .ToList();
 
-            foreach (var user in users)
+            var processed = 0;
+            foreach (var (user, account) in pairs)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
-                var account = Config.Accounts.FirstOrDefault(
-                    a => a.Enabled && a.UserJellyfinId == user.Id.ToString("N"));
-                if (account == null) continue;
-
                 await SyncOneUserAsync(user, account, source, cancellationToken).ConfigureAwait(false);
-
-                processedUsers++;
-                progress.Report((double)processedUsers / users.Count * 100);
+                processed++;
+                if (pairs.Count > 0)
+                    progress.Report((double)processed / pairs.Count * 100);
             }
 
             progress.Report(100);
@@ -80,10 +80,17 @@ public class LetterboxdSyncRunner
     }
 
     /// <summary>
-    /// Run sync for a single user. Returns false if another sync is already running,
-    /// the user is unknown, or they have no enabled account.
+    /// Run sync for a single user. When letterboxdUsername is null/empty, fan out
+    /// across all enabled accounts for the user. Otherwise target only that account.
+    /// Returns false if another sync is already running, the user is unknown, or
+    /// they have no matching enabled account.
     /// </summary>
-    public async Task<bool> TryRunForUserAsync(string userJellyfinId, string source, IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task<bool> TryRunForUserAsync(
+        string userJellyfinId,
+        string source,
+        IProgress<double> progress,
+        CancellationToken cancellationToken,
+        string? letterboxdUsername = null)
     {
         if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
         {
@@ -100,16 +107,36 @@ public class LetterboxdSyncRunner
                 return false;
             }
 
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.UserJellyfinId == userJellyfinId);
-            if (account == null)
+            List<Account> accounts;
+            if (!string.IsNullOrEmpty(letterboxdUsername))
             {
-                _logger.LogWarning("No enabled Letterboxd account for {Username}, cannot start sync", user.Username);
-                return false;
+                var single = Config.FindAccount(userJellyfinId, letterboxdUsername);
+                if (single == null)
+                {
+                    _logger.LogWarning("No enabled Letterboxd account {LbUser} for {Username}, cannot start sync",
+                        letterboxdUsername, user.Username);
+                    return false;
+                }
+                accounts = new List<Account> { single };
+            }
+            else
+            {
+                accounts = Config.GetEnabledAccountsForUser(userJellyfinId).ToList();
+                if (accounts.Count == 0)
+                {
+                    _logger.LogWarning("No enabled Letterboxd accounts for {Username}, cannot start sync", user.Username);
+                    return false;
+                }
             }
 
-            await SyncOneUserAsync(user, account, source, cancellationToken).ConfigureAwait(false);
-            progress.Report(100);
+            var processed = 0;
+            foreach (var account in accounts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await SyncOneUserAsync(user, account, source, cancellationToken).ConfigureAwait(false);
+                processed++;
+                progress.Report((double)processed / accounts.Count * 100);
+            }
             return true;
         }
         finally

--- a/LetterboxdSync/PlaybackHandler.cs
+++ b/LetterboxdSync/PlaybackHandler.cs
@@ -69,12 +69,6 @@ public class PlaybackHandler : IHostedService, IDisposable
 
         foreach (var user in e.Users)
         {
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.UserJellyfinId == user.Id.ToString("N"));
-
-            if (account == null)
-                continue;
-
             var tmdbIdStr = e.Item.GetProviderId(MetadataProvider.Tmdb);
             if (!int.TryParse(tmdbIdStr, out var tmdbId))
             {
@@ -82,63 +76,75 @@ public class PlaybackHandler : IHostedService, IDisposable
                 continue;
             }
 
-            _logger.LogInformation("Syncing {Title} (TMDb:{TmdbId}) to Letterboxd for {Username}",
-                e.Item.Name, tmdbId, user.Username);
+            // Fan out across all enabled Letterboxd accounts for this Jellyfin user.
+            // Shared TV-user case (e.g. Lachlan + Deb both on the same Jellyfin login)
+            // means each LB account independently gets the diary entry. One failing
+            // account never blocks the others; rating mirroring is identical for both
+            // since Jellyfin only stores one rating per (user, film).
+            var accounts = Config.GetEnabledAccountsForUser(user.Id.ToString("N")).ToList();
+            if (accounts.Count == 0)
+                continue;
 
-            try
+            foreach (var account in accounts)
             {
-                using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
-                    account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
-                    .ConfigureAwait(false);
+                _logger.LogInformation("Syncing {Title} (TMDb:{TmdbId}) to Letterboxd for {Username} as {LbUser}",
+                    e.Item.Name, tmdbId, user.Username, account.LetterboxdUsername);
 
-                var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
-                var viewingDate = DateTime.Now.Date;
-
-                var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
-
-                if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
+                try
                 {
-                    _logger.LogInformation("{Title} already logged on Letterboxd for {Date}, skipping",
-                        e.Item.Name, viewingDate.ToString("yyyy-MM-dd"));
+                    using var service = await LetterboxdServiceFactory.CreateAuthenticatedAsync(
+                        account.LetterboxdUsername, account.LetterboxdPassword, account.RawCookies, _logger, account.UserAgent)
+                        .ConfigureAwait(false);
+
+                    var film = await service.LookupFilmByTmdbIdAsync(tmdbId).ConfigureAwait(false);
+                    var viewingDate = DateTime.Now.Date;
+
+                    var diaryInfo = await service.GetDiaryInfoAsync(film.FilmId, account.LetterboxdUsername).ConfigureAwait(false);
+
+                    if (Helpers.IsDuplicate(diaryInfo.LastDate, viewingDate))
+                    {
+                        _logger.LogInformation("{Title} already logged on Letterboxd ({LbUser}) for {Date}, skipping",
+                            e.Item.Name, account.LetterboxdUsername, viewingDate.ToString("yyyy-MM-dd"));
+                        SyncHistory.Record(new SyncEvent
+                        {
+                            FilmTitle = e.Item.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
+                            Username = user.Username, Timestamp = DateTime.UtcNow,
+                            ViewingDate = viewingDate, Status = SyncStatus.Skipped, Source = "playback"
+                        });
+                        continue;
+                    }
+
+                    bool isRewatch = Helpers.IsRewatch(diaryInfo.LastDate, viewingDate);
+                    var userData = _userDataManager.GetUserData(user, e.Item!);
+                    bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
+                    double? lbRating = Helpers.MapRating(userData?.Rating);
+
+                    await service.MarkAsWatchedAsync(film.Slug, film.FilmId, DateTime.Now, liked,
+                        film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
+
+                    var action = isRewatch ? "Logged rewatch of" : "Logged";
+                    _logger.LogInformation("{Action} {Title} to Letterboxd diary for {Username} as {LbUser}",
+                        action, e.Item.Name, user.Username, account.LetterboxdUsername);
                     SyncHistory.Record(new SyncEvent
                     {
                         FilmTitle = e.Item.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
                         Username = user.Username, Timestamp = DateTime.UtcNow,
-                        ViewingDate = viewingDate, Status = SyncStatus.Skipped, Source = "playback"
+                        ViewingDate = viewingDate,
+                        Status = isRewatch ? SyncStatus.Rewatch : SyncStatus.Success,
+                        Source = "playback"
                     });
-                    continue;
                 }
-
-                bool isRewatch = Helpers.IsRewatch(diaryInfo.LastDate, viewingDate);
-                var userData = _userDataManager.GetUserData(user, e.Item!);
-                bool liked = account.SyncFavorites && (userData?.IsFavorite ?? false);
-                double? lbRating = Helpers.MapRating(userData?.Rating);
-
-                await service.MarkAsWatchedAsync(film.Slug, film.FilmId, DateTime.Now, liked,
-                    film.ProductionId, isRewatch, lbRating).ConfigureAwait(false);
-
-                var action = isRewatch ? "Logged rewatch of" : "Logged";
-                _logger.LogInformation("{Action} {Title} to Letterboxd diary for {Username}",
-                    action, e.Item.Name, account.LetterboxdUsername);
-                SyncHistory.Record(new SyncEvent
+                catch (Exception ex)
                 {
-                    FilmTitle = e.Item.Name, FilmSlug = film.Slug, TmdbId = tmdbId,
-                    Username = user.Username, Timestamp = DateTime.UtcNow,
-                    ViewingDate = viewingDate,
-                    Status = isRewatch ? SyncStatus.Rewatch : SyncStatus.Success,
-                    Source = "playback"
-                });
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Failed to sync {Title} (TMDb:{TmdbId}) to Letterboxd for {Username}: {Message}",
-                    e.Item.Name, tmdbId, user.Username, ex.Message);
-                SyncHistory.Record(new SyncEvent
-                {
-                    FilmTitle = e.Item.Name, TmdbId = tmdbId,
-                    Username = user.Username, Timestamp = DateTime.UtcNow,
-                    Status = SyncStatus.Failed, Error = ex.Message, Source = "playback"
-                });
+                    _logger.LogError("Failed to sync {Title} (TMDb:{TmdbId}) to Letterboxd for {Username} as {LbUser}: {Message}",
+                        e.Item.Name, tmdbId, user.Username, account.LetterboxdUsername, ex.Message);
+                    SyncHistory.Record(new SyncEvent
+                    {
+                        FilmTitle = e.Item.Name, TmdbId = tmdbId,
+                        Username = user.Username, Timestamp = DateTime.UtcNow,
+                        Status = SyncStatus.Failed, Error = ex.Message, Source = "playback"
+                    });
+                }
             }
         }
     }

--- a/LetterboxdSync/Plugin.cs
+++ b/LetterboxdSync/Plugin.cs
@@ -22,6 +22,22 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     public static Plugin? Instance { get; private set; }
 
+    /// <summary>
+    /// Normalise the at-most-one-primary-per-Jellyfin-user invariant on every config
+    /// save. The per-user PutAccount endpoint already does this, but the admin config
+    /// page saves the entire PluginConfiguration via the stock plugin API which bypasses
+    /// the controller; without this hook an admin can leave two accounts marked primary
+    /// for the same Jellyfin user and rating-conflict resolution becomes ambiguous.
+    /// </summary>
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        if (configuration is PluginConfiguration cfg)
+        {
+            cfg.NormalisePrimaryFlags();
+        }
+        base.UpdateConfiguration(configuration);
+    }
+
     public IEnumerable<PluginPageInfo> GetPages()
     {
         return new[]

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -53,22 +53,22 @@ public class WatchlistSyncRunner
         {
             using var jellyseerr = CreateJellyseerrClient();
 
-            var users = _userManager.Users.ToList();
-            var processed = 0;
+            var pairs = _userManager.Users
+                .SelectMany(u => Config.GetEnabledAccountsForUser(u.Id.ToString("N"))
+                    .Where(a => a.EnableWatchlistSync)
+                    .Select(a => (User: u, Account: a)))
+                .ToList();
+
             SyncProgress.Start("Letterboxd Watchlist", "Starting");
 
-            foreach (var user in users)
+            var processed = 0;
+            foreach (var (user, account) in pairs)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
-                var account = Config.Accounts.FirstOrDefault(
-                    a => a.Enabled && a.EnableWatchlistSync && a.UserJellyfinId == user.Id.ToString("N"));
-                if (account == null) continue;
-
                 await SyncOneUserAsync(user, account, jellyseerr, source, cancellationToken).ConfigureAwait(false);
-
                 processed++;
-                progress.Report((double)processed / users.Count * 100);
+                if (pairs.Count > 0)
+                    progress.Report((double)processed / pairs.Count * 100);
             }
 
             progress.Report(100);
@@ -81,10 +81,17 @@ public class WatchlistSyncRunner
     }
 
     /// <summary>
-    /// Run watchlist sync for a single user. Returns false if another sync is already
-    /// running, the user is unknown, or they have no enabled-with-watchlist account.
+    /// Run watchlist sync for a single user. When letterboxdUsername is null/empty,
+    /// fans out across every enabled-with-watchlist account for that user. Otherwise
+    /// targets only the named account. Returns false if another sync is already
+    /// running, the user is unknown, or they have no matching account.
     /// </summary>
-    public async Task<bool> TryRunForUserAsync(string userJellyfinId, string source, IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task<bool> TryRunForUserAsync(
+        string userJellyfinId,
+        string source,
+        IProgress<double> progress,
+        CancellationToken cancellationToken,
+        string? letterboxdUsername = null)
     {
         if (!await SyncGate.Instance.WaitAsync(0, cancellationToken).ConfigureAwait(false))
         {
@@ -101,18 +108,44 @@ public class WatchlistSyncRunner
                 return false;
             }
 
-            var account = Config.Accounts.FirstOrDefault(
-                a => a.Enabled && a.EnableWatchlistSync && a.UserJellyfinId == userJellyfinId);
-            if (account == null)
+            var enabled = Config.GetEnabledAccountsForUser(userJellyfinId)
+                .Where(a => a.EnableWatchlistSync)
+                .ToList();
+
+            List<Account> accounts;
+            if (!string.IsNullOrEmpty(letterboxdUsername))
             {
-                _logger.LogWarning("No enabled watchlist-sync account for {Username}", user.Username);
-                return false;
+                var single = enabled.FirstOrDefault(a => string.Equals(
+                    a.LetterboxdUsername, letterboxdUsername, StringComparison.OrdinalIgnoreCase));
+                if (single == null)
+                {
+                    _logger.LogWarning("No enabled watchlist-sync account {LbUser} for {Username}",
+                        letterboxdUsername, user.Username);
+                    return false;
+                }
+                accounts = new List<Account> { single };
+            }
+            else
+            {
+                accounts = enabled;
+                if (accounts.Count == 0)
+                {
+                    _logger.LogWarning("No enabled watchlist-sync accounts for {Username}", user.Username);
+                    return false;
+                }
             }
 
             using var jellyseerr = CreateJellyseerrClient();
             SyncProgress.Start("Letterboxd Watchlist", "Starting");
-            await SyncOneUserAsync(user, account, jellyseerr, source, cancellationToken).ConfigureAwait(false);
-            progress.Report(100);
+
+            var processed = 0;
+            foreach (var account in accounts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await SyncOneUserAsync(user, account, jellyseerr, source, cancellationToken).ConfigureAwait(false);
+                processed++;
+                progress.Report((double)processed / accounts.Count * 100);
+            }
             SyncProgress.Complete();
             return true;
         }
@@ -199,7 +232,7 @@ public class WatchlistSyncRunner
         _logger.LogInformation("Matched {Matched}/{Total} watchlist films to Jellyfin library",
             watchlistItemIds.Count, tmdbIds.Count);
 
-        await UpdatePlaylistAsync(user, watchlistItemIds, tmdbIds.Count).ConfigureAwait(false);
+        await UpdatePlaylistAsync(user, account, watchlistItemIds, tmdbIds.Count).ConfigureAwait(false);
 
         // Jellyseerr integration: auto-request unmatched films and/or mirror the
         // Letterboxd watchlist into the user's Jellyseerr watchlist.
@@ -266,9 +299,12 @@ public class WatchlistSyncRunner
         }
     }
 
-    private async Task UpdatePlaylistAsync(User user, HashSet<Guid> watchlistItemIds, int letterboxdCount)
+    private async Task UpdatePlaylistAsync(User user, Account account, HashSet<Guid> watchlistItemIds, int letterboxdCount)
     {
-        const string playlistName = "Letterboxd Watchlist";
+        // Per-account playlist name so users with multiple Letterboxd accounts on
+        // one Jellyfin user (e.g. shared TV login) each get their own playlist.
+        // Defaults to "Letterboxd Watchlist ({letterboxdUsername})" or the override.
+        var playlistName = account.GetPlaylistName();
 
         var existingPlaylists = _libraryManager.GetItemList(new InternalItemsQuery(user)
         {

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -260,9 +260,25 @@ public class WatchlistSyncRunner
 
         if (account.MirrorJellyseerrWatchlist)
         {
-            SyncProgress.SetPhase($"Mirroring Jellyseerr watchlist for {user.Username}");
-            await MirrorJellyseerrWatchlistAsync(jellyseerr!, jellyseerrUserId.Value, tmdbIds, user.Username!, cancellationToken)
-                .ConfigureAwait(false);
+            // The Jellyseerr watchlist is keyed by Jellyfin user, not by Letterboxd
+            // account: running the mirror once per account would have each account
+            // overwrite the previous one's diff (toRemove = Jellyseerr - thisAccount
+            // wipes the other accounts' films). Only the primary account owns the
+            // Jellyseerr-watchlist destination so two accounts on one Jellyfin user
+            // can't clobber each other.
+            var primary = Config.GetPrimaryAccountForUser(account.UserJellyfinId);
+            if (ReferenceEquals(primary, account))
+            {
+                SyncProgress.SetPhase($"Mirroring Jellyseerr watchlist for {user.Username}");
+                await MirrorJellyseerrWatchlistAsync(jellyseerr!, jellyseerrUserId.Value, tmdbIds, user.Username!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Skipping Jellyseerr watchlist mirror for {LbUser}: not the primary account for {Username}",
+                    account.LetterboxdUsername, user.Username);
+            }
         }
 
         if (account.AutoRequestWatchlist)

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -189,6 +189,13 @@
                             <label class="c-muted"><input type="checkbox" id="reviewSpoilers" /> Contains spoilers</label>
                             <label class="c-muted"><input type="checkbox" id="reviewRewatch" /> This is a rewatch</label>
                         </div>
+                        <div id="reviewAccountRow" style="display:none;margin-top:0.7em;">
+                            <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.2em;">Post as</label>
+                            <select id="reviewAccount" style="min-width:240px;">
+                                <option value="">All my Letterboxd accounts</option>
+                            </select>
+                            <span class="c-muted" style="font-size:0.8em;display:block;margin-top:0.3em;">Defaults to posting on every linked Letterboxd account. Pick one to limit to that account only.</span>
+                        </div>
                         <div id="rewatchDateRow" style="display:none;margin-top:0.5em;">
                             <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.2em;">Date watched</label>
                             <input type="date" id="reviewDate" style="padding:0.4em;background:rgba(255,255,255,0.06);color:inherit;border:1px solid rgba(255,255,255,0.1);border-radius:4px;" />
@@ -381,9 +388,13 @@
                                 + '<span class="lb-check-title">Only sync recently played films</span>'
                                 + '<span class="lb-check-desc">Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don\'t want to backfill years of history into your Letterboxd diary.</span>'
                                 + '</span></label>'
+                                + '<label><input type="checkbox" class="isPrimary" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Primary account</span>'
+                                + '<span class="lb-check-desc">When a Jellyfin user has more than one Letterboxd account linked, the primary one wins on rating-import conflicts and is preselected in the review modal. Only one primary per Jellyfin user is kept (the server demotes extras on save).</span>'
+                                + '</span></label>'
                                 + '<label><input type="checkbox" class="enableWatchlistSync" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>'
-                                + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist named "Letterboxd Watchlist". Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
+                                + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist. With multiple accounts, each gets its own playlist named "Letterboxd Watchlist (username)" by default. Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
@@ -409,6 +420,10 @@
                                 + '<div class="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">'
                                 + '<label class="lb-field">Days to look back</label>'
                                 + '<input type="number" class="dateFilterDays" min="1" max="365" value="7" /></div>'
+                                + '<div style="margin-top:0.5em;">'
+                                + '<label class="lb-field">Watchlist Playlist Name <span class="c-muted">(optional)</span></label>'
+                                + '<input type="text" class="playlistName" placeholder="Letterboxd Watchlist (username)" />'
+                                + '<div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Override the playlist name for this account\'s mirrored Letterboxd watchlist. Leave blank to use the default pattern.</div></div>'
                                 + '</div>';
                         },
 
@@ -432,6 +447,8 @@
                                 entry.querySelector('.enableDiaryImport').checked = account.EnableDiaryImport === true;
                                 entry.querySelector('.skipPreviouslySynced').checked = account.SkipPreviouslySynced !== false;
                                 entry.querySelector('.stopOnFailure').checked = account.StopOnFailure === true;
+                                entry.querySelector('.isPrimary').checked = account.IsPrimary === true;
+                                entry.querySelector('.playlistName').value = account.PlaylistName || '';
                                 if (account.EnableDateFilter) entry.querySelector('.dateFilterDaysContainer').style.display = '';
                             } else {
                                 entry.querySelector('.accountEnabled').checked = true;
@@ -461,7 +478,9 @@
                                     MirrorJellyseerrWatchlist: entry.querySelector('.mirrorJellyseerrWatchlist').checked,
                                     EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked,
                                     SkipPreviouslySynced: entry.querySelector('.skipPreviouslySynced').checked,
-                                    StopOnFailure: entry.querySelector('.stopOnFailure').checked
+                                    StopOnFailure: entry.querySelector('.stopOnFailure').checked,
+                                    IsPrimary: entry.querySelector('.isPrimary').checked,
+                                    PlaylistName: entry.querySelector('.playlistName').value.trim() || null
                                 });
                             });
                             return accounts;
@@ -472,6 +491,9 @@
                             ApiClient.getUsers().then(function (users) {
                                 self.users = users;
                                 ApiClient.getPluginConfiguration(self.PluginId).then(function (config) {
+                                    // Cache so other tabs (review modal, sync buttons) can read
+                                    // current account state without another round trip.
+                                    self.lastConfig = config;
                                     document.getElementById('accountsList').innerHTML = '';
                                     if (config.Accounts && config.Accounts.length > 0)
                                         config.Accounts.forEach(function (a) { self.addAccount(a); });
@@ -488,6 +510,7 @@
                                 config.JellyseerrUrl = document.getElementById('jellyseerrUrl').value.trim() || null;
                                 config.JellyseerrApiKey = document.getElementById('jellyseerrApiKey').value.trim() || null;
                                 ApiClient.updatePluginConfiguration(self.PluginId, config).then(function () {
+                                    self.lastConfig = config;
                                     Dashboard.processPluginConfigurationUpdateResult();
                                 });
                             });
@@ -707,6 +730,7 @@
                         },
 
                         openReview: function (slug, title, tmdbId) {
+                            var self = this;
                             this.currentSlug = slug;
                             this.currentTmdbId = tmdbId || 0;
                             document.getElementById('reviewTitle').textContent = 'Review: ' + title;
@@ -719,7 +743,37 @@
                             document.getElementById('ratingLabel').textContent = 'No rating';
                             document.querySelectorAll('#starRating span').forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
                             document.getElementById('reviewStatus').textContent = '';
+                            self.populateReviewAccountDropdown();
                             document.getElementById('reviewModal').style.display = 'block';
+                        },
+
+                        // Show the "Post as" row only when the current Jellyfin user has more than
+                        // one enabled Letterboxd account configured. The dropdown's primary account
+                        // is preselected; "All my Letterboxd accounts" stays as the visible default
+                        // value so leaving it untouched fans out to every linked account.
+                        populateReviewAccountDropdown: function () {
+                            var sel = document.getElementById('reviewAccount');
+                            var row = document.getElementById('reviewAccountRow');
+                            if (!sel || !row) return;
+                            sel.innerHTML = '<option value="">All my Letterboxd accounts</option>';
+
+                            ApiClient.getCurrentUser().then(function (user) {
+                                var jfUserId = (user.Id || '').replace(/-/g, '');
+                                var saved = (LB.lastConfig && LB.lastConfig.Accounts) || [];
+                                var mine = saved.filter(function (a) {
+                                    return a.Enabled && a.UserJellyfinId === jfUserId;
+                                });
+                                // Show primary first so the dropdown order matches the rest of the UI.
+                                mine.sort(function (a, b) {
+                                    return (b.IsPrimary ? 1 : 0) - (a.IsPrimary ? 1 : 0);
+                                });
+                                mine.forEach(function (a) {
+                                    var label = a.LetterboxdUsername + (a.IsPrimary ? ' (primary)' : '');
+                                    sel.insertAdjacentHTML('beforeend',
+                                        '<option value="' + (a.LetterboxdUsername || '').replace(/"/g, '&quot;') + '">' + label + '</option>');
+                                });
+                                row.style.display = mine.length >= 2 ? '' : 'none';
+                            });
                         },
 
                         submitReview: function () {
@@ -736,6 +790,10 @@
                             var ratingVal = document.getElementById('reviewRating').value;
                             var rating = ratingVal ? parseFloat(ratingVal) : null;
 
+                            // Empty string => server fans out to every linked account; a username
+                            // => post to that single account only.
+                            var lbUser = (document.getElementById('reviewAccount').value || '').trim();
+
                             ApiClient.ajax({
                                 url: ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/Review'),
                                 type: 'POST', contentType: 'application/json',
@@ -746,7 +804,8 @@
                                     containsSpoilers: document.getElementById('reviewSpoilers').checked,
                                     isRewatch: isRewatch,
                                     date: isRewatch && date ? date : null,
-                                    rating: rating
+                                    rating: rating,
+                                    letterboxdUsername: lbUser || null
                                 })
                             }).then(function (response) {
                                 document.getElementById('reviewSubmit').disabled = false;

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -129,8 +129,8 @@
 
                 <!-- MY ACCOUNT TAB -->
                 <div id="tab-account" class="lb-tab-content" style="display:none;">
-                    <h3>Letterboxd Account</h3>
-                    <p class="c-muted" style="font-size:0.9em;">Connect your Letterboxd account to sync your watch history.</p>
+                    <h3>Primary Letterboxd account</h3>
+                    <p class="c-muted" style="font-size:0.9em;">Connect your Letterboxd account to sync your watch history. If you have more than one Letterboxd account linked to this Jellyfin user, this page only edits the primary one. Use the admin link above to manage additional accounts.</p>
 
                     <div class="lb-account">
                         <div style="margin-bottom:0.7em;">

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -174,6 +174,13 @@
                             <label class="c-muted"><input type="checkbox" id="reviewSpoilers" /> Contains spoilers</label>
                             <label class="c-muted"><input type="checkbox" id="reviewRewatch" /> This is a rewatch</label>
                         </div>
+                        <div id="reviewAccountRow" style="display:none;margin-top:0.7em;">
+                            <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.2em;">Post as</label>
+                            <select id="reviewAccount" style="min-width:240px;">
+                                <option value="">All my Letterboxd accounts</option>
+                            </select>
+                            <span class="c-muted" style="font-size:0.8em;display:block;margin-top:0.3em;">Defaults to posting on every linked Letterboxd account. Pick one to limit to that account only.</span>
+                        </div>
                         <div id="rewatchDateRow" style="display:none;margin-top:0.5em;">
                             <label style="display:block;opacity:0.5;font-size:0.85em;margin-bottom:0.2em;">Date watched</label>
                             <input type="date" id="reviewDate" style="padding:0.4em;background:rgba(255,255,255,0.06);color:inherit;border:1px solid rgba(255,255,255,0.1);border-radius:4px;" />
@@ -688,7 +695,35 @@
                             document.getElementById('ratingLabel').textContent = 'No rating';
                             document.querySelectorAll('#starRating span').forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
                             document.getElementById('reviewStatus').textContent = '';
+                            this.populateReviewAccountDropdown();
                             document.getElementById('reviewModal').style.display = 'block';
+                        },
+
+                        // Show the "Post as" row only when the current Jellyfin user has more than
+                        // one enabled Letterboxd account. The empty-value first option fans out to
+                        // every account; named options post to that one only. Primary first so it
+                        // matches the ordering in the rest of the UI.
+                        populateReviewAccountDropdown: function () {
+                            var sel = document.getElementById('reviewAccount');
+                            var row = document.getElementById('reviewAccountRow');
+                            if (!sel || !row) return;
+                            sel.innerHTML = '<option value="">All my Letterboxd accounts</option>';
+
+                            this.apiFetch('Jellyfin.Plugin.LetterboxdSync/Accounts')
+                            .then(function (r) { return r.json(); })
+                            .then(function (data) {
+                                var mine = ((data && data.accounts) || []).filter(function (a) { return a.enabled; });
+                                mine.sort(function (a, b) {
+                                    return (b.isPrimary ? 1 : 0) - (a.isPrimary ? 1 : 0);
+                                });
+                                mine.forEach(function (a) {
+                                    var label = a.letterboxdUsername + (a.isPrimary ? ' (primary)' : '');
+                                    sel.insertAdjacentHTML('beforeend',
+                                        '<option value="' + (a.letterboxdUsername || '').replace(/"/g, '&quot;') + '">' + label + '</option>');
+                                });
+                                row.style.display = mine.length >= 2 ? '' : 'none';
+                            })
+                            .catch(function () { row.style.display = 'none'; });
                         },
 
                         submitReview: function () {
@@ -705,6 +740,10 @@
                             var ratingVal = document.getElementById('reviewRating').value;
                             var rating = ratingVal ? parseFloat(ratingVal) : null;
 
+                            // Empty string means fan out to every linked account; a username
+                            // restricts the post to that one account only.
+                            var lbUser = (document.getElementById('reviewAccount').value || '').trim();
+
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/Review', {
                                 filmSlug: self.currentSlug,
                                 tmdbId: self.currentTmdbId || null,
@@ -712,7 +751,8 @@
                                 containsSpoilers: document.getElementById('reviewSpoilers').checked,
                                 isRewatch: isRewatch,
                                 date: isRewatch && date ? date : null,
-                                rating: rating
+                                rating: rating,
+                                letterboxdUsername: lbUser || null
                             })
                             .then(function (r) { return r.json(); })
                             .then(function (data) {

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -129,73 +129,12 @@
 
                 <!-- MY ACCOUNT TAB -->
                 <div id="tab-account" class="lb-tab-content" style="display:none;">
-                    <h3>Primary Letterboxd account</h3>
-                    <p class="c-muted" style="font-size:0.9em;">Connect your Letterboxd account to sync your watch history. If you have more than one Letterboxd account linked to this Jellyfin user, this page only edits the primary one. Use the admin link above to manage additional accounts.</p>
+                    <h3>Your Letterboxd accounts</h3>
+                    <p class="c-muted" style="font-size:0.9em;">Link one or more Letterboxd accounts to this Jellyfin user. Each gets its own diary, ratings, and watchlist; auto-sync fans out across every enabled account. When you have more than one, mark one as <em>primary</em> &mdash; it wins on rating-import conflicts and is preselected in the review modal.</p>
 
-                    <div class="lb-account">
-                        <div style="margin-bottom:0.7em;">
-                            <label class="lb-field">Letterboxd Username</label>
-                            <input type="text" id="lbUsername" />
-                        </div>
-                        <div style="margin-bottom:0.7em;">
-                            <label class="lb-field">Letterboxd Password</label>
-                            <input type="password" id="lbPassword" />
-                        </div>
-                        <div style="margin-bottom:0.7em;">
-                            <label class="lb-field">Raw Cookies <span class="c-muted">(optional, Cloudflare bypass)</span></label>
-                            <input type="text" id="rawCookies" placeholder="Paste cookie header if login gets 403" />
-                        </div>
-                        <div style="margin-bottom:0.7em;">
-                            <label class="lb-field">User-Agent <span class="c-muted">(optional, must match the browser used to copy cookies)</span></label>
-                            <input type="text" id="userAgent" placeholder="Leave blank for default (Firefox 134 on Windows)" />
-                            <div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Cloudflare ties the <code>cf_clearance</code> cookie to the exact User-Agent that solved the challenge. If you copied cookies from Chrome, paste Chrome's UA here.</div>
-                        </div>
+                    <div id="accountsList"></div>
 
-                        <div style="margin-top:1em;margin-bottom:0.5em;">
-                            <button type="button" class="lb-btn lb-btn-secondary" id="testBtn">Test Connection</button>
-                            <span id="testStatus" style="font-size:0.9em;margin-left:0.7em;"></span>
-                        </div>
-
-                        <h4 style="margin-top:1.5em;margin-bottom:0.5em;">Sync Preferences</h4>
-                        <div class="lb-checks">
-                            <label><input type="checkbox" id="accountEnabled" /><span class="lb-check-text">
-                                <span class="lb-check-title">Enabled</span>
-                                <span class="lb-check-desc">Master switch for your account. When unchecked, no diary, watchlist, or playback sync runs for you. Saved settings are kept.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="syncFavorites" /><span class="lb-check-text">
-                                <span class="lb-check-title">Mark Jellyfin favourites as liked on Letterboxd</span>
-                                <span class="lb-check-desc">When a film is in your Jellyfin favourites, the diary entry on Letterboxd gets the red heart (liked). Otherwise it syncs as a plain watch.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="enableDateFilter" /><span class="lb-check-text">
-                                <span class="lb-check-title">Only sync recently played films</span>
-                                <span class="lb-check-desc">Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don't want to backfill years of history.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="enableWatchlistSync" /><span class="lb-check-text">
-                                <span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>
-                                <span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist named "Letterboxd Watchlist". Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="autoRequestWatchlist" /><span class="lb-check-text">
-                                <span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>
-                                <span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, request it through Jellyseerr. The request is attributed to your Jellyseerr account (matched by your Jellyfin login). The admin must have configured Jellyseerr in the plugin settings.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="enableDiaryImport" /><span class="lb-check-text">
-                                <span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>
-                                <span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in your Letterboxd diary.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="skipPreviouslySynced" /><span class="lb-check-text">
-                                <span class="lb-check-title">Skip films already synced locally</span>
-                                <span class="lb-check-desc">Use the plugin's own sync history to short-circuit the duplicate check, so we don't hit Letterboxd at all for films we already logged. Massively reduces Cloudflare blocks on large libraries. Recommended.</span>
-                            </span></label>
-                            <label><input type="checkbox" id="stopOnFailure" /><span class="lb-check-text">
-                                <span class="lb-check-title">Stop sync immediately on first failure</span>
-                                <span class="lb-check-desc">Halt your sync the moment a film fails (e.g. Cloudflare 403 or anti-flooding). Prevents wasted retries that further inflame Letterboxd's rate limits. Remaining films will be picked up next run, prioritising failed and never-attempted entries first.</span>
-                            </span></label>
-                        </div>
-                        <div id="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">
-                            <label class="lb-field">Days to look back</label>
-                            <input type="number" id="dateFilterDays" min="1" max="365" value="7" />
-                        </div>
-                    </div>
+                    <button type="button" class="lb-btn lb-btn-secondary" id="addAccountBtn" style="margin-top:1em;">+ Add Account</button>
 
                     <div style="margin-top:1.5em;display:flex;align-items:center;gap:1em;">
                         <button type="button" class="lb-btn lb-btn-primary" id="saveBtn">Save</button>
@@ -318,59 +257,195 @@
                             });
                         },
 
+                        accountHtml: function () {
+                            return '<div class="account-entry lb-account" style="margin-bottom:1em;">'
+                                + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5em;">'
+                                + '<h4 style="margin:0;" class="accountHeading">Account</h4>'
+                                + '<button type="button" class="lb-btn lb-btn-danger removeAccountBtn">Remove</button></div>'
+                                + '<div style="margin-bottom:0.5em;"><label class="lb-field">Letterboxd Username</label>'
+                                + '<input type="text" class="lbUsername" /></div>'
+                                + '<div style="margin-bottom:0.5em;"><label class="lb-field">Letterboxd Password</label>'
+                                + '<input type="password" class="lbPassword" /></div>'
+                                + '<div style="margin-bottom:0.5em;"><label class="lb-field">Raw Cookies <span class="c-muted">(optional, Cloudflare bypass)</span></label>'
+                                + '<input type="text" class="rawCookies" placeholder="Paste cookie header if login gets 403" /></div>'
+                                + '<div style="margin-bottom:0.5em;"><label class="lb-field">User-Agent <span class="c-muted">(optional, must match the browser used to copy cookies)</span></label>'
+                                + '<input type="text" class="userAgent" placeholder="Leave blank for default (Firefox 134 on Windows)" />'
+                                + '<div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Cloudflare ties the <code>cf_clearance</code> cookie to the exact User-Agent that solved the challenge. If you copied cookies from Chrome, paste Chrome\'s UA here.</div></div>'
+                                + '<div style="margin-top:1em;margin-bottom:0.5em;">'
+                                + '<button type="button" class="lb-btn lb-btn-secondary testBtn">Test Connection</button>'
+                                + '<span class="testStatus" style="font-size:0.9em;margin-left:0.7em;"></span></div>'
+                                + '<h4 style="margin-top:1.5em;margin-bottom:0.5em;">Sync Preferences</h4>'
+                                + '<div class="lb-checks">'
+                                + '<label><input type="checkbox" class="accountEnabled" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Enabled</span>'
+                                + '<span class="lb-check-desc">Master switch for this account. When unchecked, no diary, watchlist, or playback sync runs for it. Saved settings are kept.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="isPrimary" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Primary account</span>'
+                                + '<span class="lb-check-desc">When this Jellyfin user has more than one Letterboxd account linked, the primary one wins on rating-import conflicts and is preselected in the review modal. Only one primary per Jellyfin user is kept (the server demotes extras on save).</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="syncFavorites" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mark Jellyfin favourites as liked on Letterboxd</span>'
+                                + '<span class="lb-check-desc">When a film is in your Jellyfin favourites, the diary entry on Letterboxd gets the red heart (liked). Otherwise it syncs as a plain watch.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableDateFilter" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Only sync recently played films</span>'
+                                + '<span class="lb-check-desc">Limit the catch-up sync to films watched within the last N days (set below). Useful on first run if you don\'t want to backfill years of history.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableWatchlistSync" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist as a Jellyfin playlist</span>'
+                                + '<span class="lb-check-desc">Pulls this account\'s Letterboxd watchlist daily and mirrors it into a Jellyfin playlist. With multiple accounts each gets its own playlist named "Letterboxd Watchlist (username)" by default. Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
+                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, request it through Jellyseerr. The request is attributed to your Jellyseerr account. Requires Jellyseerr to be configured in the admin plugin settings.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="mirrorJellyseerrWatchlist" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Jellyseerr watchlist</span>'
+                                + '<span class="lb-check-desc">Two-way mirror against your Jellyseerr user\'s own watchlist. Only takes effect on the primary account, since the Jellyseerr watchlist is per-Jellyfin-user (the secondary account\'s flag is silently ignored to avoid the two accounts overwriting each other). Movies only, so manually-added Jellyseerr TV is left alone.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
+                                + '<span class="lb-check-desc">Reverse direction: marks films in your Jellyfin library as played if they are already in this account\'s Letterboxd diary. With multiple accounts the played-state is unioned across them.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="skipPreviouslySynced" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Skip films already synced locally</span>'
+                                + '<span class="lb-check-desc">Use the plugin\'s own sync history to short-circuit the duplicate check, so we don\'t hit Letterboxd at all for films we already logged. Massively reduces Cloudflare blocks on large libraries. Recommended.</span>'
+                                + '</span></label>'
+                                + '<label><input type="checkbox" class="stopOnFailure" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Stop sync immediately on first failure</span>'
+                                + '<span class="lb-check-desc">Halt this account\'s sync the moment a film fails (e.g. Cloudflare 403 or anti-flooding). Prevents wasted retries that further inflame Letterboxd\'s rate limits. Remaining films will be picked up next run, prioritising failed and never-attempted entries first.</span>'
+                                + '</span></label>'
+                                + '</div>'
+                                + '<div class="dateFilterDaysContainer" style="display:none;margin-top:0.5em;">'
+                                + '<label class="lb-field">Days to look back</label>'
+                                + '<input type="number" class="dateFilterDays" min="1" max="365" value="7" /></div>'
+                                + '<div style="margin-top:0.5em;">'
+                                + '<label class="lb-field">Watchlist Playlist Name <span class="c-muted">(optional)</span></label>'
+                                + '<input type="text" class="playlistName" placeholder="Letterboxd Watchlist (username)" />'
+                                + '<div class="c-muted" style="font-size:0.8em;margin-top:0.3em;">Override the playlist name for this account\'s mirrored Letterboxd watchlist. Leave blank to use the default pattern.</div></div>'
+                                + '</div>';
+                        },
+
+                        wireAccountEntry: function (entry, account) {
+                            var self = this;
+                            if (account) {
+                                entry.querySelector('.lbUsername').value = account.letterboxdUsername || '';
+                                entry.querySelector('.lbPassword').value = account.letterboxdPassword || '';
+                                entry.querySelector('.rawCookies').value = account.rawCookies || '';
+                                entry.querySelector('.userAgent').value = account.userAgent || '';
+                                entry.querySelector('.accountEnabled').checked = account.enabled === true;
+                                entry.querySelector('.isPrimary').checked = account.isPrimary === true;
+                                entry.querySelector('.syncFavorites').checked = account.syncFavorites === true;
+                                entry.querySelector('.enableDateFilter').checked = account.enableDateFilter === true;
+                                entry.querySelector('.dateFilterDays').value = account.dateFilterDays || 7;
+                                entry.querySelector('.enableWatchlistSync').checked = account.enableWatchlistSync === true;
+                                entry.querySelector('.autoRequestWatchlist').checked = account.autoRequestWatchlist === true;
+                                entry.querySelector('.mirrorJellyseerrWatchlist').checked = account.mirrorJellyseerrWatchlist === true;
+                                entry.querySelector('.enableDiaryImport').checked = account.enableDiaryImport === true;
+                                entry.querySelector('.skipPreviouslySynced').checked = account.skipPreviouslySynced !== false;
+                                entry.querySelector('.stopOnFailure').checked = account.stopOnFailure === true;
+                                entry.querySelector('.playlistName').value = account.playlistName || '';
+                                if (account.enableDateFilter) entry.querySelector('.dateFilterDaysContainer').style.display = '';
+                                self.updateAccountHeading(entry);
+                            } else {
+                                entry.querySelector('.accountEnabled').checked = true;
+                                entry.querySelector('.skipPreviouslySynced').checked = true;
+                                entry.querySelector('.accountHeading').textContent = 'New account';
+                            }
+                            entry.querySelector('.enableDateFilter').addEventListener('change', function () {
+                                entry.querySelector('.dateFilterDaysContainer').style.display = this.checked ? '' : 'none';
+                            });
+                            entry.querySelector('.lbUsername').addEventListener('input', function () { self.updateAccountHeading(entry); });
+                            entry.querySelector('.isPrimary').addEventListener('change', function () { self.updateAccountHeading(entry); });
+                            entry.querySelector('.removeAccountBtn').addEventListener('click', function () { entry.remove(); });
+                            entry.querySelector('.testBtn').addEventListener('click', function () { self.testConnection(entry); });
+                        },
+
+                        updateAccountHeading: function (entry) {
+                            var name = entry.querySelector('.lbUsername').value.trim();
+                            var primary = entry.querySelector('.isPrimary').checked;
+                            var label = name || 'New account';
+                            if (primary) label += ' (primary)';
+                            entry.querySelector('.accountHeading').textContent = label;
+                        },
+
+                        addAccount: function (account) {
+                            var container = document.getElementById('accountsList');
+                            container.insertAdjacentHTML('beforeend', this.accountHtml());
+                            this.wireAccountEntry(container.lastElementChild, account);
+                        },
+
                         loadAccount: function () {
                             var self = this;
-                            self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Account')
+                            self.apiFetch('Jellyfin.Plugin.LetterboxdSync/Accounts')
                             .then(function (r) { return r.json(); })
-                            .then(function (a) {
-                                document.getElementById('lbUsername').value = a.letterboxdUsername || '';
-                                document.getElementById('lbPassword').value = a.letterboxdPassword || '';
-                                document.getElementById('rawCookies').value = a.rawCookies || '';
-                                document.getElementById('userAgent').value = a.userAgent || '';
-                                document.getElementById('accountEnabled').checked = a.enabled === true;
-                                document.getElementById('syncFavorites').checked = a.syncFavorites === true;
-                                document.getElementById('enableDateFilter').checked = a.enableDateFilter === true;
-                                document.getElementById('dateFilterDays').value = a.dateFilterDays || 7;
-                                document.getElementById('enableWatchlistSync').checked = a.enableWatchlistSync === true;
-                                document.getElementById('autoRequestWatchlist').checked = a.autoRequestWatchlist === true;
-                                document.getElementById('enableDiaryImport').checked = a.enableDiaryImport === true;
-                                document.getElementById('skipPreviouslySynced').checked = a.skipPreviouslySynced !== false;
-                                document.getElementById('stopOnFailure').checked = a.stopOnFailure === true;
-                                document.getElementById('dateFilterDaysContainer').style.display = a.enableDateFilter ? '' : 'none';
+                            .then(function (data) {
+                                var list = document.getElementById('accountsList');
+                                list.innerHTML = '';
+                                var accounts = (data && data.accounts) || [];
+                                accounts.forEach(function (a) { self.addAccount(a); });
+                                if (accounts.length === 0) {
+                                    // First-time setup: render an empty row so the user has something
+                                    // to fill in rather than staring at the +Add button alone.
+                                    self.addAccount(null);
+                                }
                             })
                             .catch(function (err) {
-                                console.error('[LetterboxdSync] Failed to load account:', err);
+                                console.error('[LetterboxdSync] Failed to load accounts:', err);
                             });
+                        },
+
+                        collectAccounts: function () {
+                            var accounts = [];
+                            document.querySelectorAll('#accountsList .account-entry').forEach(function (entry) {
+                                accounts.push({
+                                    letterboxdUsername: entry.querySelector('.lbUsername').value.trim(),
+                                    letterboxdPassword: entry.querySelector('.lbPassword').value,
+                                    rawCookies: entry.querySelector('.rawCookies').value || null,
+                                    userAgent: entry.querySelector('.userAgent').value || null,
+                                    enabled: entry.querySelector('.accountEnabled').checked,
+                                    syncFavorites: entry.querySelector('.syncFavorites').checked,
+                                    enableDateFilter: entry.querySelector('.enableDateFilter').checked,
+                                    dateFilterDays: parseInt(entry.querySelector('.dateFilterDays').value, 10) || 7,
+                                    enableWatchlistSync: entry.querySelector('.enableWatchlistSync').checked,
+                                    autoRequestWatchlist: entry.querySelector('.autoRequestWatchlist').checked,
+                                    mirrorJellyseerrWatchlist: entry.querySelector('.mirrorJellyseerrWatchlist').checked,
+                                    enableDiaryImport: entry.querySelector('.enableDiaryImport').checked,
+                                    skipPreviouslySynced: entry.querySelector('.skipPreviouslySynced').checked,
+                                    stopOnFailure: entry.querySelector('.stopOnFailure').checked,
+                                    isPrimary: entry.querySelector('.isPrimary').checked,
+                                    playlistName: entry.querySelector('.playlistName').value.trim() || null
+                                });
+                            });
+                            return accounts;
                         },
 
                         saveAccount: function () {
                             var self = this;
                             var saveBtn = document.getElementById('saveBtn');
                             var saveStatus = document.getElementById('saveStatus');
+                            var accounts = self.collectAccounts();
+
+                            // Reject empty rows client-side so the server doesn't have to send a 400
+                            // for a UX problem we can describe inline.
+                            for (var i = 0; i < accounts.length; i++) {
+                                if (!accounts[i].letterboxdUsername) {
+                                    saveStatus.innerHTML = '<span class="c-red">Account #' + (i + 1) + ' is missing a Letterboxd username</span>';
+                                    return;
+                                }
+                            }
+
                             saveBtn.disabled = true;
                             saveStatus.textContent = 'Saving...';
 
-                            var data = {
-                                letterboxdUsername: document.getElementById('lbUsername').value,
-                                letterboxdPassword: document.getElementById('lbPassword').value,
-                                rawCookies: document.getElementById('rawCookies').value || null,
-                                userAgent: document.getElementById('userAgent').value || null,
-                                enabled: document.getElementById('accountEnabled').checked,
-                                syncFavorites: document.getElementById('syncFavorites').checked,
-                                enableDateFilter: document.getElementById('enableDateFilter').checked,
-                                dateFilterDays: parseInt(document.getElementById('dateFilterDays').value, 10) || 7,
-                                enableWatchlistSync: document.getElementById('enableWatchlistSync').checked,
-                                autoRequestWatchlist: document.getElementById('autoRequestWatchlist').checked,
-                                enableDiaryImport: document.getElementById('enableDiaryImport').checked,
-                                skipPreviouslySynced: document.getElementById('skipPreviouslySynced').checked,
-                                stopOnFailure: document.getElementById('stopOnFailure').checked
-                            };
-
-                            self.apiPut('Jellyfin.Plugin.LetterboxdSync/Account', data)
+                            self.apiPut('Jellyfin.Plugin.LetterboxdSync/Accounts', { accounts: accounts })
                             .then(function (r) {
                                 if (r.ok) {
                                     saveStatus.innerHTML = '<span class="c-green">Saved!</span>';
                                     saveBtn.disabled = false;
+                                    // Reload to pick up server-side normalisation (e.g. auto-promoted primary).
+                                    self.loadAccount();
                                 } else {
                                     r.json().then(function (d) {
                                         saveStatus.innerHTML = '<span class="c-red">' + (d.error || 'Failed to save') + '</span>';
@@ -382,14 +457,15 @@
                                 saveStatus.innerHTML = '<span class="c-red">Error: ' + err.message + '</span>';
                                 saveBtn.disabled = false;
                             });
+                            return;
                         },
 
-                        testConnection: function () {
+                        testConnection: function (entry) {
                             var self = this;
-                            var testBtn = document.getElementById('testBtn');
-                            var testStatus = document.getElementById('testStatus');
-                            var username = document.getElementById('lbUsername').value;
-                            var password = document.getElementById('lbPassword').value;
+                            var testBtn = entry.querySelector('.testBtn');
+                            var testStatus = entry.querySelector('.testStatus');
+                            var username = entry.querySelector('.lbUsername').value;
+                            var password = entry.querySelector('.lbPassword').value;
 
                             if (!username || !password) {
                                 testStatus.innerHTML = '<span class="c-red">Enter username and password first</span>';
@@ -402,8 +478,8 @@
                             self.apiPost('Jellyfin.Plugin.LetterboxdSync/TestConnection', {
                                 letterboxdUsername: username,
                                 letterboxdPassword: password,
-                                rawCookies: document.getElementById('rawCookies').value || null,
-                                userAgent: document.getElementById('userAgent').value || null
+                                rawCookies: entry.querySelector('.rawCookies').value || null,
+                                userAgent: entry.querySelector('.userAgent').value || null
                             })
                             .then(function (r) { return r.json(); })
                             .then(function (data) {
@@ -693,7 +769,7 @@
 
                             // Event listeners
                             document.getElementById('saveBtn').addEventListener('click', function () { self.saveAccount(); });
-                            document.getElementById('testBtn').addEventListener('click', function () { self.testConnection(); });
+                            document.getElementById('addAccountBtn').addEventListener('click', function () { self.addAccount(null); });
                             document.getElementById('runSyncBtn').addEventListener('click', function () { self.runSync(); });
                             document.getElementById('runWatchlistSyncBtn').addEventListener('click', function () { self.runWatchlistSync(); });
                             document.getElementById('historyFirst').addEventListener('click', function () { self.gotoHistoryPage(1); });
@@ -704,9 +780,6 @@
                             document.getElementById('reviewSubmit').addEventListener('click', function () { self.submitReview(); });
                             document.getElementById('reviewRewatch').addEventListener('change', function () {
                                 document.getElementById('rewatchDateRow').style.display = this.checked ? '' : 'none';
-                            });
-                            document.getElementById('enableDateFilter').addEventListener('change', function () {
-                                document.getElementById('dateFilterDaysContainer').style.display = this.checked ? '' : 'none';
                             });
 
                             // Star rating

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 set -e
 
 SERVER="lachlan@192.168.1.122"
-PLUGIN_DIR="/docker/jellyfin/config/data/plugins/LetterboxdSync_1.0.0.0"
+PLUGINS_ROOT="/docker/jellyfin/config/data/plugins"
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 read -s -p "Server password: " PASS
@@ -10,6 +10,17 @@ echo
 
 echo "Building..."
 dotnet build -c Release "$PROJECT_DIR/LetterboxdSync/LetterboxdSync.csproj" -q
+
+# Jellyfin renames the plugin directory to LetterboxdSync_<assemblyVersion> on first
+# load, so the install path drifts every release. Discover it instead of hardcoding.
+echo "Resolving plugin directory on server..."
+PLUGIN_DIR=$(sshpass -p "$PASS" ssh "$SERVER" \
+    "ls -d $PLUGINS_ROOT/LetterboxdSync_* 2>/dev/null | sort -V | tail -1")
+if [ -z "$PLUGIN_DIR" ]; then
+    echo "Could not find LetterboxdSync_* under $PLUGINS_ROOT on the server."
+    exit 1
+fi
+echo "Target: $PLUGIN_DIR"
 
 echo "Deploying..."
 sshpass -p "$PASS" scp \

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.12.0.0",
+        "changelog": "Multi-account support: one Jellyfin user can now link multiple Letterboxd accounts. Auto-sync (real-time on playback completion and scheduled) fans out across every enabled account, with per-account failures isolated. Manual /Sync, /SyncWatchlist, and /Review endpoints accept an optional letterboxdUsername selector and fan out by default when omitted. Diary import unions played-state across all accounts and merges ratings with the primary account winning conflicts (existing Jellyfin ratings are still preserved). Watchlist playlists are now per-account (default name: 'Letterboxd Watchlist ({letterboxdUsername})', overridable per account). New IsPrimary flag on each account, normalised on save (at most one primary per Jellyfin user). UI: the sidebar 'My Letterboxd' page now has feature parity with the admin page for per-account management (add, remove, test, configure every account belonging to your Jellyfin user without admin access). Review modal exposes a 'Post as' account selector when more than one account is enabled, defaulting to all accounts. Behaviour change: existing single-account users will see a new per-account watchlist playlist created on first sync after upgrade, the old 'Letterboxd Watchlist' playlist is left untouched.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.12.0/jellyfin-plugin-letterboxd-v1.12.0.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-05-14T00:00:00Z"
+      },
+      {
         "version": "1.11.3.0",
         "changelog": "Docs: when a Cloudflare 403 happens after you've already pasted Raw Cookies and a matching User-Agent, the plugin error message and README now explain why (cf_clearance is short-lived, pinned to the IP that solved the challenge, and the connection itself is TLS-fingerprinted) and what to try. Addresses the dead-end case reported in #34. No plugin behaviour changes.",
         "targetAbi": "10.11.0.0",

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,27 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.12.0',
+    headline: 'Multi-account support: one Jellyfin user, many Letterboxd accounts',
+    summary: 'Shared TV logins (e.g. two people on the same family Jellyfin profile) can now each have their own Letterboxd diary, ratings, and watchlist.',
+    highlights: {
+      new: [
+        'A Jellyfin user can link multiple Letterboxd accounts. Auto-sync (real-time and scheduled) fans out across every enabled account; one failing account never blocks the others.',
+        'The sidebar "My Letterboxd" page now has feature parity with the admin plugin page for per-account management: add, remove, reorder, test, and configure every account that belongs to your Jellyfin user, without needing admin access. (Admin-only things like the Jellyseerr server URL and editing other users\' accounts stay in the admin page.)',
+        "Per-account watchlist playlists. Default name is 'Letterboxd Watchlist ({letterboxdUsername})' so two accounts on one Jellyfin user get two separate playlists, with an optional per-account name override.",
+        "Review modal has a 'Post as' account selector when more than one account is enabled, defaulting to posting on all of them.",
+        'New IsPrimary flag on each account: used to break rating conflicts on diary import and as the preselected option in the review modal.',
+      ],
+      improvements: [
+        'Manual API endpoints (/Sync, /SyncWatchlist, /Review) accept an optional letterboxdUsername selector. Omit it to fan out across all enabled accounts.',
+        'Diary import unions played-state across all linked accounts and merges ratings with the primary account winning conflicts. Existing Jellyfin ratings are still preserved.',
+      ],
+      breaking: [
+        "Single-account users will see a new 'Letterboxd Watchlist (yourusername)' playlist created on the next watchlist sync. The old 'Letterboxd Watchlist' playlist is left untouched so you can delete or migrate at your leisure.",
+      ],
+    },
+  },
+  {
     version: '1.11.3',
     headline: 'Plain-English error and docs when Cloudflare 403s with cookies already set',
     highlights: {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -53,7 +53,7 @@ const featureGroups: FeatureGroup[] = [
     intro: 'Multi-user, resilient, and transparent about what it did.',
     visual: 'dashboard',
     items: [
-      { title: 'Multi-user', body: 'Each Jellyfin user links their own Letterboxd account, with a per-user dashboard and Run Sync Now button. No admin access needed.', icon: 'users' },
+      { title: 'Multi-user, multi-account', body: 'Each Jellyfin user links one or more Letterboxd accounts. Shared TV logins fan out to every linked diary, each account gets its own watchlist playlist, and the primary one wins on rating conflicts.', icon: 'users' },
       { title: 'Smart catch-up', body: 'Already-synced films short-circuit locally with no Letterboxd hit. Previously-failed items retry first when rate limits ease.', icon: 'bolt' },
       { title: 'Cloudflare resilient', body: 'Official API first, scraping fallback, automatic retry.', icon: 'cloud' },
       { title: 'Self-healing auth', body: 'Stale cookies trigger an automatic re-login and retry.', icon: 'refresh' },


### PR DESCRIPTION
Targets `main`. Bumps to v1.12.0 on merge.

## Summary

Adds first-class support for one Jellyfin user mapping to multiple Letterboxd accounts. Use case: shared TV-user logins (e.g. Lachlan + Deb on the same family Jellyfin profile) where each person wants their own Letterboxd diary, ratings, and watchlist.

## What changes

**Auto-sync paths fan out across all enabled accounts.** Watching a film triggers a diary entry on every Letterboxd account linked to the watching Jellyfin user; the scheduled export does the same. One failing account never blocks the others. Files: `PlaybackHandler`, `LetterboxdSyncRunner`, `WatchlistSyncRunner`.

**Manual API paths accept an optional `letterboxdUsername` selector.** When provided, target only that account; when omitted, fan out by default. Endpoints: `POST /Sync`, `POST /SyncWatchlist`, `POST /Review`.

**Diary import unions played-state and merges ratings.** Any Letterboxd account having a film in its diary marks the film played in Jellyfin. On rating conflict (e.g. 4 stars on one account, 3 stars on another), the primary account's rating wins. Existing Jellyfin ratings are still preserved (anti-clobber).

**Per-account watchlist playlists.** Default name is `Letterboxd Watchlist ({letterboxdUsername})` so two accounts on one Jellyfin user get two separate playlists. Optional override via `Account.PlaylistName`.

**`IsPrimary` flag on Account.** Used for: rating-conflict resolution on diary import, preselection in the review modal's account dropdown, and gating the Jellyseerr watchlist mirror (see below). Server normalises invariants on both save paths (admin and per-user).

**Full multi-account UX on the user-facing sidebar page**, with feature parity to the admin plugin page (except admin-global things like the Jellyseerr server URL and listing other users' accounts). The sidebar `My Letterboxd` page now exposes a list of the calling user's accounts with: + Add Account / Remove, per-row Test Connection, all per-account fields (username/password/cookies/UA/checkboxes), IsPrimary toggle, optional PlaylistName override, and the same "Post as" dropdown in the review modal that the admin page has. Two new server endpoints back this: `GET /Accounts` and `PUT /Accounts`, scoped to the calling Jellyfin user (other users' rows preserved on save, calling user's id force-stamped onto every submitted account, NormalisePrimaryFlags runs after).

**UI: account selector in the review modal.** Hidden when the user has 0 or 1 enabled accounts. Shown as "Post as" with "All my Letterboxd accounts" as the default value, then primary first, then secondaries.

**Jellyseerr watchlist mirror restricted to the primary account.** The Jellyseerr watchlist is keyed by Jellyfin user, not by Letterboxd account, so running the mirror once per account had each account's diff overwrite the last. Non-primary accounts now log a one-line skip and move on. AutoRequestWatchlist still fan-outs (idempotent on Jellyseerr's side).

**Admin-save invariant fix.** `NormalisePrimaryFlags` was only enforced on the per-user `PUT /Account` endpoint; the admin config page saves via Jellyfin's stock `updatePluginConfiguration` and bypassed it. Added `BasePlugin.UpdateConfiguration` override in `Plugin.cs` so the invariant holds across both save paths.

**Bug fix: userPage save no longer clobbers admin-managed fields.** `PUT /Account` was copying `IsPrimary` and `PlaylistName` from the request body, but the userPage form doesn't expose them. Result: every userPage save defaulted them to false/null and `NormalisePrimaryFlags` then re-promoted whichever account was first in config order, silently shuffling the primary. Stopped copying those two fields; admin page is the single source of truth for them.

**deploy.sh self-heals plugin directory.** Jellyfin renames the plugin folder to `LetterboxdSync_<assemblyVersion>` on load, so the hardcoded `LetterboxdSync_1.0.0.0` path silently no-op'd every deploy after the first install. The script now discovers the loaded directory via `ls -d ... | sort -V | tail -1`.

**Landing site copy updated** (`site/src/data/release-notes.ts`, `site/src/pages/index.astro`). Multi-user feature item is now "Multi-user, multi-account" with the shared-TV-login use case called out.

## Tests
- **470 total** (up from 256 in the original draft; 11 of the additions cover the new `/Accounts` endpoints — user-scope isolation, primary-first ordering, empty-username validation, NormalisePrimaryFlags auto-promote and demote, other-users-untouched, UserJellyfinId stamping)
- Helper coverage: enabled-only filtering, primary ordering, case-insensitive lookup, auto-promote, multi-primary collapse, per-user scoping, idempotency, playlist name fallbacks
- Contract coverage: `Account` defaults, `AccountUpdateRequest` field mapping, `ReviewRequest` exposes `LetterboxdUsername`, primary-wins ordering for the diary-import merge

## Behavioural changes existing users will notice
1. **Watchlist playlist rename.** Single-account users currently have a playlist called `Letterboxd Watchlist`; after upgrade, a new `Letterboxd Watchlist (yourusername)` is created on the next watchlist sync. The old one is left untouched.
2. **No silent fan-out for legacy single-account users.** If you have one account, behaviour is identical.

## Test plan
- [x] Unit tests: 470/470 pass
- [x] Build: Release succeeds
- [x] Deployed to a real Jellyfin server; sidebar page renders the multi-account UI, + Add Account works, Save round-trips through the new `/Accounts` endpoints, Post-as dropdown lists both accounts in the review modal
- [x] Test Connection works per-row in the sidebar
- [ ] Manual: configure two Letterboxd accounts on one Jellyfin user, finish a movie, confirm both diaries get the entry
- [ ] Manual: with two accounts, post a review with no account selected, confirm both Letterboxd accounts receive it
- [ ] Manual: post a review with one account selected, confirm only that one receives it
- [ ] Manual: rate the same film differently on two LB accounts, run diary import, confirm primary's rating wins in Jellyfin
- [ ] Manual: enable watchlist sync on both accounts, confirm two separate Jellyfin playlists appear
- [ ] Manual: enable MirrorJellyseerrWatchlist on both accounts, confirm only the primary's watchlist hits Jellyseerr
- [ ] Manual: try to mark two accounts as primary on the same user via the admin page, save, confirm only one stays primary