### PR TITLE
ci: add Codecov coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,14 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal
+        # XPlat Code Coverage uses coverlet.collector (already a test-project dep)
+        # to emit Cobertura XML under TestResults/<guid>/coverage.cobertura.xml.
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./TestResults/**/coverage.cobertura.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/ci.yml/badge.svg)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/ci.yml)
 [![Release](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/release.yml/badge.svg)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/release.yml)
+[![codecov](https://codecov.io/gh/builtbyproxy/jellyfin-plugin-letterboxd/branch/main/graph/badge.svg)](https://codecov.io/gh/builtbyproxy/jellyfin-plugin-letterboxd)
 [![GitHub release](https://img.shields.io/github/v/release/builtbyproxy/jellyfin-plugin-letterboxd)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/github/downloads/builtbyproxy/jellyfin-plugin-letterboxd/total)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,48 @@
+# Codecov config. See https://docs.codecov.com/docs/codecov-yaml
+#
+# We optimise for "coverage as a signal" rather than "coverage as a blocker":
+# new code on a PR should generally have a test, but small dips on the project
+# total don't fail CI. Codecov posts a comment with diff coverage on every PR.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 1
+  round: nearest
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        # Project-wide coverage target. `auto` means "match the previous commit"
+        # so we don't reject PRs that hold the line. 1% threshold lets refactors
+        # through without forcing churn on covered code.
+        target: auto
+        threshold: 1%
+        informational: false
+        only_pulls: false
+    patch:
+      default:
+        # Coverage of the lines this PR adds/changes. New code should be tested
+        # but we tolerate small misses (test setup, error paths) below 70%.
+        target: 70%
+        threshold: 5%
+        informational: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Don't penalise the project total for code that's intentionally untested:
+#  - Web/ contains embedded HTML/JS resources, not C#
+#  - bin/ and obj/ are build artifacts
+#  - .Tests/ shouldn't measure its own coverage
+ignore:
+  - "**/bin/**"
+  - "**/obj/**"
+  - "LetterboxdSync/Web/**"
+  - "LetterboxdSync.Tests/**"


### PR DESCRIPTION
## Summary

Wires up [Codecov](https://app.codecov.io/gh/builtbyproxy/jellyfin-plugin-letterboxd) so PRs get coverage diff comments and the README shows a coverage badge.

## What changes

**CI workflow (`ci.yml`)**: the existing test step now collects coverage via `--collect:"XPlat Code Coverage"`, which uses the `coverlet.collector` package already on the test project to emit Cobertura XML under `TestResults/`. A new step uploads the XML to Codecov via `codecov/codecov-action@v5`, gated on `secrets.CODECOV_TOKEN` (already set on the repo).

**Codecov config (`codecov.yml`)**:
- Project status target is `auto` with a 1% threshold, so PRs that hold the line aren't rejected
- Patch (diff) coverage target is 70% with a 5% threshold, so new code is generally tested but not blocked on hard-to-mock paths
- Ignores `Web/` (embedded HTML/JS resources, not C#), `bin/`, `obj/`, and the test project itself
- PR comment shows reach + diff + flags + files

**README badge**: standard Codecov svg, slotted between the Release badge and the GitHub release version badge.

## Coverage baseline

Local run reports project line rate of **~31.6%** today. The well-covered code is `Helpers`, the rating mappers, the `LetterboxdScraper.ExtractRatingFromContainer` parser, the `LetterboxdApiClient` field extractors, and `AccountExtensions`. The under-covered code is the syncers (`PlaybackHandler`, `LetterboxdSyncRunner`, `WatchlistSyncRunner`, `DiaryImportTask`) which need Jellyfin DI plumbing to test directly — those are deliberate gaps for now.

## Test plan
- [x] Local: `dotnet test --collect:"XPlat Code Coverage"` produces `coverage.cobertura.xml`
- [x] `gh secret list` confirms `CODECOV_TOKEN` is set
- [x] Reviewer to confirm the CI run on this PR uploads to Codecov and the bot leaves a comment with diff coverage