### PR TITLE
fix(watchlist): skip tv/ TMDb links to prevent movie-namespace collisions

### DIFF
--- a/LetterboxdSync.Tests/RatedFilmsApiTests.cs
+++ b/LetterboxdSync.Tests/RatedFilmsApiTests.cs
@@ -66,6 +66,62 @@ public class FilmSummaryHelperTests
         Assert.Null(LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
     }
 
+    // Regression: Letterboxd's API returns the same FilmSummary shape for TV-show
+    // entries, with the tmdb link pointing at /tv/<id>. TMDb's movie and TV ID
+    // namespaces are independent, so e.g. tv/198102 = "Hijack" and movie/198102 =
+    // "Cutie Honey Flash". Without the /tv/ guard, watchlisting Hijack on
+    // Letterboxd ends up auto-requesting Cutie Honey in Jellyseerr.
+    [Fact]
+    public void ExtractTmdbIdFromLinks_TvShow_SkipsTvLink()
+    {
+        var film = Parse(@"{
+            ""name"": ""Hijack"",
+            ""links"": [
+                { ""type"": ""letterboxd"", ""id"": ""HykO"", ""url"": ""https://letterboxd.com/film/hijack-2023/"" },
+                { ""type"": ""imdb"", ""id"": ""tt19854762"", ""url"": ""https://www.imdb.com/title/tt19854762/"" },
+                { ""type"": ""tmdb"", ""id"": ""198102"", ""url"": ""https://www.themoviedb.org/tv/198102"" }
+            ]
+        }");
+
+        Assert.Null(LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_MovieUrl_ReturnsId()
+    {
+        var film = Parse(@"{
+            ""links"": [
+                { ""type"": ""tmdb"", ""id"": ""1233413"", ""url"": ""https://www.themoviedb.org/movie/1233413"" }
+            ]
+        }");
+
+        Assert.Equal(1233413, LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_TmdbWithNoUrl_StillReturnsId()
+    {
+        // Older API responses sometimes omit `url`; without it we have no way to
+        // disambiguate, so fall back to returning the id (caller's existing
+        // movie-namespace assumption).
+        var film = Parse(@"{ ""links"": [ { ""type"": ""tmdb"", ""id"": ""550"" } ] }");
+        Assert.Equal(550, LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
+    [Fact]
+    public void ExtractTmdbIdFromLinks_MixedTvAndMovieLinks_PrefersMovie()
+    {
+        // Defensive: if the API ever returns both, take the movie one.
+        var film = Parse(@"{
+            ""links"": [
+                { ""type"": ""tmdb"", ""id"": ""198102"", ""url"": ""https://www.themoviedb.org/tv/198102"" },
+                { ""type"": ""tmdb"", ""id"": ""1233413"", ""url"": ""https://www.themoviedb.org/movie/1233413"" }
+            ]
+        }");
+
+        Assert.Equal(1233413, LetterboxdApiClient.ExtractTmdbIdFromLinks(film));
+    }
+
     [Fact]
     public void ExtractMemberRating_PresentRating_ReturnsValue()
     {

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -317,6 +317,9 @@ public class LetterboxdApiClient : ILetterboxdService
     /// Pull TMDb ID from a FilmSummary's `links` array.
     /// FilmSummary uses `links: [{type:"tmdb", id:"123"}, ...]` rather than a
     /// nested `film` object with provider IDs (which is what /log-entries returns).
+    /// Skips TV-show TMDb links: TMDb has separate ID namespaces for movies
+    /// and TV, so e.g. tv/198102 (Hijack, BBC drama) collides with movie/198102
+    /// (Cutie Honey Flash). The watchlist/diary syncs target movies only.
     /// </summary>
     internal static int? ExtractTmdbIdFromLinks(JsonElement film)
     {
@@ -327,6 +330,12 @@ public class LetterboxdApiClient : ILetterboxdService
         {
             if (!link.TryGetProperty("type", out var type)) continue;
             if (!string.Equals(type.GetString(), "tmdb", StringComparison.OrdinalIgnoreCase)) continue;
+
+            if (link.TryGetProperty("url", out var urlEl) &&
+                urlEl.GetString() is string url &&
+                url.Contains("/tv/", StringComparison.Ordinal))
+                continue;
+
             if (!link.TryGetProperty("id", out var idEl)) continue;
             if (int.TryParse(idEl.GetString(), out var id)) return id;
         }
@@ -495,23 +504,7 @@ public class LetterboxdApiClient : ILetterboxdService
         return string.Empty;
     }
 
-    private static int? ExtractTmdbId(JsonElement film)
-    {
-        if (film.TryGetProperty("links", out var links))
-        {
-            foreach (var link in links.EnumerateArray())
-            {
-                if (link.TryGetProperty("type", out var type) && type.GetString() == "tmdb" &&
-                    link.TryGetProperty("id", out var id))
-                {
-                    if (int.TryParse(id.GetString(), out var tmdbId))
-                        return tmdbId;
-                }
-            }
-        }
-
-        return null;
-    }
+    private static int? ExtractTmdbId(JsonElement film) => ExtractTmdbIdFromLinks(film);
 
     internal record TokenInfo(string AccessToken, string RefreshToken, DateTime ExpiresAtUtc, string MemberId);
 }


### PR DESCRIPTION
## Summary

The watchlist sync was auto-requesting wrong films in Jellyseerr when a user watchlisted a TV show on Letterboxd. Reproduced live: \`8bitproxy\` watchlists \`Hijack\` (BBC drama, 2023) and Jellyseerr ends up with a request for \`Cutie Honey Flash: The Movie\` (1997).

## Root cause

TMDb maintains independent ID namespaces for movies and TV shows. \`tv/198102\` is \`Hijack\`; \`movie/198102\` is \`Cutie Honey Flash\`. Letterboxd's API correctly distinguishes them by URL:

```json
{ "type": "tmdb", "id": "198102", "url": "https://www.themoviedb.org/tv/198102" }
```

But \`ExtractTmdbIdFromLinks\` and the duplicated private \`ExtractTmdbId\` only read \`link.id\` and ignore \`link.url\`. Downstream, \`WatchlistSyncRunner\` and \`GetDiaryFilmEntriesAsync\` hand the bare integer to \`JellyseerrClient.RequestMovieAsync\` / TMDB-movie-ID matchers, so Jellyseerr resolves \`198102\` in its movie namespace.

## Fix

- \`ExtractTmdbIdFromLinks\`: skip links whose \`url\` contains \`/tv/\`. Without a \`url\` field, fall back to the existing behavior so older API shapes still work.
- Collapse the duplicated \`ExtractTmdbId\` private into a delegating call to \`ExtractTmdbIdFromLinks\`. The duplicate was the bug-multiplier here.

## Test plan

- [x] \`dotnet test\` — 422/422 pass
- [x] New regression cases in \`FilmSummaryHelperTests\`:
  - TV link with full \`/tv/198102\` URL returns null
  - Movie link with \`/movie/...\` URL returns id
  - Missing-\`url\` legacy shape still returns id (graceful fallback)
  - Mixed TV+movie links prefers the movie one
- [ ] Manual: rebuild + scp DLL to server, trigger watchlist sync, confirm Cutie Honey is no longer re-added when Hijack is on the watchlist