### PR TITLE
fix(diary-import): suppress phantom rewatch entries on Letterboxd (#32)

### DIFF
--- a/LetterboxdSync.Tests/DiaryImportTaskTests.cs
+++ b/LetterboxdSync.Tests/DiaryImportTaskTests.cs
@@ -45,6 +45,11 @@ public class DiaryImportTaskTests : IDisposable
 
         new Plugin(paths, xml);
 
+        // Isolate SyncHistory I/O to the test's temp dir so each test starts clean and
+        // doesn't pollute the shared on-disk store the assembly would otherwise use.
+        SyncHistory.DataPathOverride = Path.Combine(_tempDir, "sync-history.jsonl");
+        SyncHistory.ResetForTesting();
+
         _userManager = Substitute.For<IUserManager>();
         _libraryManager = Substitute.For<ILibraryManager>();
         _userDataManager = Substitute.For<IUserDataManager>();
@@ -55,6 +60,8 @@ public class DiaryImportTaskTests : IDisposable
     public void Dispose()
     {
         LetterboxdServiceFactory.OverrideForTesting = null;
+        SyncHistory.DataPathOverride = null;
+        SyncHistory.ResetForTesting();
         try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
     }
 
@@ -368,5 +375,72 @@ public class DiaryImportTaskTests : IDisposable
         Assert.Equal("LetterboxdDiaryImport", _task.Key);
         Assert.Equal("Letterboxd", _task.Category);
         Assert.False(string.IsNullOrEmpty(_task.Description));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NewlyMarkedPlayed_RecordsDiaryImportSyncEvent()
+    {
+        // Regression test for #32: a film marked played from the LB diary must be tagged
+        // in SyncHistory so the LetterboxdSyncRunner can recognise it as imported and
+        // refuse to re-export it back to Letterboxd as a phantom diary entry.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.Users.Returns(new[] { user });
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId, LetterboxdUsername = "u",
+            Enabled = true, EnableDiaryImport = true
+        });
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetDiaryFilmEntriesAsync(Arg.Any<string>())
+            .Returns(new List<DiaryFilmEntry> { new(1233413, null) });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        var movie = MakeMovie(1233413, "Sinners");
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>())
+            .Returns(new List<BaseItem> { movie });
+
+        var userData = MakeUserData(played: false, rating: null);
+        _userDataManager.GetUserData(user, movie).Returns(userData);
+
+        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.True(SyncHistory.WasImportedFromDiary("lachlan", 1233413));
+
+        var recorded = SyncHistory.GetRecent(count: 10, username: "lachlan");
+        var importEvent = Assert.Single(recorded);
+        Assert.Equal(SyncEventSources.DiaryImport, importEvent.Source);
+        Assert.Equal(1233413, importEvent.TmdbId);
+        Assert.Equal("Sinners", importEvent.FilmTitle);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyPlayed_DoesNotRecordDiaryImportEvent()
+    {
+        // If the film was already marked played in Jellyfin (e.g. real playback or a prior
+        // import), we don't write a fresh marker. Re-running the import is idempotent.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.Users.Returns(new[] { user });
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId, LetterboxdUsername = "u",
+            Enabled = true, EnableDiaryImport = true
+        });
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetDiaryFilmEntriesAsync(Arg.Any<string>())
+            .Returns(new List<DiaryFilmEntry> { new(1233413, null) });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+
+        var userData = MakeUserData(played: true, rating: null);
+        _userDataManager.GetUserData(user, movie).Returns(userData);
+
+        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.False(SyncHistory.WasImportedFromDiary("lachlan", 1233413));
+        Assert.Empty(SyncHistory.GetRecent(count: 10, username: "lachlan"));
     }
 }

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -45,6 +45,11 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         new Plugin(paths, xml);
 
+        // Isolate SyncHistory I/O per test so the diary-import suppression check
+        // doesn't see stale events from other tests.
+        SyncHistory.DataPathOverride = Path.Combine(_tempDir, "sync-history.jsonl");
+        SyncHistory.ResetForTesting();
+
         _userManager = Substitute.For<IUserManager>();
         _libraryManager = Substitute.For<ILibraryManager>();
         _userDataManager = Substitute.For<IUserDataManager>();
@@ -55,6 +60,8 @@ public class LetterboxdSyncRunnerTests : IDisposable
     public void Dispose()
     {
         LetterboxdServiceFactory.OverrideForTesting = null;
+        SyncHistory.DataPathOverride = null;
+        SyncHistory.ResetForTesting();
         try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
     }
 
@@ -369,5 +376,101 @@ public class LetterboxdSyncRunnerTests : IDisposable
         Assert.True(ok);
         // We never get past the TMDb-id check, so LookupFilmByTmdbIdAsync isn't called.
         await service.DidNotReceive().LookupFilmByTmdbIdAsync(Arg.Any<int>());
+    }
+
+    // ----- Diary-import suppression (issue #32) -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_DiaryImportedFilmWithoutLastPlayedDate_DoesNotExportToLetterboxd()
+    {
+        // The bug: DiaryImportTask marked the film played from the LB diary; the next
+        // scheduled sync sees IsPlayed=true with no LastPlayedDate, defaults to today,
+        // and posts a phantom diary entry. With the fix, the diary-import marker
+        // gates re-export until a real Jellyfin playback (LastPlayedDate set).
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.Users.Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+
+        var importedUserData = new UserItemData
+        {
+            Key = "k", Played = true, LastPlayedDate = null
+        };
+        _userDataManager.GetUserData(user, movie).Returns(importedUserData);
+
+        SyncHistory.Record(new SyncEvent
+        {
+            FilmTitle = "Sinners",
+            TmdbId = 1233413,
+            Username = "lachlan",
+            Timestamp = DateTime.UtcNow,
+            Status = SyncStatus.Skipped,
+            Source = SyncEventSources.DiaryImport
+        });
+
+        var factoryHit = false;
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(Substitute.For<ILetterboxdService>());
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        // Filter eliminated the only candidate, so the runner exits before authenticating.
+        Assert.False(factoryHit);
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_DiaryImportedFilmThenActuallyPlayed_StillExportsToLetterboxd()
+    {
+        // Counterpart to the suppression test: if the user actually watches the film
+        // on Jellyfin after the import (LastPlayedDate set), the suppression must
+        // release so the rewatch lands on Letterboxd.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.Users.Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+
+        var playedUserData = new UserItemData
+        {
+            Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow
+        };
+        _userDataManager.GetUserData(user, movie).Returns(playedUserData);
+
+        SyncHistory.Record(new SyncEvent
+        {
+            FilmTitle = "Sinners",
+            TmdbId = 1233413,
+            Username = "lachlan",
+            Timestamp = DateTime.UtcNow.AddDays(-3),
+            Status = SyncStatus.Skipped,
+            Source = SyncEventSources.DiaryImport
+        });
+
+        var factoryHit = false;
+        var service = Substitute.For<ILetterboxdService>();
+        // Make the lookup throw so we don't have to wait through the runner's inter-call
+        // delay. We only care that the runner got past the diary-import suppression and
+        // attempted to authenticate / look the film up.
+        service.LookupFilmByTmdbIdAsync(Arg.Any<int>())
+            .Returns<Task<FilmResult>>(_ => throw new Exception("stop here"));
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(service);
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(factoryHit, "real playback after diary import should re-enable export");
     }
 }

--- a/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
+++ b/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
@@ -166,4 +166,67 @@ public class SyncHistoryLookupTests
         // The newer event belongs to the other user — ours is older but is the right answer.
         Assert.Equal(SyncStatus.Failed, SyncHistory.GetLastStatusForFilm(events, User, FilmA));
     }
+
+    private static SyncEvent DiaryImportEvent(string username, int tmdbId, DateTime? recordedAt = null)
+        => new()
+        {
+            Username = username,
+            TmdbId = tmdbId,
+            Status = SyncStatus.Skipped,
+            Source = SyncEventSources.DiaryImport,
+            Timestamp = recordedAt ?? DateTime.UtcNow
+        };
+
+    [Fact]
+    public void WasImportedFromDiary_TrueWhenMatchingDiaryImportEventExists()
+    {
+        var events = new List<SyncEvent> { DiaryImportEvent(User, FilmA) };
+
+        Assert.True(SyncHistory.WasImportedFromDiary(events, User, FilmA));
+    }
+
+    [Fact]
+    public void WasImportedFromDiary_FalseWhenSourceIsNotDiaryImport()
+    {
+        // Only the diary-import sentinel counts; ordinary sync events are not import markers.
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Success)
+        };
+
+        Assert.False(SyncHistory.WasImportedFromDiary(events, User, FilmA));
+    }
+
+    [Fact]
+    public void WasImportedFromDiary_IgnoresOtherUsersAndOtherFilms()
+    {
+        var events = new List<SyncEvent>
+        {
+            DiaryImportEvent(OtherUser, FilmA),
+            DiaryImportEvent(User, FilmB)
+        };
+
+        Assert.False(SyncHistory.WasImportedFromDiary(events, User, FilmA));
+    }
+
+    [Fact]
+    public void WasImportedFromDiary_FalseOnEmptyHistory()
+    {
+        Assert.False(SyncHistory.WasImportedFromDiary(new List<SyncEvent>(), User, FilmA));
+    }
+
+    [Fact]
+    public void WasImportedFromDiary_TrueWhenAnyHistoricalDiaryImportExists()
+    {
+        // Even if subsequent attempts produce other events, the historical import marker
+        // should keep the runner from re-exporting until a real Jellyfin playback happens
+        // (which the runner gates separately via LastPlayedDate).
+        var events = new List<SyncEvent>
+        {
+            DiaryImportEvent(User, FilmA, recordedAt: new DateTime(2026, 4, 1)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 2))
+        };
+
+        Assert.True(SyncHistory.WasImportedFromDiary(events, User, FilmA));
+    }
 }

--- a/LetterboxdSync.Tests/SyncHistoryStaticTests.cs
+++ b/LetterboxdSync.Tests/SyncHistoryStaticTests.cs
@@ -15,8 +15,12 @@ namespace LetterboxdSync.Tests;
 /// the public API (Record / GetRecent / GetPage / GetLastStatusForFilm / GetStats /
 /// WasSuccessfullySynced / GetLastSuccessfulSyncDate) end-to-end via the new
 /// DataPathOverride hook so file I/O is isolated to a temp file per test.
+///
+/// Lives in the "Plugin" collection because PlaybackHandler / LetterboxdSyncRunner
+/// / DiaryImportTask tests in that collection write to SyncHistory through the
+/// code under test, and xUnit only serialises tests within the same collection.
 /// </summary>
-[Collection("SyncHistory")]
+[Collection("Plugin")]
 public class SyncHistoryStaticTests : IDisposable
 {
     private readonly string _tempDir;

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -125,6 +125,23 @@ public class DiaryImportTask : IScheduledTask
                     marked++;
                     _logger.LogInformation("Marked {Title} as played for {Username} (from Letterboxd diary)",
                         movie.Name, user.Username);
+
+                    // Record a diary-import event so LetterboxdSyncRunner can recognise this
+                    // film as imported (rather than truly watched on Jellyfin) and refuse to
+                    // re-export it back to Letterboxd. Without this, the next scheduled sync
+                    // sees IsPlayed=true with no LastPlayedDate, defaults the viewing date to
+                    // today, fails the same-day duplicate check (LB diary entry is from
+                    // another date), and creates a phantom rewatch entry. See issue #32.
+                    SyncHistory.Record(new SyncEvent
+                    {
+                        FilmTitle = movie.Name,
+                        TmdbId = tmdbId,
+                        Username = user.Username ?? string.Empty,
+                        Timestamp = DateTime.UtcNow,
+                        Status = SyncStatus.Skipped,
+                        Source = SyncEventSources.DiaryImport,
+                        Error = "Marked played from Letterboxd diary; suppress re-export"
+                    });
                 }
 
                 // Apply Letterboxd rating only when Jellyfin doesn't already have one.

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -152,6 +152,41 @@ public class LetterboxdSyncRunner
             return;
         }
 
+        // Suppress films that DiaryImportTask marked played from the user's Letterboxd
+        // diary, unless they've since been actually watched on Jellyfin (LastPlayedDate
+        // set). Without this, the daily sync would invent a phantom rewatch every time
+        // it ran for the same imported film, because viewingDate defaults to today
+        // when LastPlayedDate is null and the LB-side same-day duplicate check
+        // therefore never matches the original (older) diary date. See issue #32.
+        var skippedDiaryImports = 0;
+        movies = movies.Where(m =>
+        {
+            var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
+            if (!int.TryParse(tmdbStr, out var tmdbId)) return true;
+
+            var ud = _userDataManager.GetUserData(user, m);
+            if (ud?.LastPlayedDate.HasValue == true) return true;
+
+            if (SyncHistory.WasImportedFromDiary(user.Username ?? string.Empty, tmdbId))
+            {
+                skippedDiaryImports++;
+                return false;
+            }
+            return true;
+        }).ToList();
+
+        if (skippedDiaryImports > 0)
+            _logger.LogInformation(
+                "Skipping {Count} films for {Username}: previously imported from Letterboxd diary " +
+                "and not played on Jellyfin since",
+                skippedDiaryImports, user.Username);
+
+        if (movies.Count == 0)
+        {
+            SyncProgress.Complete();
+            return;
+        }
+
         // Filter out anything we already successfully synced for this exact viewing date,
         // so we don't burn Cloudflare quota re-checking films that are definitely on Letterboxd.
         // Sort what's left so previously-failed/skipped films come first — if rate limits hit,

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -16,6 +16,16 @@ public enum SyncStatus
     Rewatch
 }
 
+/// <summary>
+/// Well-known values for SyncEvent.Source. Free-form strings are still allowed,
+/// but these are the ones the runner switches on.
+/// </summary>
+public static class SyncEventSources
+{
+    /// <summary>DiaryImportTask marked a Jellyfin item played because it appeared on the user's Letterboxd diary.</summary>
+    public const string DiaryImport = "diary-import";
+}
+
 public class SyncEvent
 {
     public string FilmTitle { get; set; } = string.Empty;
@@ -278,6 +288,32 @@ public static class SyncHistory
             if (latest == null || e.Timestamp > latest.Timestamp) latest = e;
         }
         return latest?.ViewingDate;
+    }
+
+    /// <summary>
+    /// True if DiaryImportTask has previously marked this user's Jellyfin copy of this
+    /// film as played because the film was found on their Letterboxd diary. The runner
+    /// uses this as a guard against the import-then-export loop described in
+    /// https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/issues/32.
+    /// </summary>
+    public static bool WasImportedFromDiary(string username, int tmdbId)
+    {
+        lock (_lock)
+        {
+            return WasImportedFromDiary(LoadEvents(), username, tmdbId);
+        }
+    }
+
+    internal static bool WasImportedFromDiary(IEnumerable<SyncEvent> events, string username, int tmdbId)
+    {
+        foreach (var e in events)
+        {
+            if (e.TmdbId != tmdbId) continue;
+            if (!string.Equals(e.Username, username, StringComparison.Ordinal)) continue;
+            if (string.Equals(e.Source, SyncEventSources.DiaryImport, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
     }
 
     public static (int Total, int Success, int Failed, int Skipped, int Rewatches) GetStats(string? username = null)


### PR DESCRIPTION
## Summary

Fixes #32. With \`EnableDiaryImport\` on, the daily \`SyncTask\` was creating phantom rewatch entries on Letterboxd for films that \`DiaryImportTask\` had marked as played from the user's Letterboxd diary.

**The loop:**
1. User logs a film on Letterboxd directly (e.g. watched on another device).
2. \`DiaryImportTask\` runs, marks the Jellyfin item \`Played = true\`. \`LastPlayedDate\` is intentionally left \`null\` to avoid this very loop.
3. \`LetterboxdSyncRunner\` later picks the film up because \`IsPlayed = true\`, defaults \`viewingDate\` to today (since \`LastPlayedDate\` is null), and the same-day duplicate check against the LB diary fails (LB entry is from a different date).
4. Runner posts a fresh diary entry. Next day: same thing → another phantom rewatch.

## Fix

- \`SyncHistory\` records a new \`SyncEvent\` with \`Source = "diary-import"\` whenever \`DiaryImportTask\` marks a film played.
- \`LetterboxdSyncRunner.SyncOneUserAsync\` filters out films that have a diary-import marker AND no \`LastPlayedDate\` (i.e. never actually played on Jellyfin since the import). If the user later watches the film on Jellyfin, \`LastPlayedDate\` is set by playback and the suppression releases — the rewatch lands on Letterboxd as expected.
- New \`SyncHistory.WasImportedFromDiary\` helper, plus a \`SyncEventSources\` constants class so the sentinel string isn't repeated across modules.

## Test plan

- [x] \`SyncHistoryLookupTests\` — pure-function tests for \`WasImportedFromDiary\` (true/false/other-user/other-film/empty/coexists-with-other-events)
- [x] \`DiaryImportTaskTests\` — verifies the diary-import event is recorded on first import and not re-recorded for an already-played film
- [x] \`LetterboxdSyncRunnerTests\` — \`DiaryImportedFilmWithoutLastPlayedDate_DoesNotExportToLetterboxd\` (film is filtered out before auth) and \`DiaryImportedFilmThenActuallyPlayed_StillExportsToLetterboxd\` (real playback releases the suppression)
- [x] \`SyncHistoryStaticTests\` moved into the \`Plugin\` collection so xUnit serialises it against the Plugin-collection tests that now write to \`SyncHistory\` (closes a pre-existing race that surfaced once \`DiaryImportTask\` started recording)
- [x] Full suite: 431 passed, 0 failed (35s, ~stable across reruns)

Note: the second part of #32 (manual "ignore and remove from Letterboxd" UI) is intentionally out of scope for this PR.