### PR TITLE
docs: document File Transformation plugin as sidebar link prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,22 @@ Uses Letterboxd's current JSON API (`/api/v0/production-log-entries`).
 ### Plugin repository (recommended)
 
 1. In Jellyfin, go to **Dashboard > Plugins > Repositories**
-2. Add a new repository:
+2. Add the **File Transformation** repository (required for the sidebar link):
+   - **Name:** `File Transformation`
+   - **URL:** `https://www.iamparadox.dev/jellyfin/plugins/manifest.json`
+3. Add the LetterboxdSync repository:
    - **Name:** `LetterboxdSync`
    - **URL:** `https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json`
-3. Go to **Catalog**, find **LetterboxdSync**, and click **Install**
-4. Restart Jellyfin
+4. Go to **Catalog**, install **File Transformation**, then install **LetterboxdSync**
+5. Restart Jellyfin
+6. Hard-refresh the Jellyfin web UI (Ctrl/Cmd + Shift + R) so the new sidebar link loads
 
 ### Manual install
 
-1. Download the latest ZIP from [Releases](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases)
-2. Extract `LetterboxdSync.dll` and `HtmlAgilityPack.dll` to your Jellyfin plugins directory
-3. Restart Jellyfin
+1. Install the **File Transformation** plugin first (see [iamparadox27/Jellyfin.Plugin.FileTransformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation/releases)), required for the sidebar link to appear
+2. Download the latest LetterboxdSync ZIP from [Releases](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases)
+3. Extract `LetterboxdSync.dll` and `HtmlAgilityPack.dll` to your Jellyfin plugins directory
+4. Restart Jellyfin
 
 ## Setup
 
@@ -99,6 +104,7 @@ The `cf_clearance` cookie expires periodically and may need refreshing.
 
 - Jellyfin 10.11+
 - A Letterboxd account
+- [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation), required for the Letterboxd link to appear in the Jellyfin sidebar (everything else works without it)
 
 ## Building from source
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,6 +7,8 @@ import DashboardPeek from '../components/DashboardPeek.astro';
 
 const repoUrl = 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd';
 const manifestUrl = 'https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json';
+const fileTransformationManifestUrl = 'https://www.iamparadox.dev/jellyfin/plugins/manifest.json';
+const fileTransformationRepoUrl = 'https://github.com/IAmParadox27/jellyfin-plugin-file-transformation';
 const releasesUrl = `${repoUrl}/releases`;
 const latestReleaseUrl = `${repoUrl}/releases/latest`;
 
@@ -204,7 +206,16 @@ const featureGroups: FeatureGroup[] = [
           <h3>Plugin repository</h3>
           <ol class="steps">
             <li>Open <strong>Dashboard &rarr; Plugins &rarr; Repositories</strong> in Jellyfin.</li>
-            <li>Add a new repository with name <code>LetterboxdSync</code> and URL:
+            <li>Add the <strong>File Transformation</strong> repository (needed for the sidebar link to appear):
+              <div class="install-pill install-pill-inline" data-pill>
+                <code class="install-pill-url">{fileTransformationManifestUrl}</code>
+                <button class="install-pill-btn" type="button" data-copy={fileTransformationManifestUrl} aria-label="Copy File Transformation manifest URL">
+                  <span class="copy-icon" aria-hidden="true">⧉</span>
+                  <span class="copy-text">Copy</span>
+                </button>
+              </div>
+            </li>
+            <li>Add the <strong>LetterboxdSync</strong> repository:
               <div class="install-pill install-pill-inline" data-pill>
                 <code class="install-pill-url">{manifestUrl}</code>
                 <button class="install-pill-btn" type="button" data-copy={manifestUrl} aria-label="Copy manifest URL">
@@ -213,15 +224,16 @@ const featureGroups: FeatureGroup[] = [
                 </button>
               </div>
             </li>
-            <li>Open the <strong>Catalog</strong>, find <strong>LetterboxdSync</strong>, and click <strong>Install</strong>.</li>
-            <li>Restart Jellyfin.</li>
+            <li>Open the <strong>Catalog</strong>, install <strong>File Transformation</strong>, then install <strong>LetterboxdSync</strong>.</li>
+            <li>Restart Jellyfin, then hard-refresh the web UI (Ctrl/Cmd + Shift + R) so the sidebar link loads.</li>
           </ol>
         </div>
 
         <div class="install-card">
           <h3>Manual install</h3>
           <ol class="steps">
-            <li>Download the latest ZIP from <a href={latestReleaseUrl} rel="noopener">Releases</a>.</li>
+            <li>Install the <a href={fileTransformationRepoUrl} rel="noopener">File Transformation plugin</a> first, required for the Letterboxd sidebar link.</li>
+            <li>Download the latest LetterboxdSync ZIP from <a href={latestReleaseUrl} rel="noopener">Releases</a>.</li>
             <li>Extract <code>LetterboxdSync.dll</code> and <code>HtmlAgilityPack.dll</code> into your Jellyfin plugins directory.</li>
             <li>Restart Jellyfin.</li>
           </ol>
@@ -232,6 +244,7 @@ const featureGroups: FeatureGroup[] = [
       <div class="reqs">
         <div class="req"><span class="req-label">Jellyfin</span><span class="req-value">10.11 or newer</span></div>
         <div class="req"><span class="req-label">Requires</span><span class="req-value">A Letterboxd account</span></div>
+        <div class="req"><span class="req-label">For sidebar link</span><span class="req-value"><a href={fileTransformationRepoUrl} rel="noopener">File Transformation plugin</a></span></div>
         <div class="req"><span class="req-label">License</span><span class="req-value">MIT</span></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The sidebar link injection in `SidebarInjection.cs` requires the File Transformation plugin to be installed alongside LetterboxdSync. Without it, `RegisterWithFileTransformation()` silently skips (logged at Debug level), so users see no Letterboxd entry in the Jellyfin sidebar and have no obvious clue why. A user just reported this against v1.11.1.

This PR documents the prerequisite in both the README and the landing site:

**README**
- Install section: adds the File Transformation repository as step 2 (plugin repo path) and as step 1 (manual install path), plus a hard-refresh step so the new sidebar entry actually loads.
- Requirements section: lists File Transformation with a note that everything else works without it.

**Site (`site/src/pages/index.astro`)**
- Plugin repository install card: adds a copy-pill for the File Transformation manifest URL and reorders the steps.
- Manual install card: adds File Transformation as the first step.
- Requirements footer: adds a "For sidebar link" row.

No plugin code touched, no version bump, no CHANGELOG (this repo doesn't track one — releases are git-tagged from csproj `AssemblyVersion`).

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Site deploy workflow (`deploy-docs.yml`) picks up the `site/**` change and ships to https://lachlanyoung.dev/jellyfin-plugin-letterboxd/
- [ ] Copy buttons on both manifest URLs work after deploy