### PR TITLE
docs: refresh CLAUDE.md with current architecture, test filters, and release steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,70 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Project Overview
 
-Jellyfin plugin that syncs watch history to Letterboxd. C#/.NET 9, targets Jellyfin 10.11. No official Letterboxd API exists, so this plugin authenticates via web scraping (cookie-based login, CSRF tokens, HTML parsing with HtmlAgilityPack).
+Jellyfin plugin that syncs watch history to Letterboxd. C#/.NET 9, targets Jellyfin 10.11 (`Jellyfin.Controller`/`Jellyfin.Model` 10.11.0). Letterboxd's official endpoint (`/api/v0/production-log-entries`) is preferred; the plugin falls back to web scraping (cookie login, CSRF tokens, HtmlAgilityPack) when the API path fails.
+
+The sidebar link in the Jellyfin web UI depends on the third-party **File Transformation** plugin; the rest of the plugin works without it.
 
 ## Build & Test
 
 ```bash
 dotnet build -c Release
-dotnet test -c Release --verbosity normal
+dotnet test  -c Release --verbosity normal
 ```
+
+Run a single test class or method (xUnit, `dotnet test` filter syntax):
+
+```bash
+dotnet test --filter "FullyQualifiedName~ScraperTests"
+dotnet test --filter "FullyQualifiedName~ScraperTests.LookupBySlug_Returns_Result"
+```
+
+CI also collects coverage via `--collect:"XPlat Code Coverage"` into `TestResults/`; Codecov consumes the Cobertura XML.
+
+Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `LetterboxdSync.dll` + `HtmlAgilityPack.dll` and restarts the container).
 
 ## Architecture
 
-Four core classes handle Letterboxd interaction:
-- `LetterboxdHttpClient` — shared HTTP client, cookie/CSRF management, Cloudflare retry
-- `LetterboxdAuth` — login, session management, re-auth on 401
-- `LetterboxdScraper` — HTML parsing, film lookup, diary/watchlist scraping
-- `LetterboxdDiary` — diary writes, review posting
+### Service abstraction with fallback
 
-Three scheduled tasks: `SyncTask` (export watches), `WatchlistSyncTask` (import watchlist to playlist), `DiaryImportTask` (import diary as played).
+`ILetterboxdService` (`ILetterboxdService.cs`) is the seam every caller uses. Two implementations:
 
-Real-time sync via `PlaybackHandler` (IHostedService, fires on playback completion).
+- `LetterboxdApiClient` — preferred, talks to Letterboxd's JSON endpoints.
+- `ScrapingLetterboxdService` — fallback, composes `LetterboxdHttpClient` (cookies/CSRF/Cloudflare retry), `LetterboxdAuth` (login + re-auth on 401), `LetterboxdScraper` (HTML parsing, film lookup, diary/watchlist scraping), and `LetterboxdDiary` (diary writes, review posting).
 
-## Release Process
+`LetterboxdServiceFactory.CreateAuthenticatedAsync` tries the API first and silently falls back to scraping if auth fails. The factory also exposes an `internal static OverrideForTesting` hook used via `InternalsVisibleTo` from `LetterboxdSync.Tests` to inject mock services — production code never touches it.
 
-Tag with `git tag v1.x.0 && git push --tags`. GitHub Actions builds, tests, packages ZIP, creates release, and auto-updates manifest.json checksum. Use PLACEHOLDER for checksum in manifest before tagging.
+### Sync entry points
+
+- `SyncTask` — scheduled, exports recent watches to the Letterboxd diary.
+- `WatchlistSyncTask` / `WatchlistSyncRunner` — imports the user's Letterboxd watchlist as a Jellyfin playlist.
+- `DiaryImportTask` — marks Jellyfin items as played if present in the Letterboxd diary.
+- `PlaybackHandler` — `IHostedService` registered in `ServiceRegistrator`, fires the real-time sync on playback completion.
+- `LetterboxdSyncRunner` — shared engine used by `SyncTask` and `PlaybackHandler`; `SyncGate`, `SyncHistory`, `SyncProgress`, and `TmdbCache` coordinate dedupe, progress UI, and TMDb lookups.
+
+### Plugin surface
+
+- `Plugin.cs` + `ServiceRegistrator.cs` register services and config.
+- `Api/LetterboxdController.cs` and `Api/SidebarController.cs` expose REST endpoints consumed by the config dashboard.
+- `Web/*.html` and `Web/*.js` are embedded resources (see `LetterboxdSync.csproj`) served as the plugin's config pages.
+- `SidebarInjection.cs` registers a transformation with the File Transformation plugin to inject the sidebar link.
+
+## Releasing
+
+Versions live in **three** places and must be bumped together before tagging:
+
+1. `Directory.Build.props` — `<Version>` / `<AssemblyVersion>` / `<FileVersion>`
+2. `LetterboxdSync/LetterboxdSync.csproj` — `<AssemblyVersion>` / `<FileVersion>`
+3. `manifest.json` — add a new version entry; set `checksum` to `PLACEHOLDER`
+
+Then `git tag vX.Y.Z && git push --tags`. `release.yml` builds, tests, packages the ZIP, creates the GitHub release, and commits the real md5 checksum to `manifest.json` on `main` (directly, no PR — see `TODOS.md`).
+
+## OpenSpec
+
+Spec-driven workflow lives under `openspec/` (`changes/`, `specs/`, `config.yaml`). Use the `/opsx:propose`, `/opsx:apply`, `/opsx:archive`, `/opsx:explore` skills for non-trivial changes when the user requests them.
 
 ## Skill routing
 


### PR DESCRIPTION
## Summary
- Document the `ILetterboxdService` abstraction and the API-then-scraping fallback in `LetterboxdServiceFactory`, replacing the outdated "four scraping classes" picture.
- Add `dotnet test --filter` examples for running single tests, the CI coverage flag, and the `./deploy.sh` local deploy hook.
- Spell out the three places version numbers must be bumped together before tagging (`Directory.Build.props`, `LetterboxdSync.csproj`, `manifest.json`), and note the File Transformation plugin prerequisite for the sidebar link.
- Mention the `openspec/` workflow.

## Test plan
- [x] Skim the rendered CLAUDE.md on the PR page — sections, code fences, and links all render correctly.