### PR TITLE
release: v1.11.2

### DIFF
--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.11.1.0</AssemblyVersion>
-    <FileVersion>1.11.1.0</FileVersion>
+    <AssemblyVersion>1.11.2.0</AssemblyVersion>
+    <FileVersion>1.11.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.11.2.0",
+        "changelog": "Fix: with diary-import enabled, the daily sync was posting phantom rewatch entries to Letterboxd for films you had only marked played via diary import (never actually watched on Jellyfin). The runner now suppresses these films until a real Jellyfin playback sets a LastPlayedDate, at which point the rewatch lands on Letterboxd as expected. Docs: install instructions now call out the File Transformation plugin as a prerequisite for the in-sidebar Letterboxd link.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.11.2/jellyfin-plugin-letterboxd-v1.11.2.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-05-13T00:00:00Z"
+      },
+      {
         "version": "1.11.1.0",
         "changelog": "Fix: watchlisting a TV show on Letterboxd no longer auto-requests an unrelated movie in Jellyseerr. TMDb has independent ID namespaces for movies and TV (e.g. tv/198102 = Hijack, movie/198102 = Cutie Honey Flash), and the link extractor was treating every tmdb link as a movie ID. Now skips links whose URL points at /tv/. Adds regression coverage for the mismatch.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
Release bump for v1.11.2.

Bumps `AssemblyVersion`/`FileVersion` to 1.11.2.0 and adds the manifest entry. Checksum is `PLACEHOLDER` and will be replaced by the release workflow after the tag is pushed.

## What's shipping

**Fix — phantom rewatch entries from diary-import (#32, #33)**
With `EnableDiaryImport` on, the daily sync was posting fresh rewatch entries to Letterboxd for films you only marked played via diary import (never actually watched on Jellyfin). The runner now suppresses these films until a real Jellyfin playback sets a `LastPlayedDate`, at which point the rewatch lands as expected.

**Docs — File Transformation prerequisite (#35)**
README and landing site now call out the File Transformation plugin as required for the in-sidebar Letterboxd link.

Once this merges I'll tag `v1.11.2` from main and the release workflow will build, publish, and overwrite the checksum.