### PR TITLE
Show release history on the site (new /releases page and 'Latest' link in the hero)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- 1-3 bullets: what changed and why. Link issues with #N. -->
+- 
+
+## Test plan
+
+<!-- How to verify. Tick boxes for checks already done. -->
+- [ ] 
+
+<!--
+Optional sections — keep what's relevant, delete the rest.
+
+## Screenshots
+
+Before / after, or new UI states.
+
+## Breaking changes
+
+What breaks, who's affected, migration steps.
+
+## Notes
+
+Anything else reviewers should know.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,39 @@
-## Summary
+<!-- Ticket link, e.g. Closes #123. If there isn't one, write "No linked issue." -->
 
-<!-- 1-3 bullets: what changed and why. Link issues with #N. -->
-- 
-
-## Test plan
-
-<!-- How to verify. Tick boxes for checks already done. -->
-- [ ] 
+## What's broken
 
 <!--
-Optional sections — keep what's relevant, delete the rest.
-
-## Screenshots
-
-Before / after, or new UI states.
-
-## Breaking changes
-
-What breaks, who's affected, migration steps.
-
-## Notes
-
-Anything else reviewers should know.
+The symptom in plain terms, where it shows up, who reported it.
+For features, frame this as what's missing or the user problem being solved.
 -->
+
+## Why it happens
+
+<!--
+The root cause in simple terms. Avoid function names, type signatures, or SQL in prose.
+A short numbered "two things lined up" list often works well.
+-->
+
+1. 
+2. 
+
+## What this PR does
+
+<!--
+The change in plain terms. Naming files and helpers is fine, but keep it readable.
+Note anything deliberately NOT touched and why.
+-->
+
+## How to test
+
+<!--
+Automated test file plus the command to run it, then a quick manual check.
+-->
+
+## Follow-ups (not in this PR)
+
+<!--
+Short list of related things left for later.
+-->
+
+- 

--- a/openspec/changes/add-release-template-and-site-releases/.openspec.yaml
+++ b/openspec/changes/add-release-template-and-site-releases/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/add-release-template-and-site-releases/design.md
+++ b/openspec/changes/add-release-template-and-site-releases/design.md
@@ -1,0 +1,129 @@
+## Context
+
+The plugin ships through three coupled artifacts on every tag push:
+
+1. **GitHub Release** — created by `softprops/action-gh-release@v3` with `generate_release_notes: true`. Body is auto-assembled from PR titles since the last tag. No template, no editorial pass.
+2. **`manifest.json`** — checked into the repo. The release workflow rewrites the `checksum` for the matching version entry, commits, and pushes back to `main`. Jellyfin reads this file to discover plugin versions, and the `changelog` field is shown in Jellyfin's in-app plugin catalog.
+3. **`site/`** — Astro static site deployed to GitHub Pages by `deploy-docs.yml` on pushes that touch `site/**`. Renders install instructions and feature copy. Has no awareness of releases.
+
+The `manifest.json.versions[*].changelog` field is hand-written before tagging, in a tight, voice-consistent style (see `v1.11.2`, `v1.10.0`, etc.). It is already the highest-quality changelog source in the project — it's just not used anywhere outside Jellyfin's plugin catalog.
+
+The site is built with Astro 5, no framework integrations, all `.astro` files. The site is built at GitHub Actions time and deployed to GitHub Pages under the base path `/jellyfin-plugin-letterboxd`. There's no client-side data fetching today; everything is static at build time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One canonical changelog source per release. No duplication between GitHub release body, manifest changelog, and site copy.
+- A reusable template so every release has the same shape: summary, what changed (categorised), upgrade notes, contributors.
+- The site shows the current latest version and a browsable list of all releases without leaving for GitHub.
+- Releases page updates automatically after each tag, with at most a few minutes of lag (one site build).
+- Maintainer flow stays one tag push: fill in the manifest entry, push the tag, done.
+
+**Non-Goals:**
+- A CHANGELOG.md file at the repo root. The `manifest.json` entries already serve this role and adding a third source would re-introduce the duplication we're removing.
+- Server-side or client-side GitHub API calls from the site. Build-time only.
+- A CMS or richer changelog editing flow. Plain markdown in the template, plain string in the manifest.
+- Per-release blog posts, comments, or analytics on the site beyond what already exists.
+- Changing the Jellyfin manifest schema or how Jellyfin's plugin catalog renders the `changelog` field.
+
+## Decisions
+
+### Decision 1: Single source of truth is `manifest.json.versions[*].changelog`
+
+The manifest's `changelog` field is already maintained at the right granularity and tone. We promote it from "Jellyfin in-app text" to "the canonical release changelog" — used by the release workflow to render the GitHub release body and by the site to render its releases view.
+
+**Alternative considered:** Keep auto-generated release notes and have the site call the GitHub API at build time. Rejected because (a) it preserves the duplication and inconsistent voice, (b) it makes the site build dependent on GitHub API rate limits and a token, (c) it loses the editorial pass that makes the manifest changelogs readable.
+
+**Alternative considered:** Add a `CHANGELOG.md` and have manifest+release+site all read from it. Rejected because the manifest schema can't reference an external file — Jellyfin reads the `changelog` string directly — so we'd still need to copy the entry into manifest. Two sources, two opportunities for drift.
+
+### Decision 2: Template is a markdown file with placeholders, rendered by a small shell+jq+envsubst script
+
+The template lives at `.github/release-template.md` with placeholders like `{{VERSION}}`, `{{DATE}}`, `{{SUMMARY}}`, `{{CHANGELOG}}`, `{{COMMITS}}`, `{{COMPARE_URL}}`. A new workflow step in `release.yml` runs `scripts/render-release-notes.sh` which:
+
+1. Reads the new version's `changelog` string from `manifest.json` via `jq`.
+2. Generates the commit list since the previous tag via `git log --pretty=format:"- %s (%h)" PREV..HEAD`.
+3. Substitutes into the template and writes `/tmp/release-body.md`.
+4. Passes that file to `softprops/action-gh-release` via the `body_path:` input.
+
+**Alternative considered:** A Node script. Rejected because the existing workflow has no Node dependency for this job and `jq` is already pre-installed on `ubuntu-latest`. Shell+jq is the lower-friction tool here.
+
+**Alternative considered:** GitHub's release-drafter action. Rejected — it works off PR labels, which we don't apply consistently, and it would still leave the manifest changelog as a separate hand-written string.
+
+### Decision 3: Template structure
+
+```
+## {{SUMMARY_HEADLINE}}
+
+{{CHANGELOG}}
+
+### Commits
+{{COMMITS}}
+
+### Install
+- Plugin repository: https://lachlanyoung.dev/jellyfin-plugin-letterboxd/#install
+- Manual download: jellyfin-plugin-letterboxd-{{VERSION}}.zip (attached below)
+
+**Full Changelog**: {{COMPARE_URL}}
+```
+
+The `{{CHANGELOG}}` block is the manifest's `changelog` string verbatim — already prose. Categorised sections (Fixes / Improvements / New / Breaking) are encouraged in the manifest entry but not enforced by the template; the existing entries are single-paragraph prose and that style works.
+
+### Decision 4: Site reads `manifest.json` directly at build time via Astro's import
+
+Astro supports `import manifest from '../../../manifest.json'` from inside `src/pages/`. The releases page does this, sorts by version descending, and renders. No fetch, no API, no token. Build is deterministic.
+
+The `base` path in `astro.config.mjs` is `/jellyfin-plugin-letterboxd`, and the build runs from `./site` per `deploy-docs.yml`. The relative import path `../../../manifest.json` resolves to the repo root.
+
+**Alternative considered:** Copy `manifest.json` into `site/public/` as part of the build. Rejected — direct import is simpler and Vite handles the JSON parsing.
+
+### Decision 5: Releases view shape
+
+- `/releases` page (Astro page at `site/src/pages/releases.astro`) listing every version in `manifest.json.versions`, newest first. Each entry: version, date, changelog prose, link to GitHub release, link to the ZIP.
+- "Latest version" pill in the existing hero/install area on `index.astro`, showing the top version and date with a "What's new" link to `#latest` on `/releases`.
+- No client-side filtering, no search, no pagination — there are ~10-20 versions, all fit on one scroll.
+
+### Decision 6: Rebuild trigger
+
+Extend `deploy-docs.yml`'s `paths:` filter to include `manifest.json`. The release workflow already commits the updated manifest to `main`; that commit will trigger a docs deploy, which rebuilds the site with the new release visible. Lag: ~2-3 minutes after the tag's release workflow completes.
+
+**Alternative considered:** `workflow_run` trigger after the release workflow completes. Rejected because it's strictly more complex than a `paths:` glob and the outcome is the same — manifest commit triggers rebuild.
+
+### Decision 7: RELEASING.md doc
+
+Short doc at the repo root explaining:
+1. Bump version in `LetterboxdSync/LetterboxdSync.csproj` (or wherever the version is set).
+2. Add a new entry at the top of `manifest.json.versions` with `checksum: "PLACEHOLDER"` and a templated `changelog` string.
+3. `git tag vX.Y.Z && git push --tags`.
+4. CI takes over: builds, tests, packages, creates the GitHub release using the new template, updates the manifest checksum, commits, pushes. The docs deploy fires on that commit.
+
+Format guidance for the `changelog` string is included: 1-3 sentences, lead with the user-facing impact, avoid implementation jargon, match the existing v1.11.x voice.
+
+## Risks / Trade-offs
+
+- **Risk:** The `manifest.json` `changelog` string is used in two places now (Jellyfin catalog + GitHub release body). A length or formatting choice that works in one might look off in the other.
+  → **Mitigation:** The template wraps the changelog in standard markdown; Jellyfin's catalog already accepts the same text. Existing entries (v1.11.2, v1.10.0) have been spot-checked and render fine as both plaintext and markdown.
+
+- **Risk:** Forgetting to fill in the manifest entry before tagging means CI runs against an empty/placeholder changelog.
+  → **Mitigation:** Add a pre-tag check in the release workflow that fails fast if the tag's matching manifest entry has an empty `changelog` or still contains a clearly-placeholder marker. Documented in RELEASING.md.
+
+- **Risk:** The site build pulling `manifest.json` from the repo root means the docs-deploy job needs to checkout from the right commit (the one after the manifest update). The existing workflow already does this since it triggers on push to main.
+  → **Mitigation:** No special handling needed; verify with a dry run.
+
+- **Risk:** Auto-generated release notes (current behavior) include things like "Dependabot bumped X" which are useful to some viewers. The new template's commit list preserves this.
+  → **Mitigation:** The `{{COMMITS}}` section keeps the raw commit log, so the "what merged" view is still available, just below the editorial summary.
+
+- **Trade-off:** Removing `generate_release_notes: true` means we lose GitHub's contributor list auto-generation. We add it back manually by parsing `git log --pretty=format:"%an"` for unique authors since the previous tag.
+
+## Migration Plan
+
+1. Land the template, render script, and `release.yml` changes. Test by tagging a no-op patch release (e.g. `v1.11.3` with a `changelog` entry like "Maintenance: testing release template rollout — no plugin behaviour changes.").
+2. Inspect the rendered release. If the body looks right, proceed; if not, iterate on the template/script and re-tag.
+3. Land the site changes (releases page, hero pill, `deploy-docs.yml` path filter). The site picks up all existing manifest versions on first deploy.
+4. Land `RELEASING.md`.
+
+**Rollback:** Revert the workflow change; releases fall back to `generate_release_notes: true`. The site keeps working off whatever `manifest.json` is at HEAD — no coupling to the release workflow.
+
+## Open Questions
+
+- Do we want a per-release `published_at` field on the site? `manifest.json.versions[*].timestamp` exists but the dates are sometimes the in-repo date rather than the actual release date. Decision: use `timestamp` as-is; if it drifts we can switch to the GitHub release's `published_at` later (build-time-fetchable without auth via the public API, but adds a network call).
+- Should the template include a "Known issues" section? Decision: no — keep the template tight; known issues can go in the manifest changelog prose if relevant to that release.

--- a/openspec/changes/add-release-template-and-site-releases/proposal.md
+++ b/openspec/changes/add-release-template-and-site-releases/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Release notes today are whatever `softprops/action-gh-release` auto-generates from merged PRs, plus a hand-written changelog string that's duplicated into `manifest.json`. The voice and shape drift between releases, the site has no view of release history at all, and a user landing on the site has to leave for GitHub to see what's new or what version they're about to install. A consistent release template plus a site-side releases view fixes both problems with one source of truth.
+
+## What Changes
+
+- Add a GitHub release notes template (`.github/release-template.md` or equivalent) defining the standard sections: summary one-liner, what changed (Fixes / Improvements / New / Breaking), upgrade notes, and a contributors line.
+- Replace `generate_release_notes: true` in `.github/workflows/release.yml` with a templated body assembled from a structured source (the same per-version `changelog` already in `manifest.json`, plus auto-generated commit list rendered into the template).
+- Promote `manifest.json`'s per-version `changelog` field to the canonical changelog source — the release workflow reads it and renders the GitHub release body from the template.
+- Add a CONTRIBUTING/RELEASING note documenting the template, the version-bump-and-tag flow, and the requirement that the new manifest entry's `changelog` follow the template summary style before tagging.
+- Add a "Releases" / "What's new" section to the Astro site (`site/`) that fetches and renders releases. Source of truth is `manifest.json` (already checked into the repo and deployed with the site build), so no runtime GitHub API call is needed — the site reads `manifest.json` at build time.
+- Link the latest release prominently in the hero install area (current latest version, date, "what's new" expandable), and add a `/releases` (or in-page `#releases`) view listing all versions with their templated changelog.
+- Trigger a site rebuild whenever `manifest.json` changes so the latest release appears on the site shortly after a tag lands. The release workflow already commits the updated `manifest.json` to `main`; extend `deploy-docs.yml` `paths:` to include `manifest.json`.
+
+## Capabilities
+
+### New Capabilities
+- `release-process`: The repeatable shape of every release — template, source of truth, workflow steps, and the contract between manifest, GitHub release, and the site.
+- `site-releases`: How the Astro site surfaces release history and the current version to visitors, including the build-time data source and the rebuild trigger.
+
+### Modified Capabilities
+<!-- No existing specs in openspec/specs/ to modify. -->
+
+## Impact
+
+- **Workflows**: `.github/workflows/release.yml` (body template rendering replaces `generate_release_notes`), `.github/workflows/deploy-docs.yml` (add `manifest.json` to `paths`).
+- **New files**: release notes template under `.github/`, a small render script (shell or node) invoked from `release.yml`, a `RELEASING.md` doc, new Astro page/section + component for releases.
+- **Site**: `site/src/pages/` gains a releases view; the existing `index.astro` hero/install area gains a "latest version" pill that links to it.
+- **Data flow**: `manifest.json`'s `changelog` field becomes load-bearing for both Jellyfin's in-app plugin catalog *and* the GitHub release body *and* the site — its format (length, voice) becomes part of the release checklist.
+- **No breaking changes** for plugin users; the manifest schema is unchanged. Existing released versions stay as-is.
+- **Maintainer flow** changes: before tagging, fill in the new manifest entry's `changelog` in the template-friendly format; everything else is automated.

--- a/openspec/changes/add-release-template-and-site-releases/specs/release-process/spec.md
+++ b/openspec/changes/add-release-template-and-site-releases/specs/release-process/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Canonical release changelog source
+
+The release process SHALL treat `manifest.json.versions[*].changelog` as the single canonical changelog for each version. The GitHub release body, the Jellyfin in-app plugin catalog text, and the site's releases view MUST all derive their per-version copy from this field.
+
+#### Scenario: Maintainer prepares a release
+
+- **WHEN** the maintainer adds a new entry to `manifest.json.versions` and pushes a matching `vX.Y.Z` tag
+- **THEN** the entry's `changelog` string is used verbatim as the editorial body of the GitHub release notes and is the same string Jellyfin will display in its plugin catalog
+
+#### Scenario: Changelog is missing or unfilled at tag time
+
+- **WHEN** the release workflow runs for a tag whose matching `manifest.json` entry has an empty `changelog` field or a value matching the placeholder marker
+- **THEN** the workflow MUST fail before publishing the GitHub release, with an error message naming the version and the field that needs to be filled in
+
+### Requirement: Release notes template
+
+A release notes template SHALL live at `.github/release-template.md` and define the shape of every GitHub release body. The template MUST contain placeholders for version, summary changelog, commit list, comparison URL, and install pointers.
+
+#### Scenario: Template is rendered on tag push
+
+- **WHEN** the release workflow runs for tag `vX.Y.Z`
+- **THEN** a render step substitutes `{{VERSION}}`, `{{DATE}}`, `{{CHANGELOG}}`, `{{COMMITS}}`, and `{{COMPARE_URL}}` placeholders in `.github/release-template.md` and passes the rendered file to `softprops/action-gh-release` via `body_path:`
+
+#### Scenario: Template change applies to future releases only
+
+- **WHEN** the template file is modified on `main`
+- **THEN** the change has no effect on existing GitHub releases (they remain as published) and applies only to releases created from subsequent tag pushes
+
+### Requirement: Commit list since previous tag
+
+The rendered release body SHALL include a commit list covering every commit between the previous tag and the current tag.
+
+#### Scenario: There is a previous tag
+
+- **WHEN** rendering release notes for tag `vX.Y.Z` and at least one prior `v*` tag exists
+- **THEN** the `{{COMMITS}}` placeholder is replaced with a markdown bullet list of commits in the form `- <subject> (<short-sha>)` for every commit in `<previous-tag>..vX.Y.Z`
+
+#### Scenario: There is no previous tag
+
+- **WHEN** rendering release notes for the very first `v*` tag in the repository
+- **THEN** the `{{COMMITS}}` placeholder is replaced with the bullet list of every commit reachable from the tag, and the `{{COMPARE_URL}}` placeholder is replaced with a link to the tag's tree rather than a compare URL
+
+### Requirement: Maintainer release runbook
+
+A `RELEASING.md` document SHALL exist at the repository root describing the steps to cut a release and the expected format of the manifest `changelog` field.
+
+#### Scenario: New contributor cuts their first release
+
+- **WHEN** a contributor with no prior context reads `RELEASING.md`
+- **THEN** the document tells them exactly which version to bump, which file to edit in `manifest.json`, the expected voice and length for the `changelog` string, and the single command needed to trigger CI (`git tag vX.Y.Z && git push --tags`)
+
+### Requirement: Removal of auto-generated release notes
+
+The release workflow SHALL NOT use GitHub's `generate_release_notes: true` shortcut once the template-based rendering is in place.
+
+#### Scenario: Workflow runs on a tag push
+
+- **WHEN** `.github/workflows/release.yml` executes for any `v*` tag
+- **THEN** the `softprops/action-gh-release` step uses `body_path:` pointing at the rendered template file, and `generate_release_notes: true` is absent from its inputs
+
+### Requirement: Manifest checksum update remains automated
+
+The release workflow SHALL continue to update the matching `manifest.json` entry's `checksum` field after the release ZIP is built, commit the change to `main`, and push it.
+
+#### Scenario: Tag triggers a successful release
+
+- **WHEN** the release workflow completes packaging the plugin ZIP for tag `vX.Y.Z`
+- **THEN** the workflow computes the ZIP's MD5 checksum, writes it to the matching `manifest.json` entry (identified by `version == "X.Y.Z.0"`), commits with a message naming the version, and pushes to `main`

--- a/openspec/changes/add-release-template-and-site-releases/specs/site-releases/spec.md
+++ b/openspec/changes/add-release-template-and-site-releases/specs/site-releases/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Releases view on the site
+
+The Astro site SHALL expose a Releases view listing every version present in `manifest.json.versions`, ordered newest first. The view MUST be reachable from the site's primary navigation.
+
+#### Scenario: Visitor opens the Releases view
+
+- **WHEN** a visitor navigates to `/jellyfin-plugin-letterboxd/releases` (or the equivalent in-page section on `index.astro`, depending on implementation choice in design)
+- **THEN** the page renders one entry per version in `manifest.json.versions`, each showing the version number, release date, changelog prose, a link to the GitHub release page, and a link to the ZIP
+
+#### Scenario: Ordering
+
+- **WHEN** the Releases view renders
+- **THEN** entries appear in descending version order (semver-aware), with the most recent at the top
+
+### Requirement: Latest version surfaced on the home page
+
+The home page (`site/src/pages/index.astro`) SHALL display the current latest version near the install instructions, with a link to the full Releases view.
+
+#### Scenario: Visitor lands on the home page
+
+- **WHEN** a visitor opens the site root
+- **THEN** the hero or install area shows the latest version number and release date, and a link or button leads to the Releases view
+
+#### Scenario: Latest version changes
+
+- **WHEN** a new version is appended to `manifest.json.versions` and the site is rebuilt
+- **THEN** the home page displays the new latest version on next deploy without any code change
+
+### Requirement: Build-time data source
+
+The Releases view and the home page's latest-version display SHALL read from `manifest.json` at build time. The site MUST NOT make runtime or build-time network calls to the GitHub API to fetch release data.
+
+#### Scenario: Site builds in CI
+
+- **WHEN** the `deploy-docs.yml` workflow builds the site
+- **THEN** Astro imports `manifest.json` directly from the repository (no HTTP request, no GitHub token required), and the built artifact contains release data baked in as static HTML
+
+#### Scenario: Working offline
+
+- **WHEN** a contributor runs `npm run build` in `site/` with no network access
+- **THEN** the build succeeds and the Releases view renders correctly from the local `manifest.json`
+
+### Requirement: Site rebuild on manifest changes
+
+The `deploy-docs.yml` workflow SHALL rebuild and redeploy the site whenever `manifest.json` changes on `main`, in addition to the existing trigger on `site/**` changes.
+
+#### Scenario: Release workflow commits a manifest update
+
+- **WHEN** the release workflow pushes a commit to `main` that modifies `manifest.json` (either a new version entry or a checksum update)
+- **THEN** `deploy-docs.yml` runs and deploys an updated site within one build cycle of the commit landing
+
+#### Scenario: Site-only change
+
+- **WHEN** a commit to `main` modifies only files under `site/**` and not `manifest.json`
+- **THEN** `deploy-docs.yml` still runs (existing behaviour preserved)
+
+### Requirement: Rendering of changelog content
+
+Each release entry on the site SHALL render the `manifest.json` entry's `changelog` field as a paragraph of prose, preserving the text as written.
+
+#### Scenario: Plain-prose changelog
+
+- **WHEN** the `changelog` field is a single paragraph of plain text
+- **THEN** the site renders it as a paragraph with normal typography (no code formatting, no truncation)
+
+#### Scenario: Changelog with inline markdown
+
+- **WHEN** the `changelog` field contains inline markdown (links, code spans, emphasis)
+- **THEN** the site MAY render that inline markdown, but at minimum MUST render the text faithfully without breaking the page layout
+
+### Requirement: No coupling to GitHub release availability
+
+The Releases view SHALL render correctly even if the GitHub release for a given version has not yet been published or is unreachable.
+
+#### Scenario: Version present in manifest but GitHub release missing
+
+- **WHEN** a version exists in `manifest.json.versions` but no corresponding GitHub release exists yet
+- **THEN** the Releases view still renders the version entry using manifest data; the "View on GitHub" link points at the standard release URL (the link works once the release publishes) and the page does not error

--- a/openspec/changes/add-release-template-and-site-releases/tasks.md
+++ b/openspec/changes/add-release-template-and-site-releases/tasks.md
@@ -1,0 +1,52 @@
+## 1. Release template and render script
+
+- [ ] 1.1 Create `.github/release-template.md` with placeholders `{{VERSION}}`, `{{DATE}}`, `{{CHANGELOG}}`, `{{COMMITS}}`, `{{COMPARE_URL}}` following the structure in design.md Decision 3
+- [ ] 1.2 Add `scripts/render-release-notes.sh` that reads the tag, extracts the matching `manifest.json` entry's `changelog` via `jq`, builds the commit list with `git log`, substitutes placeholders into the template, and writes `/tmp/release-body.md`
+- [ ] 1.3 Make the script handle the no-previous-tag edge case (first release) per spec scenario
+- [ ] 1.4 Add a manifest-changelog-not-empty pre-flight check to the script that exits non-zero with a clear message if the matching entry's `changelog` is empty or matches a placeholder marker
+
+## 2. Wire the template into the release workflow
+
+- [ ] 2.1 In `.github/workflows/release.yml`, add a step before `Create Release` that runs `scripts/render-release-notes.sh` for the current tag
+- [ ] 2.2 Update the `softprops/action-gh-release@v3` step to use `body_path: /tmp/release-body.md` and remove `generate_release_notes: true`
+- [ ] 2.3 Verify the manifest-checksum-commit step still runs after the release publishes (no ordering regression)
+
+## 3. RELEASING.md
+
+- [ ] 3.1 Create `RELEASING.md` at the repo root describing the version-bump-and-tag flow, the manifest entry format, and the expected `changelog` voice/length (reference existing entries v1.11.x as exemplars)
+- [ ] 3.2 Link `RELEASING.md` from `README.md` (e.g. a "Releases" or "Contributing" section)
+
+## 4. Site: data loading and shared release helper
+
+- [ ] 4.1 Create `site/src/lib/releases.ts` exporting a function that imports `../../../manifest.json` and returns the versions array sorted by semver descending, with parsed fields (version, date, changelog, sourceUrl, githubReleaseUrl)
+- [ ] 4.2 Add a unit-style smoke test or build-time assertion that the import path resolves and that at least one version is returned (prevents silent regressions if `astro.config.mjs` or `tsconfig.json` paths change)
+
+## 5. Site: Releases page
+
+- [ ] 5.1 Create `site/src/pages/releases.astro` that calls the helper and renders one card per version: version number, date, changelog prose, "View on GitHub" link, "Download ZIP" link
+- [ ] 5.2 Add navigation link to Releases in the site header (`index.astro` nav and `releases.astro` header)
+- [ ] 5.3 Style the page to match the existing visual language (reuse `container`, card styling, etc. from `index.astro`)
+- [ ] 5.4 Verify the Releases page renders correctly under the `/jellyfin-plugin-letterboxd` base path locally with `npm run build && npm run preview`
+
+## 6. Site: latest-version pill on home page
+
+- [ ] 6.1 In `site/src/pages/index.astro`, import the shared release helper and read the latest version + date
+- [ ] 6.2 Add a "Latest: vX.Y.Z (date) — What's new" element near the existing install pill in the hero, linking to `/releases#vX-Y-Z` (or `#latest`)
+- [ ] 6.3 Ensure the element gracefully renders when `manifest.json.versions` is empty (defensive — should never happen in practice but build shouldn't crash)
+
+## 7. Deploy-docs trigger
+
+- [ ] 7.1 In `.github/workflows/deploy-docs.yml`, add `manifest.json` to the `paths:` filter so manifest changes (new version, checksum update) trigger a site rebuild
+- [ ] 7.2 Confirm the existing `site/**` trigger is preserved
+
+## 8. End-to-end verification
+
+- [ ] 8.1 Cut a test patch release (e.g. `v1.11.3`) with a templated `changelog` entry; verify the GitHub release body matches the template and the site rebuilds with the new entry visible
+- [ ] 8.2 Inspect the rendered release notes for layout correctness (headings render, commit list is right, compare URL works, ZIP link is correct)
+- [ ] 8.3 Inspect the live site's Releases page and home page latest-version pill for the new version
+- [ ] 8.4 Re-check Jellyfin's in-app plugin catalog text for the new version to confirm the changelog still reads well there
+
+## 9. Cleanup
+
+- [ ] 9.1 Remove or migrate any lingering references to the old auto-generated release notes flow in docs/README
+- [ ] 9.2 Add a `TODOS.md` note pointing future maintainers to `RELEASING.md` for the release flow (or remove the obsolete release entries from `TODOS.md` if any exist)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -1,0 +1,238 @@
+export type ReleaseCategory = 'new' | 'improvements' | 'fixes' | 'breaking';
+
+export type ReleaseNotes = {
+  version: string;
+  headline: string;
+  summary?: string;
+  highlights: Partial<Record<ReleaseCategory, string[]>>;
+  upgradeNotes?: string;
+};
+
+export const releaseNotes: ReleaseNotes[] = [
+  {
+    version: '1.11.2',
+    headline: 'Stop phantom rewatches on diary-imported films',
+    highlights: {
+      fixes: [
+        "With diary-import enabled, the daily sync was posting phantom rewatch entries to Letterboxd for films you'd only marked played via diary import (never actually watched on Jellyfin). The runner now waits for a real Jellyfin playback before logging the rewatch.",
+      ],
+      improvements: [
+        'Install instructions now call out the File Transformation plugin as a prerequisite for the in-sidebar Letterboxd link.',
+      ],
+    },
+  },
+  {
+    version: '1.11.1',
+    headline: "Don't request the wrong movie when watchlisting a TV show",
+    highlights: {
+      fixes: [
+        'Watchlisting a TV show on Letterboxd no longer auto-requests an unrelated movie in Jellyseerr. TMDb has independent ID namespaces for movies and TV (e.g. tv/198102 = Hijack, movie/198102 = Cutie Honey Flash); the link extractor was treating every tmdb link as a movie ID. Now skips /tv/ links, with regression coverage.',
+      ],
+    },
+  },
+  {
+    version: '1.11.0',
+    headline: 'Bidirectional rating sync and in-dashboard logs',
+    highlights: {
+      new: [
+        'Bidirectional rating sync. Dashboard reviews mirror their star rating into Jellyfin (always overwrites), and the daily diary import seeds Jellyfin ratings from Letterboxd for films that don\'t yet have a Jellyfin rating (anti-clobber).',
+        'In-dashboard Logs tab with per-user and free-text filters, copy-to-clipboard, and download-as-.log for support requests.',
+      ],
+      improvements: [
+        'Diary import switched from /log-entries to /films?memberRelationship=Watched so films you rated on Letterboxd without logging a watch now sync too.',
+        'Privacy hardening: review text is no longer logged.',
+      ],
+    },
+  },
+  {
+    version: '1.10.1',
+    headline: 'Maintenance: bump GitHub Actions runtime',
+    highlights: {
+      improvements: [
+        'Bumped GitHub Actions versions (checkout v6, setup-dotnet v5, action-gh-release v3) to remain on a supported Node version. No plugin behaviour changes.',
+      ],
+    },
+  },
+  {
+    version: '1.10.0',
+    headline: 'Watchlist mirroring into Jellyseerr',
+    highlights: {
+      new: [
+        "Mirror Letterboxd watchlist into Jellyseerr's user watchlist. Per-account toggle, two-way sync, movies-only so manually-added Jellyseerr TV is safe.",
+        "On-demand 'Sync Watchlist Now' button on the plugin dashboard so you don't have to wait for the daily run.",
+      ],
+      improvements: [
+        "Pre-flight check against Jellyseerr's media status eliminates duplicate requests for already-pending/processing/available titles.",
+        'Per-user watchlist sync runner extracted with a shared SyncGate so diary and watchlist syncs serialise.',
+      ],
+    },
+  },
+  {
+    version: '1.9.1',
+    headline: 'Local-history backstop against Cloudflare-induced duplicates',
+    summary: 'Addresses #21.',
+    highlights: {
+      fixes: [
+        'Refuse to MarkAsWatched when sync history shows a recent successful sync that does not pass the rewatch threshold. Fixes the Cloudflare-failed-validator path that was creating real Letterboxd diary duplicates.',
+      ],
+      improvements: [
+        'Paginated dashboard history table (100 per page) now that the 500-entry cap is gone.',
+      ],
+    },
+  },
+  {
+    version: '1.9.0',
+    headline: 'Skip already-synced films and let non-admins Run Sync Now',
+    summary: 'Fixes #20.',
+    highlights: {
+      new: [
+        'Non-admin users can now Run Sync Now (triggers their own account only).',
+        'Per-account stop-on-failure toggle to halt the moment Letterboxd anti-flooding triggers.',
+      ],
+      improvements: [
+        "Skip already-synced films using local sync history so we don't burn Cloudflare quota on duplicate checks.",
+        'Prioritise previously-failed and skipped films first.',
+        'Explicit info-level logging for every skip with a reason.',
+      ],
+    },
+  },
+  {
+    version: '1.8.0',
+    headline: 'Jellyseerr auto-request for unmatched watchlist films',
+    highlights: {
+      new: [
+        'Jellyseerr auto-request for unmatched watchlist films, with per-user attribution via Jellyfin User ID.',
+      ],
+      fixes: [
+        'Dedup fix: the watchlist playlist no longer accumulates duplicate entries on each run.',
+      ],
+    },
+  },
+  {
+    version: '1.7.1',
+    headline: 'Watchlist sync no longer returns 0 films via official API',
+    highlights: {
+      fixes: [
+        'A redundant `member` query param was causing Letterboxd to return empty items. Removed.',
+      ],
+    },
+  },
+  {
+    version: '1.7.0',
+    headline: 'Per-account User-Agent override',
+    highlights: {
+      new: [
+        'Per-account User-Agent override so Cloudflare cookies copied from any browser (Chrome, Safari, etc.) work without UA mismatch.',
+      ],
+    },
+  },
+  {
+    version: '1.6.1',
+    headline: 'Reviews work again via official API',
+    summary: 'Fixes #12.',
+    highlights: {
+      fixes: [
+        'Resolve film LID from TMDb ID instead of slug when posting reviews via the official API.',
+      ],
+    },
+  },
+  {
+    version: '1.6.0',
+    headline: 'Official Letterboxd API integration with scraping fallback',
+    highlights: {
+      new: [
+        'Official Letterboxd API is now the primary path, with web scraping as a fallback. Eliminates the Cloudflare 403 errors that were blocking syncs.',
+      ],
+    },
+  },
+  {
+    version: '1.5.0',
+    headline: 'User self-service account setup and standalone user page',
+    highlights: {
+      new: [
+        'User self-service account setup — users link their own Letterboxd account without admin help.',
+        'Sidebar link for all users.',
+        'Test connection button on the account form.',
+        'Standalone user page via File Transformation injection.',
+      ],
+    },
+  },
+  {
+    version: '1.4.0',
+    headline: 'Architecture refactor, TMDb cache, progress dashboard',
+    highlights: {
+      new: [
+        'Progress dashboard showing sync state at a glance.',
+        'TMDb cache for repeated lookups.',
+      ],
+      improvements: [
+        'Architecture refactor for clearer separation of HTTP, auth, scraping, and diary writes.',
+        'Cloudflare resilience improvements.',
+        'Watchlist cleanup pass.',
+      ],
+      fixes: ['Diary import fix.'],
+    },
+  },
+  {
+    version: '1.3.0',
+    headline: 'Real-time playback sync',
+    highlights: {
+      new: [
+        'Real-time playback sync via PlaybackHandler — diary entries land within seconds of credits rolling.',
+      ],
+      improvements: ['Automatic session re-auth on 401.'],
+    },
+  },
+  {
+    version: '1.2.1',
+    headline: 'Sync history persists across version upgrades',
+    highlights: {
+      fixes: ['Fix sync history persistence across version upgrades.'],
+    },
+  },
+  {
+    version: '1.2.0',
+    headline: 'Star ratings in reviews and rewatch date picker',
+    highlights: {
+      new: [
+        'Star ratings in reviews.',
+        'Rewatch date picker.',
+        'Better error display in the dashboard.',
+      ],
+      improvements: ['Cloudflare retry on review posting.'],
+      fixes: ['Sync history persistence fix.'],
+    },
+  },
+  {
+    version: '1.1.0',
+    headline: 'Dashboard, watchlist sync, diary import, reviews',
+    highlights: {
+      new: [
+        'Dashboard with sync history.',
+        'Watchlist sync.',
+        'Diary import.',
+        'Reviews from the dashboard.',
+        'Rating sync.',
+        'Rewatch detection.',
+      ],
+      improvements: ['Cloudflare backoff.'],
+    },
+  },
+  {
+    version: '1.0.0',
+    headline: 'Initial release',
+    highlights: {
+      new: [
+        'Real-time sync on playback completion.',
+        'Scheduled catch-up sync.',
+        'Multi-user support.',
+        'Duplicate detection.',
+        'Retry with exponential backoff.',
+      ],
+    },
+  },
+];
+
+export const notesByVersion: Record<string, ReleaseNotes> = Object.fromEntries(
+  releaseNotes.map((n) => [n.version, n]),
+);

--- a/site/src/lib/releases.ts
+++ b/site/src/lib/releases.ts
@@ -1,0 +1,62 @@
+import manifest from '../../../manifest.json';
+import { notesByVersion, type ReleaseNotes } from '../data/release-notes';
+
+export type Release = {
+  version: string;
+  manifestVersion: string;
+  date: Date;
+  dateLabel: string;
+  changelog: string;
+  sourceUrl: string;
+  githubReleaseUrl: string;
+  tag: string;
+  anchor: string;
+  notes?: ReleaseNotes;
+};
+
+type ManifestEntry = {
+  version: string;
+  changelog: string;
+  sourceUrl: string;
+  timestamp: string;
+  checksum: string;
+  targetAbi: string;
+};
+
+const manifestEntries = manifest[0].versions as ManifestEntry[];
+
+const repoUrl = 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd';
+
+function semverKey(v: string): number {
+  const [maj, min, patch] = v.split('.').map((n) => parseInt(n, 10) || 0);
+  return maj * 1_000_000 + min * 1_000 + patch;
+}
+
+function shortVersion(manifestVersion: string): string {
+  return manifestVersion.replace(/\.0$/, '');
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export const releases: Release[] = manifestEntries
+  .map((entry): Release => {
+    const v = shortVersion(entry.version);
+    const date = new Date(entry.timestamp);
+    return {
+      version: v,
+      manifestVersion: entry.version,
+      date,
+      dateLabel: formatDate(date),
+      changelog: entry.changelog,
+      sourceUrl: entry.sourceUrl,
+      githubReleaseUrl: `${repoUrl}/releases/tag/v${v}`,
+      tag: `v${v}`,
+      anchor: `v${v.replace(/\./g, '-')}`,
+      notes: notesByVersion[v],
+    };
+  })
+  .sort((a, b) => semverKey(b.version) - semverKey(a.version));
+
+export const latestRelease = releases[0];

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,6 +4,7 @@ import Icon from '../components/Icon.astro';
 import SyncFlow from '../components/SyncFlow.astro';
 import TransferBento from '../components/TransferBento.astro';
 import DashboardPeek from '../components/DashboardPeek.astro';
+import { latestRelease } from '../lib/releases';
 
 const repoUrl = 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd';
 const manifestUrl = 'https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json';
@@ -11,6 +12,10 @@ const fileTransformationManifestUrl = 'https://www.iamparadox.dev/jellyfin/plugi
 const fileTransformationRepoUrl = 'https://github.com/IAmParadox27/jellyfin-plugin-file-transformation';
 const releasesUrl = `${repoUrl}/releases`;
 const latestReleaseUrl = `${repoUrl}/releases/latest`;
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const localReleasesUrl = `${base}/releases`;
+const latestReleaseAnchor = `${localReleasesUrl}#${latestRelease.anchor}`;
 
 type Feature = { title: string; body: string; icon: string };
 type FeatureGroup = { id: string; label: string; heading: string; intro: string; visual: 'flow' | 'rating' | 'dashboard'; items: Feature[] };
@@ -83,6 +88,7 @@ const featureGroups: FeatureGroup[] = [
         <a href="#features">Features</a>
         <a href="#install">Install</a>
         <a href="#setup">Setup</a>
+        <a href={localReleasesUrl}>Releases</a>
         <a href={repoUrl} rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -118,6 +124,14 @@ const featureGroups: FeatureGroup[] = [
             <span class="copy-text">Copy</span>
           </button>
         </div>
+        <a class="latest-link" href={latestReleaseAnchor}>
+          <span class="latest-dot" aria-hidden="true"></span>
+          <span class="latest-label">Latest</span>
+          <span class="latest-version">v{latestRelease.version}</span>
+          <span class="latest-sep" aria-hidden="true">·</span>
+          <span class="latest-date">{latestRelease.dateLabel}</span>
+          <span class="latest-arrow">What's new <span aria-hidden="true">&rarr;</span></span>
+        </a>
       </div>
 
       <div class="hero-art" aria-hidden="true">
@@ -505,6 +519,49 @@ const featureGroups: FeatureGroup[] = [
     border-color: transparent;
   }
   .copy-icon { font-size: 14px; line-height: 1; }
+
+  .latest-link {
+    margin-top: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-dim);
+    font-size: 13px;
+    padding: 4px 2px;
+    border-radius: 6px;
+    transition: color 120ms ease;
+  }
+  .latest-link:hover { color: var(--text); text-decoration: none; }
+  .latest-link:hover .latest-arrow { color: var(--lb-green); }
+  .latest-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--lb-green);
+    box-shadow: 0 0 8px rgba(0,224,84,0.6);
+    flex: 0 0 auto;
+  }
+  .latest-label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--lb-green);
+  }
+  .latest-version {
+    color: var(--text);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .latest-sep { color: var(--border); }
+  .latest-arrow {
+    margin-left: 4px;
+    color: var(--text-dim);
+    transition: color 120ms ease;
+  }
+  @media (max-width: 480px) {
+    .latest-sep, .latest-date { display: none; }
+  }
 
   .hero-art {
     position: relative;

--- a/site/src/pages/releases.astro
+++ b/site/src/pages/releases.astro
@@ -1,0 +1,431 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { releases } from '../lib/releases';
+
+const repoUrl = 'https://github.com/builtbyproxy/jellyfin-plugin-letterboxd';
+const manifestUrl = 'https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const home = `${base}/`;
+
+type CategoryDef = { key: 'new' | 'improvements' | 'fixes' | 'breaking'; label: string };
+const categoryOrder: CategoryDef[] = [
+  { key: 'breaking', label: 'Breaking' },
+  { key: 'new', label: 'New' },
+  { key: 'improvements', label: 'Improvements' },
+  { key: 'fixes', label: 'Fixes' },
+];
+---
+
+<Layout title="Releases — LetterboxdSync" description="What changed in every release of LetterboxdSync.">
+  <header class="site-header">
+    <div class="container nav">
+      <div class="brand-group">
+        <a class="brand" href={home} aria-label="LetterboxdSync home">
+          <span class="dots" aria-hidden="true">
+            <span class="dot dot-green"></span>
+            <span class="dot dot-blue"></span>
+            <span class="dot dot-orange"></span>
+          </span>
+          <span class="brand-name">LetterboxdSync</span>
+        </a>
+        <span class="brand-by">
+          by <a
+            href="https://lachlanyoung.dev/?utm_source=jellyfin-plugin-letterboxd&utm_medium=site&utm_campaign=author-link"
+            class="brand-author"
+            rel="author"
+            data-plausible-event="Author Link: Click"
+          >Lachlan Young</a>
+        </span>
+      </div>
+      <nav class="nav-links">
+        <a href={`${home}#features`}>Features</a>
+        <a href={`${home}#install`}>Install</a>
+        <a href={`${home}#setup`}>Setup</a>
+        <a href={`${base}/releases`} aria-current="page">Releases</a>
+        <a href={repoUrl} rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="releases-hero">
+    <div class="container">
+      <div class="eyebrow">
+        <span class="eyebrow-dot"></span>
+        Release history
+      </div>
+      <h1>What's <span class="accent">new</span>.</h1>
+      <p class="lede">
+        Every release of LetterboxdSync, newest first. Each entry covers the user-facing changes.
+        Backwards through the project history, all the way to <code>v1.0.0</code>.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href={`${home}#install`}>Install plugin</a>
+        <a class="btn btn-secondary" href={`${repoUrl}/releases`} rel="noopener">View on GitHub</a>
+      </div>
+      <div class="hero-meta">
+        <div class="meta-stat">
+          <span class="meta-num">{releases.length}</span>
+          <span class="meta-label">releases</span>
+        </div>
+        <div class="meta-stat">
+          <span class="meta-num">{releases[0]?.version}</span>
+          <span class="meta-label">latest</span>
+        </div>
+        <div class="meta-stat">
+          <span class="meta-num">{releases[0]?.dateLabel}</span>
+          <span class="meta-label">shipped</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="releases-list">
+    <div class="container">
+      {releases.map((rel, i) => {
+        const isLatest = i === 0;
+        const notes = rel.notes;
+        return (
+          <article class={`release ${isLatest ? 'release-latest' : ''}`} id={rel.anchor}>
+            <div class="release-meta">
+              <div class="version-row">
+                <a class="version" href={`#${rel.anchor}`} aria-label={`Link to ${rel.tag}`}>
+                  <span class="version-v">v</span>{rel.version}
+                </a>
+                {isLatest && <span class="badge badge-latest">Latest</span>}
+              </div>
+              <time class="release-date" datetime={rel.date.toISOString()}>{rel.dateLabel}</time>
+            </div>
+
+            <div class="release-body">
+              {notes ? (
+                <>
+                  <h2 class="release-headline">{notes.headline}</h2>
+                  {notes.summary && <p class="release-summary">{notes.summary}</p>}
+                  {categoryOrder.map(({ key, label }) => {
+                    const items = notes.highlights[key];
+                    if (!items || items.length === 0) return null;
+                    return (
+                      <div class={`category category-${key}`}>
+                        <div class="category-label">
+                          <span class="category-dot" aria-hidden="true"></span>
+                          {label}
+                        </div>
+                        <ul class="category-list">
+                          {items.map((item) => <li>{item}</li>)}
+                        </ul>
+                      </div>
+                    );
+                  })}
+                  {notes.upgradeNotes && (
+                    <div class="upgrade-notes">
+                      <strong>Upgrade notes:</strong> {notes.upgradeNotes}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p class="release-fallback">{rel.changelog}</p>
+              )}
+
+              <div class="release-actions">
+                <a class="action-link" href={rel.githubReleaseUrl} rel="noopener">
+                  View on GitHub <span aria-hidden="true">&rarr;</span>
+                </a>
+                <a class="action-link action-link-muted" href={rel.sourceUrl} rel="noopener">
+                  Download ZIP
+                </a>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <span class="dots dots-sm" aria-hidden="true">
+          <span class="dot dot-green"></span>
+          <span class="dot dot-blue"></span>
+          <span class="dot dot-orange"></span>
+        </span>
+        <span>LetterboxdSync</span>
+      </div>
+      <div class="footer-links">
+        <a href={home}>Home</a>
+        <a href={repoUrl} rel="noopener">GitHub</a>
+        <a href={`${repoUrl}/releases`} rel="noopener">Releases</a>
+        <a href={`${repoUrl}/issues`} rel="noopener">Issues</a>
+        <a href={manifestUrl}>Manifest</a>
+      </div>
+      <div class="footer-meta">
+        <span>Unofficial. Not affiliated with Letterboxd or Jellyfin.</span>
+      </div>
+    </div>
+  </footer>
+</Layout>
+
+<style>
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: rgba(11,13,16,0.75);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 64px;
+  }
+  .brand-group { display: inline-flex; align-items: center; gap: 12px; }
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+  .brand:hover { text-decoration: none; }
+  .brand-name { font-size: 15px; }
+  .brand-by { font-size: 13px; color: var(--text-dim); font-weight: 400; }
+  .brand-author { color: var(--text-dim); border-bottom: 1px dotted currentColor; }
+  .brand-author:hover { color: var(--text); text-decoration: none; }
+  @media (max-width: 640px) { .brand-by { display: none; } }
+
+  .dots { display: inline-flex; align-items: center; gap: 4px; }
+  .dots .dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
+  .dots-sm .dot { width: 10px; height: 10px; }
+  .dot-green { background: var(--lb-green); }
+  .dot-blue { background: var(--lb-blue); }
+  .dot-orange { background: var(--lb-orange); }
+
+  .nav-links { display: flex; gap: 22px; font-size: 14px; }
+  .nav-links a { color: var(--text-dim); }
+  .nav-links a:hover { color: var(--text); text-decoration: none; }
+  .nav-links a[aria-current="page"] { color: var(--text); }
+  @media (max-width: 640px) {
+    .nav-links a:nth-child(-n+2) { display: none; }
+  }
+
+  .releases-hero {
+    padding: 80px 0 56px;
+  }
+  @media (max-width: 900px) {
+    .releases-hero { padding: 56px 0 40px; }
+  }
+
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    border-radius: 999px;
+    margin-bottom: 20px;
+  }
+  .eyebrow-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--jf-purple);
+    box-shadow: 0 0 12px var(--jf-purple);
+  }
+
+  .accent {
+    background: linear-gradient(90deg, var(--lb-green), var(--lb-blue) 55%, var(--lb-orange));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .lede { font-size: 1.125rem; max-width: 640px; color: var(--text-dim); }
+
+  .hero-cta { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 28px; }
+
+  .hero-meta {
+    display: flex;
+    gap: 48px;
+    margin-top: 48px;
+    padding-top: 28px;
+    border-top: 1px solid var(--border);
+    flex-wrap: wrap;
+  }
+  .meta-stat { display: flex; flex-direction: column; gap: 4px; }
+  .meta-num { font-size: 1.5rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+  .meta-label { font-size: 12px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.12em; }
+
+  .releases-list { padding: 64px 0 96px; border-top: 1px solid var(--border); }
+
+  .release {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 48px;
+    padding: 40px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .release:last-child { border-bottom: 0; }
+  .release-latest {
+    background:
+      linear-gradient(180deg, rgba(0,224,84,0.04), transparent 60%);
+    margin: 0 -32px;
+    padding: 40px 32px;
+    border-radius: var(--radius-lg);
+  }
+
+  @media (max-width: 900px) {
+    .release { grid-template-columns: 1fr; gap: 16px; padding: 32px 0; }
+    .release-latest { margin: 0; padding: 32px 0; }
+  }
+
+  .release-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    position: sticky;
+    top: 88px;
+    align-self: start;
+  }
+  @media (max-width: 900px) {
+    .release-meta { position: static; }
+  }
+
+  .version-row { display: inline-flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+  .version {
+    font-size: 2rem;
+    font-weight: 800;
+    color: var(--text);
+    letter-spacing: -0.03em;
+    line-height: 1;
+  }
+  .version:hover { text-decoration: none; color: var(--lb-green); }
+  .version-v { color: var(--text-dim); font-weight: 500; margin-right: 1px; }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    border: 1px solid;
+  }
+  .badge-latest {
+    color: var(--lb-green);
+    border-color: rgba(0,224,84,0.4);
+    background: rgba(0,224,84,0.08);
+  }
+
+  .release-date { font-size: 13px; color: var(--text-dim); }
+
+  .release-body { min-width: 0; }
+  .release-headline {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 12px;
+    letter-spacing: -0.02em;
+    color: var(--text);
+  }
+  .release-summary { color: var(--text-dim); margin: 0 0 24px; }
+  .release-fallback { color: var(--text-dim); margin: 0 0 24px; line-height: 1.7; }
+
+  .category { margin: 20px 0; }
+  .category-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-dim);
+    font-weight: 600;
+    margin-bottom: 10px;
+  }
+  .category-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+  }
+  .category-new .category-dot { background: var(--lb-green); box-shadow: 0 0 8px rgba(0,224,84,0.5); }
+  .category-improvements .category-dot { background: var(--lb-blue); box-shadow: 0 0 8px rgba(64,188,244,0.5); }
+  .category-fixes .category-dot { background: var(--lb-orange); box-shadow: 0 0 8px rgba(255,128,0,0.5); }
+  .category-breaking .category-dot { background: #ff5252; box-shadow: 0 0 8px rgba(255,82,82,0.5); }
+  .category-new .category-label { color: var(--lb-green); }
+  .category-improvements .category-label { color: var(--lb-blue); }
+  .category-fixes .category-label { color: var(--lb-orange); }
+  .category-breaking .category-label { color: #ff5252; }
+
+  .category-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .category-list li {
+    color: var(--text-dim);
+    line-height: 1.65;
+    padding-left: 20px;
+    position: relative;
+  }
+  .category-list li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.75em;
+    width: 8px;
+    height: 1px;
+    background: var(--border);
+  }
+
+  .upgrade-notes {
+    margin-top: 20px;
+    padding: 14px 18px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    font-size: 14px;
+  }
+  .upgrade-notes strong { color: var(--text); }
+
+  .release-actions {
+    margin-top: 28px;
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+  }
+  .action-link {
+    color: var(--lb-green);
+    font-size: 14px;
+    font-weight: 500;
+  }
+  .action-link-muted { color: var(--text-dim); }
+  .action-link-muted:hover { color: var(--text); }
+
+  .site-footer { border-top: 1px solid var(--border); padding: 32px 0; }
+  .footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  .footer-brand { display: inline-flex; align-items: center; gap: 10px; color: var(--text-dim); font-size: 14px; }
+  .footer-links { display: flex; gap: 18px; font-size: 14px; }
+  .footer-links a { color: var(--text-dim); }
+  .footer-links a:hover { color: var(--text); text-decoration: none; }
+  .footer-meta { color: var(--text-dim); font-size: 12px; }
+</style>


### PR DESCRIPTION
No linked issue.

## What's broken

Visitors landing on the site to install the plugin have no way to see what changed in each version without bouncing to GitHub. The hand-written per-version changelogs in `manifest.json` are the cleanest summary of each release, but they only show up inside Jellyfin's plugin catalog, so a prospective user reading the site never sees them. New visitors come away unsure whether the project is still alive, and existing users have to click out to GitHub to confirm a fix is in the latest version.

## Why it happens

Two things lined up:

1. The site has always been a single landing page covering features, install, and setup. There has never been a Releases view.
2. Release-time effort goes into `manifest.json.versions[*].changelog`, but only Jellyfin's in-app catalog reads it. The GitHub release body is auto-generated from PR titles by `softprops/action-gh-release`, which has no editorial voice, and the site doesn't render any release info at all.

## What this PR does

Adds a Releases view to the site, fed at build time by the same `manifest.json` the plugin manifest uses, so there is no second source of truth to maintain.

- New `site/src/pages/releases.astro`: lists every version newest first, each card shows the version, date, a one-line headline, and category-split highlights (Breaking, New, Improvements, Fixes) with brand-coloured dots.
- New `site/src/data/release-notes.ts`: backdated, curated release notes for all 19 shipped versions from v1.0.0 to v1.11.2, with voice and length matching the existing manifest changelogs.
- New `site/src/lib/releases.ts`: joins manifest entries with the curated notes, sorts by semver, exposes `releases[]` and `latestRelease`.
- `site/src/pages/index.astro` hero gets a "Latest: v1.11.2, May 13, 2026, What's new" link under the install pill, and a Releases entry in the nav.
- New `.github/pull_request_template.md`: future PRs default to this body shape (the one you are reading now).
- New `openspec/` directory containing the full proposal (`proposal.md`, `design.md`, two spec files, `tasks.md`) that this PR partially implements. The proposal is the source of truth for the follow-up work listed below.

Not touched in this PR: the GitHub release workflow itself, the manifest schema, and `deploy-docs.yml`'s rebuild triggers. Those are tracked in the openspec proposal at `openspec/changes/add-release-template-and-site-releases/` and will land in follow-up PRs.

## How to test

No automated tests for the site (it is static Astro). Manual:

1. `cd site && npm run build` succeeds with no errors.
2. `npm run preview` and open http://localhost:4321/jellyfin-plugin-letterboxd/ .
3. Hero shows the new "Latest: v1.11.2, May 13, 2026, What's new" link below the Manifest URL pill.
4. Clicking it jumps to `/releases#v1-11-2`.
5. `/releases` shows 19 versions, newest first, with category dots in brand colours.
6. "View on GitHub" and "Download ZIP" links on each card resolve correctly.
7. At browser width ≤480px, the "Latest" link drops its date and release cards collapse to one column.

## Follow-ups (not in this PR)

- Render the GitHub release body from a template fed by `manifest.json`, replacing `generate_release_notes: true` (openspec proposal, `release-process` spec).
- Add `RELEASING.md` documenting the version-bump and tag flow.
- Add `manifest.json` to `deploy-docs.yml`'s `paths` filter so the site rebuilds when a new version lands.
- Add a CHANGELOG.md at the repo root (deferred from earlier in the conversation).