### PR TITLE
Explain why Cloudflare can still 403 after pasting cookies and User-Agent (#34)

### DIFF
--- a/LetterboxdSync/LetterboxdScraper.cs
+++ b/LetterboxdSync/LetterboxdScraper.cs
@@ -32,7 +32,13 @@ public class LetterboxdScraper
         using var res = await _http.GetWithCloudflareRetryAsync($"/tmdb/{tmdbId}").ConfigureAwait(false);
 
         if (res.StatusCode == HttpStatusCode.Forbidden)
-            throw new Exception($"TMDb lookup returned 403 for /tmdb/{tmdbId} after retries. Cloudflare is blocking. Try providing raw cookies.");
+            throw new Exception(
+                $"TMDb lookup returned 403 for /tmdb/{tmdbId} after retries. Cloudflare is blocking. " +
+                "If Raw Cookies and a matching User-Agent are already set, cf_clearance is most likely " +
+                "(1) expired (the token is short-lived, often around 30 minutes), " +
+                "(2) pinned to a different IP than the Jellyfin server (Cloudflare ties the token to the IP that solved the challenge, so a VPN or different machine breaks it), or " +
+                "(3) rejected by TLS fingerprinting (the plugin's HTTP client doesn't look like a real browser at the connection layer). " +
+                "See README \"Cloudflare issues\" for what to try.");
 
         if (res.StatusCode == HttpStatusCode.NotFound)
             throw new Exception($"Film with TMDb ID {tmdbId} not found on Letterboxd.");

--- a/README.md
+++ b/README.md
@@ -96,9 +96,19 @@ If login fails with a 403 error:
 5. Paste it into the **Raw Cookies** field
 6. Copy the **User-Agent** request header value from the same request and paste it into the **User-Agent** field
 
-The `cf_clearance` cookie expires periodically and may need refreshing.
-
 **Important:** Cloudflare ties `cf_clearance` to the exact User-Agent that solved the challenge. If you copied cookies from Chrome but leave the User-Agent field blank, the plugin sends the default Firefox UA and Cloudflare will reject the cookie. Always paste the User-Agent from the same browser you copied the cookies from. Leave it blank only if you copied cookies from Firefox 134 on Windows.
+
+#### Still 403ing after pasting Raw Cookies and a matching User-Agent
+
+When a correctly-copied cookie still gets blocked, it's usually one of these:
+
+1. **Different IP.** Cloudflare pins `cf_clearance` to the IP address that solved the challenge, not just the User-Agent. If the box running Jellyfin reaches the internet via a different public IP than the browser did (different machine, VPN, mobile tether, a server in a datacenter), Cloudflare sees the token arrive from a new IP and rejects it. Fix: paste fresh cookies from a browser running on the **same network as the Jellyfin server**, and watch out for VPNs or split tunnels.
+
+2. **It expired.** `cf_clearance` from a managed challenge is short-lived, often around 30 minutes. If there's a gap between copying the cookies and the sync actually running, the token can already be dead. Fix: paste fresh cookies and immediately trigger a sync from the plugin dashboard rather than waiting for the scheduled run.
+
+3. **Connection fingerprint.** Cloudflare doesn't only check the cookie and UA, it also fingerprints the TLS handshake and HTTP/2 behaviour of the connection. A plugin's HTTP client doesn't look like a real browser at that layer, so on a site running bot-fight mode the right cookie isn't always enough on its own. There isn't much the plugin can do about this one.
+
+If you've ruled all three out and a single film keeps getting stuck on the TMDb lookup, open an issue. A workaround that skips the Cloudflare-protected lookup for that one film (pointing a TMDb ID directly at a Letterboxd slug) is being considered.
 
 ## Requirements
 


### PR DESCRIPTION
Closes #34.

## What's broken

A user (@peeel in #34) pasted their Brave cookies and matching User-Agent exactly as the README instructed, and the sync still failed every run with this error in the log:

> Failed to sync "Forgotten" (TMDb:488623) for "rmn": "TMDb lookup returned 403 for /tmdb/488623 after retries. Cloudflare is blocking. Try providing raw cookies."

The error says "try providing raw cookies", but they already had. That's a dead end for the user, they have no idea what to do next, and the README's "Cloudflare issues" section stops at "paste cookies and UA" too, so there's nowhere to look it up.

## Why it happens

Cloudflare's `cf_clearance` has three constraints beyond cookie value + User-Agent that the error message and README never spelled out:

1. **IP pinning.** Cloudflare ties `cf_clearance` to the IP address that solved the challenge, not just the UA. If Jellyfin's egress IP differs from the browser's (different machine, VPN, mobile tether, datacenter), the token is rejected even though the cookie is correct.
2. **Short TTL.** A `cf_clearance` from a managed challenge often expires in about 30 minutes. A token pasted in advance can be dead by the time the scheduled sync actually runs.
3. **Connection fingerprint.** Cloudflare also fingerprints the TLS handshake and HTTP/2 behaviour. A .NET HTTP client doesn't look like a real browser at that layer, so on a domain in bot-fight mode the right cookie may not be enough.

The maintainer reply in #34 lays out all three, this PR just lifts that explanation into the code and the docs so future users don't have to find the issue thread.

## What this PR does

- `LetterboxdSync/LetterboxdScraper.cs`: rewrote the TMDb 403 exception message. Instead of "Try providing raw cookies." (which the user has already done) it now names the three likely causes and points at the README section by name.
- `README.md`: added a new "Still 403ing after pasting Raw Cookies and a matching User-Agent" subsection under "Cloudflare issues", explaining the three causes in plain English with a concrete fix per cause ("paste fresh cookies from a browser on the same network as the Jellyfin server", "trigger the sync immediately rather than waiting for the scheduled run", "there isn't much the plugin can do about this one"). Dropped the now-duplicate "the cookie expires periodically" line, the new subsection covers it.

Not touched on purpose:

- The partial-results log lines in `GetWatchlistTmdbIdsAsync` and `GetDiaryFilmEntriesAsync`, the sign-in 403 in `LetterboxdAuth.cs`, and the dashboard JS error in `userPage.html`. They have the same "try raw cookies" framing and would benefit from the same rewrite, but the change set is kept tight to the path that fired in the issue's log. Easy follow-up.
- The "manual TMDb ID maps to Letterboxd slug" workaround flagged in the issue comment. That's a real feature (storage, UI on the account page, lookup short-circuit, tests) and warrants its own design pass.

## How to test

- `dotnet build -c Release` clean (build succeeded, only pre-existing test-project warnings).
- `dotnet test -c Release` passes 431/431 in 35s, same as main. No test referenced the old exception string.
- Render the README on GitHub and confirm the new subsection lays out cleanly under the existing "Cloudflare issues" heading.
- Manual reproduction of the 403 path (block letterboxd.com locally, run a sync) is the only way to see the new exception text end-to-end, and is optional given there's no test that hits this path.

## Follow-ups (not in this PR)

- Same plain-English rewrite for the other three Cloudflare error surfaces: `LetterboxdScraper.cs` partial-results log lines, `LetterboxdAuth.cs:118` sign-in 403, and the "Blocked by Cloudflare. Try adding Raw Cookies with cf_clearance." string in `userPage.html`.
- Design and ship the manual TMDb-to-slug override so a single stuck film can be worked around without hitting the Cloudflare-protected lookup at all.