### PR TITLE
Move the site to letterboxdsync.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Jellyfin Letterboxd Sync](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/)
+# [Jellyfin Letterboxd Sync](https://letterboxdsync.dev/)
 
 [![CI](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/ci.yml/badge.svg)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/ci.yml)
 [![Release](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/release.yml/badge.svg)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/actions/workflows/release.yml)
@@ -7,8 +7,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/github/downloads/builtbyproxy/jellyfin-plugin-letterboxd/total)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases)
 
-**Website:** [lachlanyoung.dev/jellyfin-plugin-letterboxd](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/)
-**What's new:** [Release notes for every version](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/releases/)
+**Website:** [letterboxdsync.dev](https://letterboxdsync.dev/)
+**What's new:** [Release notes for every version](https://letterboxdsync.dev/releases/)
 
 Automatically sync your Jellyfin watch history to your Letterboxd diary. Films are logged in real-time when you finish watching, with a daily scheduled sync as a safety net.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Downloads](https://img.shields.io/github/downloads/builtbyproxy/jellyfin-plugin-letterboxd/total)](https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases)
 
 **Website:** [lachlanyoung.dev/jellyfin-plugin-letterboxd](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/)
+**What's new:** [Release notes for every version](https://lachlanyoung.dev/jellyfin-plugin-letterboxd/releases/)
 
 Automatically sync your Jellyfin watch history to your Letterboxd diary. Films are logged in real-time when you finish watching, with a daily scheduled sync as a safety net.
 
@@ -115,6 +116,13 @@ dotnet build -c Release
 ```
 
 Output DLLs are in `LetterboxdSync/bin/Release/net9.0/`.
+
+## Contributing
+
+PRs welcome. A few conventions:
+
+- **PR body shape** lives in [`.github/pull_request_template.md`](.github/pull_request_template.md). Symptom first, plain English, six fixed sections (What's broken, Why it happens, What this PR does, How to test, Follow-ups).
+- **Non-trivial changes** are planned through [`openspec/`](openspec/) before implementation: proposal, design, specs, then tasks. See [`openspec/changes/`](openspec/changes/) for active proposals and the [`archive/`](openspec/changes/archive/) folder for past ones.
 
 ## License
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,8 +1,7 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://lachlanyoung.dev',
-  base: '/jellyfin-plugin-letterboxd',
+  site: 'https://letterboxdsync.dev',
   trailingSlash: 'ignore',
   build: {
     assets: 'assets',

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+letterboxdsync.dev

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -67,7 +67,7 @@ const featureGroups: FeatureGroup[] = [
   <header class="site-header">
     <div class="container nav">
       <div class="brand-group">
-        <a class="brand" href="/jellyfin-plugin-letterboxd/" aria-label="LetterboxdSync home">
+        <a class="brand" href="/" aria-label="LetterboxdSync home">
           <span class="dots" aria-hidden="true">
             <span class="dot dot-green"></span>
             <span class="dot dot-blue"></span>


### PR DESCRIPTION
No linked issue. Stacked on top of #38, change the base to `main` once that one merges.

## What's broken

The site lives under a subpath of the maintainer's personal portfolio at `lachlanyoung.dev/jellyfin-plugin-letterboxd/`. Two problems with that:

1. It reads like a hobby corner of one developer's portfolio rather than a plugin with its own identity. The plugin is "LetterboxdSync" everywhere else (manifest, dashboard, install docs).
2. The site's URL is tied to the maintainer's personal domain. If `lachlanyoung.dev` ever moves, expires, or gets repurposed, the plugin's "home" disappears with it.

## Why it happens

The site lives in this repo's `site/` directory and is served as a GitHub Pages **project page** under whichever user/org-level Pages site owns the apex domain. With `lachlanyoung.dev` configured at the user level, all project pages auto-route to `<apex>/<repo-name>/`. Until this repo claims its own custom domain, it inherits that path-prefixed URL.

Two things needed to change to fix it:

1. The repo needs to claim its own CNAME so GitHub Pages stops routing it through the user-level domain.
2. The Astro build needs to stop prefixing every asset with `/jellyfin-plugin-letterboxd/`, since under the new domain the site lives at the root.

## What this PR does

Moves the site to **`letterboxdsync.dev`**, still hosted on the same GitHub Pages infrastructure. Domain is registered via Namecheap and A and AAAA records already point at GitHub's IPs (verified with `dig letterboxdsync.dev +short`).

- `site/public/CNAME` new file, single line `letterboxdsync.dev`. The Astro action copies `public/` through to the build output verbatim, so GitHub Pages picks it up at deploy time.
- `site/astro.config.mjs` `site` becomes `https://letterboxdsync.dev`, `base: '/jellyfin-plugin-letterboxd'` is removed entirely. Every internal link and asset that uses `import.meta.env.BASE_URL` auto-adjusts to `/`.
- `site/src/pages/index.astro` one hardcoded `href="/jellyfin-plugin-letterboxd/"` on the brand link becomes `href="/"`. Everything else (nav, latest pill, Releases link) already routes through `BASE_URL`.
- `README.md` the H1 link, the `**Website:**` row, and the `**What's new:**` row swap to the new domain.

Not touched on purpose:

- `https://raw.githubusercontent.com/builtbyproxy/jellyfin-plugin-letterboxd/main/manifest.json` (the manifest URL in install instructions) is unchanged. It's a GitHub raw URL, not a site URL, so it survives the move. Anyone who already added that URL to Jellyfin keeps working with zero action.
- The Plausible script tag in `Layout.astro` is unchanged. The script ID is opaque and doesn't reference the domain. Allowlisting `letterboxdsync.dev` happens in the Plausible dashboard, called out as a follow-up.
- The author-attribution link in the hero (`https://lachlanyoung.dev/?utm_source=...`) is unchanged. That's a deliberate attribution link, not a site URL.

## How to test

Local:

- `cd site && npm run build` succeeds with no errors.
- `site/dist/CNAME` contains `letterboxdsync.dev`.
- `grep -o 'href="[^"]*"' site/dist/index.html | sort -u` returns clean root paths (`/`, `/releases`, `/releases#v1-11-2`), no `/jellyfin-plugin-letterboxd/` prefix anywhere except the GitHub repo URLs (correct, those reference the repo name).
- `dig letterboxdsync.dev +short` returns GitHub's four IPs (`185.199.108.153`, `.109.153`, `.110.153`, `.111.153`).

Post-merge:

- `deploy-docs.yml` runs on the push to main.
- Within a few minutes, `https://letterboxdsync.dev/` and `https://letterboxdsync.dev/releases` load with valid Let's Encrypt certs (GitHub auto-provisions on first deploy with a CNAME present).
- Verify cert state: `gh api repos/builtbyproxy/jellyfin-plugin-letterboxd/pages` shows `https_certificate.state: approved`.
- Flip `https_enforced: true` (Settings UI or `gh api -X PUT .../pages -f https_enforced=true`).

## Follow-ups (not in this PR)

- Add `letterboxdsync.dev` as an allowed domain in the Plausible dashboard so traffic to the new host actually gets counted.
- Optional: add a meta-refresh redirect at `lachlanyoung.dev/jellyfin-plugin-letterboxd/` (in the repo backing the user-level Pages site) so the old URL doesn't 404 for inbound links.
- Optional: serve a vanity manifest URL at `https://letterboxdsync.dev/manifest.json` by copying the root `manifest.json` into the site build. Friendlier than the GitHub raw URL for install docs.