### PR TITLE
Release v1.11.3, Cloudflare 403 docs and clearer error message

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.0.0</Version>
-        <AssemblyVersion>1.2.0.0</AssemblyVersion>
-        <FileVersion>1.2.0.0</FileVersion>
+        <Version>1.11.3.0</Version>
+        <AssemblyVersion>1.11.3.0</AssemblyVersion>
+        <FileVersion>1.11.3.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.11.2.0</AssemblyVersion>
-    <FileVersion>1.11.2.0</FileVersion>
+    <AssemblyVersion>1.11.3.0</AssemblyVersion>
+    <FileVersion>1.11.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,14 @@
     "category": "General",
     "versions": [
       {
+        "version": "1.11.3.0",
+        "changelog": "Docs: when a Cloudflare 403 happens after you've already pasted Raw Cookies and a matching User-Agent, the plugin error message and README now explain why (cf_clearance is short-lived, pinned to the IP that solved the challenge, and the connection itself is TLS-fingerprinted) and what to try. Addresses the dead-end case reported in #34. No plugin behaviour changes.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.11.3/jellyfin-plugin-letterboxd-v1.11.3.zip",
+        "checksum": "PLACEHOLDER",
+        "timestamp": "2026-05-14T00:00:00Z"
+      },
+      {
         "version": "1.11.2.0",
         "changelog": "Fix: with diary-import enabled, the daily sync was posting phantom rewatch entries to Letterboxd for films you had only marked played via diary import (never actually watched on Jellyfin). The runner now suppresses these films until a real Jellyfin playback sets a LastPlayedDate, at which point the rewatch lands on Letterboxd as expected. Docs: install instructions now call out the File Transformation plugin as a prerequisite for the in-sidebar Letterboxd link.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
Release bump for v1.11.3.

Bumps `AssemblyVersion` and `FileVersion` to `1.11.3.0` in `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`, and adds the corresponding manifest entry with `checksum: "PLACEHOLDER"` (replaced automatically by the release workflow after the tag is pushed).

## What's shipping

**Docs and error message, Cloudflare 403 with cookies and User-Agent already set (Closes #34)**

A user pasted cookies and the matching User-Agent from the same Brave session exactly as the README said to, and the sync still failed every run with a Cloudflare 403. The plugin's only error said "Try providing raw cookies", which is a dead end when they already had. The README's Cloudflare section stopped at the same point.

Now:

- The TMDb-lookup 403 exception names the three real causes (token expired, pinned to a different IP than the Jellyfin server, or rejected by TLS fingerprinting) and points at the README.
- README has a new subsection under "Cloudflare issues" explaining each cause in plain English with a concrete fix per cause (paste fresh cookies from a browser on the same network, trigger the sync immediately rather than waiting for the scheduled run, accept that bot-fight-mode fingerprinting may always reject the plugin's TLS handshake).

No plugin behaviour changes.

## After this lands

Tag `v1.11.3` from main, the release workflow will build, package the ZIP, create the GitHub release, and commit the real md5 checksum back to `manifest.json` on `main`.

```
git checkout main && git pull
git tag v1.11.3
git push --tags
```

## Not in this release

- The three sibling Cloudflare error-message rewrites called out as follow-ups in #39 (partial-results log lines in `LetterboxdScraper`, the sign-in 403 in `LetterboxdAuth`, the dashboard JS in `userPage.html`).
- The manual TMDb-ID-to-Letterboxd-slug workaround for stuck single films.
- The Plausible domain allowlist update and the optional `lachlanyoung.dev/jellyfin-plugin-letterboxd/` redirect from the website migration (off-repo work).