### PR TITLE
Show v1.11.3 on the Releases page and auto-rebuild the site on future manifest changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - 'manifest.json'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,16 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.11.3',
+    headline: 'Plain-English error and docs when Cloudflare 403s with cookies already set',
+    highlights: {
+      improvements: [
+        "The TMDb-lookup 403 exception now names the three real causes (cf_clearance expired, often around 30 minutes; pinned to a different IP than the Jellyfin server; or rejected by Cloudflare's TLS fingerprinting) and points at the README, instead of suggesting raw cookies that the user has already pasted.",
+        "README has a new 'Still 403ing after pasting Raw Cookies and a matching User-Agent' subsection under 'Cloudflare issues' with a concrete fix per cause. Addresses the dead-end case reported in #34.",
+      ],
+    },
+  },
+  {
     version: '1.11.2',
     headline: 'Stop phantom rewatches on diary-imported films',
     highlights: {


### PR DESCRIPTION
No linked issue.

## What's broken

v1.11.3 was tagged and released last night, but visiting `https://letterboxdsync.dev/releases` doesn't show it. The latest release card on the page is still v1.11.2.

## Why it happens

Two things lined up:

1. The deploy-docs workflow only triggers on `paths: site/**` and `.github/workflows/deploy-docs.yml`. The release workflow committed the v1.11.3 manifest entry and the real checksum directly to `manifest.json` on main, which isn't in the trigger filter. So the site didn't rebuild.
2. Even if it had rebuilt, `site/src/data/release-notes.ts` (the categorised release-notes source the Releases page joins with the manifest) doesn't have a v1.11.3 entry, so the v1.11.3 card would have fallen back to the manifest's prose rendering. Functional, less polished.

## What this PR does

- `.github/workflows/deploy-docs.yml`, adds `manifest.json` to the `paths` filter, so future releases auto-trigger a site rebuild the moment the release workflow commits the manifest checksum back to main. No more manually-triggered deploys after a release.
- `site/src/data/release-notes.ts`, prepends the v1.11.3 entry above v1.11.2. Categorised as `improvements` (no plugin behaviour changed, just the error message and README). Two bullets, one for the exception text rewrite and one for the new README subsection.

Not touched: the underlying releases helper (`site/src/lib/releases.ts`) and the page template (`site/src/pages/releases.astro`). They already pick up new manifest entries automatically once the rebuild fires.

## How to test

Local:

- `cd site && npm run build` succeeds with no errors.
- `dist/releases/index.html` contains "v1.11.3" and the new improvements bullets.

Post-merge:

- The deploy-docs workflow runs because this PR touches `site/**` (the release-notes.ts file). Verify with `gh run list --workflow=deploy-docs.yml --limit 1`.
- Visit `https://letterboxdsync.dev/releases` and confirm v1.11.3 sits at the top of the list with the "Latest" badge and a green-dotted "Improvements" section.
- Visit `https://letterboxdsync.dev/` and confirm the hero "Latest" pill shows v1.11.3.

To verify the new manifest-rebuild trigger works for real, the next release tag push will be the test. Should "just work" because `release.yml` already commits the manifest checksum back to main, and that commit will now match the new path filter.

## Follow-ups (not in this PR)

- Resume the openspec archive of `add-release-template-and-site-releases` (was interrupted earlier in this session, stashed locally). Now that the deploy trigger is in place, the remaining `release-process` tasks (template file, render script, RELEASING.md, manifest-changelog-required check) are the only ones left of that proposal.