### PR TITLE
test(integration): /review follow-ups (throttle, paths filter, narrowed catches, extracted logger)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,9 +14,24 @@ name: Integration tests (live Letterboxd)
 # workflow. The job below detects missing credentials up front and skips
 # (success exit) so external contributors aren't blocked.
 on:
+  # Paths filter: skip the suite on PRs that only touch docs, site, manifest,
+  # deploy scripts, etc. — anything that can't change plugin behaviour. Manual
+  # workflow_dispatch has no filter so a release-gate run always exercises it.
   push:
     branches: [main]
+    paths:
+      - 'LetterboxdSync/**'
+      - 'LetterboxdSync.Tests/**'
+      - 'Directory.Build.props'
+      - 'LetterboxdSync.sln'
+      - '.github/workflows/integration.yml'
   pull_request:
+    paths:
+      - 'LetterboxdSync/**'
+      - 'LetterboxdSync.Tests/**'
+      - 'Directory.Build.props'
+      - 'LetterboxdSync.sln'
+      - '.github/workflows/integration.yml'
   workflow_dispatch:
 
 jobs:

--- a/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
+++ b/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,19 +26,6 @@ public class LetterboxdLiveTests
     {
         _output = output;
         _logger = new XunitLogger(output);
-    }
-
-    private sealed class XunitLogger : ILogger
-    {
-        private readonly ITestOutputHelper _output;
-        public XunitLogger(ITestOutputHelper output) { _output = output; }
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-        public bool IsEnabled(LogLevel logLevel) => true;
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-            try { _output.WriteLine($"[{logLevel}] {formatter(state, exception)}"); } catch { }
-        }
-        private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
     }
 
     private const string EnvUser = "LETTERBOXD_TEST_USERNAME";
@@ -146,9 +132,11 @@ public class LetterboxdLiveTests
             Assert.True(string.IsNullOrWhiteSpace(film?.Slug),
                 "Lookup of unknown TMDb id should not return a real film slug");
         }
-        catch (Exception)
+        catch (Exception ex) when (IsExpectedNotFoundException(ex))
         {
-            // Throw is also acceptable — production callers wrap and log.
+            // Throw with a "not found"-shaped message is acceptable; production callers
+            // wrap and log. Network, auth, or Cloudflare failures fall through and fail
+            // the test loudly so transient infra problems don't masquerade as passes.
         }
     }
 
@@ -173,10 +161,24 @@ public class LetterboxdLiveTests
             if (film != null && !string.IsNullOrWhiteSpace(film.Slug))
                 Assert.DoesNotContain("hijack-2023", film.Slug, StringComparison.OrdinalIgnoreCase);
         }
-        catch (Exception)
+        catch (Exception ex) when (IsExpectedNotFoundException(ex))
         {
-            // No-match throw is fine.
+            // No-match throw is fine. Other exception shapes (network, auth, Cloudflare)
+            // fall through so the test fails red instead of silently passing on infra blips.
         }
+    }
+
+    /// <summary>
+    /// Filter for exceptions raised by `LookupFilmByTmdbIdAsync` when the TMDb id
+    /// doesn't map to a Letterboxd film. The API client throws a bare `Exception`
+    /// today; we match on the message shape so transient network/auth/Cloudflare
+    /// errors are NOT caught by negative-path tests and instead surface as failures.
+    /// </summary>
+    private static bool IsExpectedNotFoundException(Exception ex)
+    {
+        var msg = ex.Message ?? string.Empty;
+        return msg.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            || msg.Contains("no result", StringComparison.OrdinalIgnoreCase);
     }
 
     [SkippableFact]

--- a/LetterboxdSync.Tests/Integration/XunitLogger.cs
+++ b/LetterboxdSync.Tests/Integration/XunitLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace LetterboxdSync.Tests.Integration;
+
+/// <summary>
+/// Bridges Microsoft.Extensions.Logging output to xUnit's per-test output buffer
+/// so the integration suite's auth, list, write, and cleanup paths surface their
+/// log lines on the test runner's console (and in CI run logs) without polluting
+/// stdout. Used by every integration test class; instantiate one per test class
+/// from the test's constructor with the injected <see cref="ITestOutputHelper"/>.
+/// </summary>
+internal sealed class XunitLogger : ILogger
+{
+    private readonly ITestOutputHelper _output;
+
+    public XunitLogger(ITestOutputHelper output) { _output = output; }
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        // WriteLine can throw if the test has already completed and the output
+        // buffer is closed (rare but real with async logger paths that outlive
+        // the test). Swallow to avoid masking the actual test result.
+        try { _output.WriteLine($"[{logLevel}] {formatter(state, exception)}"); }
+        catch { }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/LetterboxdSync/LetterboxdApiClient.cs
+++ b/LetterboxdSync/LetterboxdApiClient.cs
@@ -388,11 +388,20 @@ public class LetterboxdApiClient : ILetterboxdService
         using var doc = JsonDocument.Parse(json);
         if (!doc.RootElement.TryGetProperty("items", out var items)) return;
 
+        // Throttle deletes so an account with accumulated residue (e.g. from a prior
+        // run that died mid-cleanup) doesn't fire dozens of DELETEs back-to-back and
+        // trip Letterboxd's rate limit, which would leave entries undeleted and pollute
+        // future runs.
+        var first = true;
         foreach (var item in items.EnumerateArray())
         {
             if (!item.TryGetProperty("id", out var idEl)) continue;
             var entryId = idEl.GetString();
             if (string.IsNullOrEmpty(entryId)) continue;
+
+            if (!first)
+                await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            first = false;
 
             try
             {
@@ -406,7 +415,7 @@ public class LetterboxdApiClient : ILetterboxdService
             }
             catch (Exception ex)
             {
-                _logger.LogWarning("Cleanup: DELETE /log-entries/{Id} threw: {Message}", entryId, ex.Message);
+                _logger.LogWarning("Cleanup: DELETE /log-entry/{Id} threw: {Message}", entryId, ex.Message);
             }
         }
     }


### PR DESCRIPTION
Follow-up to PRs #28 and #43. Addresses all four findings from the post-merge `/review` of the integration test suite.

## What changes

**1. Throttle cleanup deletes** (`LetterboxdSync/LetterboxdApiClient.cs`)

`DeleteAllLogEntriesForFilmAsync` now sleeps 250ms between subsequent DELETEs. First delete fires immediately. Steady-state cost: zero (1 entry per run). Recovery cost when a prior run crashed mid-cleanup: `(N-1) × 250ms`, which gives Letterboxd's rate-limit window room to breathe instead of snowballing residue.

**2. Paths filter on the integration workflow** (`.github/workflows/integration.yml`)

`push` and `pull_request` triggers now scope to `LetterboxdSync/**`, `LetterboxdSync.Tests/**`, `Directory.Build.props`, `LetterboxdSync.sln`, and the workflow file itself. Docs-only or site-only PRs no longer hit Letterboxd. `workflow_dispatch` deliberately has no filter so a manual release-gate run always exercises the suite.

**3. Narrow negative-path exception catches** (`LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs`)

`LookupFilmByTmdbId_UnknownId_*` and `_TvShowId_*` previously caught bare `Exception`, which swallowed transient network/DNS/Cloudflare failures and made infra blips look like passes. The catches now use a `when (IsExpectedNotFoundException(ex))` filter that matches on \"not found\" / \"no result\" message shapes — semantics preserved for the legitimate \"id doesn't map to a film\" case, but DNS/auth/Cloudflare errors now fall through and fail the test red.

**4. Extract `XunitLogger`** (`LetterboxdSync.Tests/Integration/XunitLogger.cs`)

Moved the inlined `ILogger → ITestOutputHelper` bridge from inside `LetterboxdLiveTests` to a standalone file in the same namespace. Pure refactor: no behaviour change, just available to future integration test classes without copy-paste.

## Why include all four

Original PR description here only included the throttle. You pushed back asking why I excluded the other three — fair call:
- The paths filter still runs integration in CI, just not on docs-only PRs. That respects \"run in CI\" without burning Cloudflare quota on README changes.
- Narrowing the bare catches is a real correctness improvement: it prevents infra failures from being silently treated as passes.
- Extracting `XunitLogger` is a pure file move; the \"premature without a second class\" reasoning was taste, not safety.

## Verified

- `dotnet test --filter \"Category!=Integration\"` → 470/470 unit tests pass on this branch
- Skipped local integration run (avoiding credential paste into shell history); CI's integration workflow will exercise the throttled cleanup and narrowed catches live on this PR

## Test plan
- [x] Unit suite: 470/470 pass
- [x] Build: Release clean
- [ ] CI integration workflow run on this PR is green (auto-triggered on push since the diff touches `LetterboxdSync/**` and `LetterboxdSync.Tests/**`)