### PR TITLE
ci: make release workflow the sole writer of manifest.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Validate manifest.json
+        # manifest.json is CI-managed (see release.yml). This guards the two
+        # ways it can be poisoned by hand: a PLACEHOLDER checksum left in,
+        # or a sourceUrl that no longer resolves (release deleted/renamed).
+        run: |
+          set -e
+          if grep -q PLACEHOLDER manifest.json; then
+            echo "::error::manifest.json contains PLACEHOLDER. Manifest entries are inserted by release.yml after a successful build — do not pre-commit them. See CLAUDE.md > Releasing."
+            exit 1
+          fi
+          fail=0
+          while IFS= read -r url; do
+            code=$(curl -sIL -o /dev/null -w '%{http_code}' "$url")
+            if [ "$code" != "200" ]; then
+              echo "::error::manifest sourceUrl returned HTTP $code: $url"
+              fail=1
+            fi
+          done < <(jq -r '.[0].versions[].sourceUrl' manifest.json)
+          exit $fail
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,61 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout main
+        # Check out main directly (not the tag's detached HEAD) so the
+        # manifest commit at the end of this job lands on main cleanly.
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          set -e
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          ASSEMBLY="${VERSION}.0"
+          echo "tag=$TAG"           >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION"   >> "$GITHUB_OUTPUT"
+          echo "assembly=$ASSEMBLY" >> "$GITHUB_OUTPUT"
+
+      - name: Verify project version matches tag
+        # If the dev tags without bumping Directory.Build.props/csproj the
+        # built DLL's AssemblyVersion won't match the manifest entry we're
+        # about to write, and Jellyfin will refuse to load it. Fail loud.
+        run: |
+          set -e
+          ASSEMBLY="${{ steps.version.outputs.assembly }}"
+          PROJ=$(grep -oE '<AssemblyVersion>[^<]+' Directory.Build.props | head -1 | sed 's/<AssemblyVersion>//')
+          if [ "$PROJ" != "$ASSEMBLY" ]; then
+            echo "::error::Directory.Build.props AssemblyVersion ($PROJ) does not match tag (${ASSEMBLY}). Bump versions on main before tagging."
+            exit 1
+          fi
+          CSPROJ=$(grep -oE '<AssemblyVersion>[^<]+' LetterboxdSync/LetterboxdSync.csproj | head -1 | sed 's/<AssemblyVersion>//')
+          if [ "$CSPROJ" != "$ASSEMBLY" ]; then
+            echo "::error::LetterboxdSync.csproj AssemblyVersion ($CSPROJ) does not match tag (${ASSEMBLY})."
+            exit 1
+          fi
+
+      - name: Read changelog from tag annotation
+        # Annotated tag message becomes the user-facing changelog text in
+        # both the GitHub release body and the manifest entry. Lightweight
+        # tags (no annotation) are rejected — the changelog is required.
+        run: |
+          set -e
+          TAG="${{ steps.version.outputs.tag }}"
+          MSG=$(git tag -l --format='%(contents)' "$TAG")
+          # Strip any trailing PGP signature block
+          MSG=$(printf '%s' "$MSG" | sed '/^-----BEGIN PGP SIGNATURE-----/,$d')
+          MSG=$(printf '%s' "$MSG" | sed -e 's/[[:space:]]*$//')
+          if [ "${#MSG}" -lt 20 ]; then
+            echo "::error::Tag $TAG must be an annotated tag with a changelog message of at least 20 chars. Use: git tag -a $TAG -F release-notes.md && git push origin $TAG"
+            exit 1
+          fi
+          printf '%s' "$MSG" > /tmp/changelog.txt
+          echo "Changelog (${#MSG} chars):"
+          head -c 400 /tmp/changelog.txt; echo
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -26,29 +80,60 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal
+        run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=Integration"
 
       - name: Package
         run: |
           cd LetterboxdSync/bin/Release/net9.0
-          zip -j /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip LetterboxdSync.dll HtmlAgilityPack.dll
+          zip -j /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip LetterboxdSync.dll HtmlAgilityPack.dll
 
-      - name: Create Release
+      - name: Compute checksum
+        id: cs
+        run: |
+          CS=$(md5sum /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip | awk '{print $1}')
+          echo "checksum=$CS" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip
-          generate_release_notes: true
+          files: /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip
+          body_path: /tmp/changelog.txt
 
-      - name: Update manifest checksum
+      - name: Insert manifest entry
+        # Manifest is CI-managed: the only writer is this step, after the
+        # release artifact actually exists. Idempotent on re-run (updates
+        # in place if the version already exists in the manifest).
         run: |
-          CHECKSUM=$(md5sum /tmp/jellyfin-plugin-letterboxd-${{ github.ref_name }}.zip | awk '{print $1}')
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
+          set -e
+          ASSEMBLY="${{ steps.version.outputs.assembly }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          CS="${{ steps.cs.outputs.checksum }}"
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/jellyfin-plugin-letterboxd-${TAG}.zip"
+          TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # Inherit targetAbi from the most recent existing entry so bumping
+          # the Jellyfin ABI floor stays a deliberate edit to manifest.json.
+          ABI=$(jq -r '.[0].versions[0].targetAbi // "10.11.0.0"' manifest.json)
+          CHANGELOG=$(cat /tmp/changelog.txt)
 
-          # Use jq to update the checksum for the matching version entry
-          jq --arg ver "${VERSION}.0" --arg cs "$CHECKSUM" \
-            '.[0].versions |= map(if .version == $ver then .checksum = $cs else . end)' \
-            manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+          if jq -e --arg v "$ASSEMBLY" '.[0].versions | any(.version == $v)' manifest.json > /dev/null; then
+            echo "Updating existing $ASSEMBLY entry in place"
+            jq --arg v "$ASSEMBLY" --arg cs "$CS" --arg url "$URL" --arg ts "$TS" --arg cl "$CHANGELOG" \
+              '.[0].versions |= map(if .version == $v then (.checksum=$cs | .sourceUrl=$url | .timestamp=$ts | .changelog=$cl) else . end)' \
+              manifest.json > manifest.tmp
+          else
+            echo "Inserting new $ASSEMBLY entry at top of manifest"
+            jq --arg v "$ASSEMBLY" --arg cs "$CS" --arg url "$URL" --arg ts "$TS" --arg cl "$CHANGELOG" --arg abi "$ABI" \
+              '.[0].versions = ([{
+                version: $v,
+                changelog: $cl,
+                targetAbi: $abi,
+                sourceUrl: $url,
+                checksum: $cs,
+                timestamp: $ts
+              }] + .[0].versions)' \
+              manifest.json > manifest.tmp
+          fi
+          mv manifest.tmp manifest.json
 
       - name: Commit manifest update
         run: |
@@ -56,5 +141,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add manifest.json
           git diff --cached --quiet && exit 0
-          git commit -m "Update manifest checksum for ${{ github.ref_name }}"
+          git commit -m "Release ${{ steps.version.outputs.tag }} (manifest auto-update)"
           git push origin HEAD:main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,24 @@ Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `Letterb
 
 ## Releasing
 
-Versions live in **three** places and must be bumped together before tagging:
+`manifest.json` is **CI-managed**. `release.yml` is the only writer. Do not pre-add `PLACEHOLDER` entries by hand; `ci.yml` will refuse the PR. Past incident: a v1.12.0.0 manifest entry was merged to main without the tag ever being pushed, leaving the manifest advertising a release whose ZIP did not exist (404 on install for every user). The workflow now inserts the manifest entry only after the build succeeds, so that state is unreachable.
 
-1. `Directory.Build.props` — `<Version>` / `<AssemblyVersion>` / `<FileVersion>`
-2. `LetterboxdSync/LetterboxdSync.csproj` — `<AssemblyVersion>` / `<FileVersion>`
-3. `manifest.json` — add a new version entry; set `checksum` to `PLACEHOLDER`
+Steps:
 
-Then `git tag vX.Y.Z && git push --tags`. `release.yml` builds, tests, packages the ZIP, creates the GitHub release, and commits the real md5 checksum to `manifest.json` on `main` (directly, no PR — see `TODOS.md`).
+1. Bump versions on `main`:
+   - `Directory.Build.props`, set `<Version>` / `<AssemblyVersion>` / `<FileVersion>`
+   - `LetterboxdSync/LetterboxdSync.csproj`, set `<AssemblyVersion>` / `<FileVersion>`
+2. Write the user-facing changelog into `release-notes.md` (or pass `-m` inline). The release workflow uses this verbatim for both the GitHub release body and the `changelog` field in `manifest.json`.
+3. Create an **annotated** tag and push it:
+
+   ```bash
+   git tag -a vX.Y.Z -F release-notes.md
+   git push origin vX.Y.Z
+   ```
+
+   Lightweight tags (no annotation) are rejected by the workflow.
+
+`release.yml` then verifies the tag matches the project's `AssemblyVersion`, builds + tests, packages the ZIP, creates the GitHub release, and inserts a new entry into `manifest.json` on `main` with the real md5 checksum, the release `sourceUrl`, and the tag annotation as the changelog. Re-running the workflow on the same tag is idempotent (updates the entry in place).
 
 ## OpenSpec
 

--- a/manifest.json
+++ b/manifest.json
@@ -88,14 +88,6 @@
         "timestamp": "2026-04-26T00:00:00Z"
       },
       {
-        "version": "1.7.1.0",
-        "changelog": "Fix watchlist sync returning 0 films via official API: redundant `member` query param caused Letterboxd to return empty items",
-        "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.7.1/jellyfin-plugin-letterboxd-v1.7.1.zip",
-        "checksum": "PLACEHOLDER",
-        "timestamp": "2026-04-25T00:00:00Z"
-      },
-      {
         "version": "1.7.0.0",
         "changelog": "Per-account User-Agent override so Cloudflare cookies copied from any browser (Chrome, Safari, etc.) work without UA mismatch",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary

Closes a structural hole in the release process that caused issues #45 / #46 (v1.12.0 install failing with a 404). The old flow had devs commit a `manifest.json` entry with `"checksum": "PLACEHOLDER"` on main *before* tagging; if the tag was never pushed (as happened for v1.12.0, May 2026), the manifest ended up advertising a version whose GitHub release artifact did not exist, and every install attempt 404'd.

This PR makes the manifest CI-managed: `release.yml` is the only thing that ever writes to `manifest.json`, and only after the build/test/package/release-create steps succeed. The broken intermediate state is unreachable.

## Changes

- `.github/workflows/release.yml`
  - Resolves version from the tag, verifies it matches `Directory.Build.props` and `LetterboxdSync.csproj` AssemblyVersion before doing anything else
  - Requires an **annotated** tag whose message becomes the user-facing changelog (used verbatim for both the GitHub release body and the manifest's `changelog` field)
  - Builds, tests (excluding `Category=Integration` to match `ci.yml`), packages, creates the release
  - **Inserts** the new manifest entry (was: updated an existing PLACEHOLDER). `targetAbi` is inherited from the previous most-recent entry so bumping the Jellyfin ABI floor stays a deliberate manifest edit
  - Idempotent on workflow re-run (updates existing entry in place if present)
- `.github/workflows/ci.yml`
  - New "Validate manifest.json" step: fails on `PLACEHOLDER` and HEAD-checks every `sourceUrl` returns 200. Catches any future hand-edit that puts the manifest back in a broken state
- `CLAUDE.md`
  - Releasing section rewritten: drops the manifest bump step, documents the annotated-tag-with-changelog requirement, notes the past incident

## New release flow

```bash
# 1. bump Directory.Build.props + LetterboxdSync.csproj on main
# 2. write the changelog
$EDITOR release-notes.md
# 3. annotated tag + push
git tag -a v1.13.0 -F release-notes.md
git push origin v1.13.0
```

`release.yml` does the rest.

## Test plan

- [ ] CI passes on this PR (the new validate-manifest step runs against current `manifest.json` on `main`, which is already in a healthy post-v1.12.0 state, so it should be green)
- [ ] Next real release (v1.13.x) exercises the new insertion path end-to-end
- [ ] If the next release fails for any reason, manifest.json on main is unchanged (the commit step only fires after `Create GitHub Release` succeeds)