### PR TITLE
fix(plugin): reflection shim for IUserManager.Users to survive Jellyfin 10.11.9 signature change (#46)

### DIFF
--- a/LetterboxdSync.Tests/DiaryImportTaskTests.cs
+++ b/LetterboxdSync.Tests/DiaryImportTaskTests.cs
@@ -106,6 +106,22 @@ public class DiaryImportTaskTests : IDisposable
         Assert.False(LetterboxdSyncRunner.IsRunning);
     }
 
+    // Jellyfin 10.11.9 IUserManager.Users signature change (issue #46): a direct
+    // read throws MissingMethodException on 10.11.9+ because the plugin's binding
+    // is against the 10.11.0 IEnumerable<User> getter signature. The reflection
+    // shim swallows the throw and returns empty, so the scheduled task must
+    // complete the same way it does for a zero-user server.
+    [Fact]
+    public async Task ExecuteAsync_WhenUsersGetterThrows_CompletesWithoutCrash()
+    {
+        _userManager.Users.Returns(_ => throw new MissingMethodException(
+            "Method not found: 'System.Collections.Generic.IEnumerable`1<...User> IUserManager.get_Users()'."));
+
+        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.False(LetterboxdSyncRunner.IsRunning);
+    }
+
     [Fact]
     public async Task ExecuteAsync_UserHasNoAccount_SkippedSilently()
     {

--- a/LetterboxdSync.Tests/LetterboxdControllerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdControllerTests.cs
@@ -106,6 +106,96 @@ public class LetterboxdControllerTests
         Assert.Equal(0, Prop<int>(result, "offset"));
     }
 
+    // ----- GetJellyfinUsername (defensive paths, issue #46) -----
+    // Every reported 500 on /Stats and /History collapsed into this method's frame.
+    // The defensive fix returns null on every failure mode so the read endpoints
+    // degrade to unfiltered results instead of 500ing the dashboard.
+
+    [Fact]
+    public void GetJellyfinUsername_NoUserClaim_ReturnsNull()
+    {
+        using var h = new ControllerTestHarness(currentUserId: null);
+
+        Assert.Null(h.Controller.GetJellyfinUsername());
+    }
+
+    [Fact]
+    public void GetJellyfinUsername_ClaimWithNoMatchingUser_ReturnsNull()
+    {
+        // Claim is present, but _userManager.Users contains no row with that id.
+        // Pre-fix this path was already safe; we keep the test to lock the contract.
+        // ControllerTestHarness.SetUsers can't be used here: it substitutes User via
+        // NSubstitute, but Jellyfin.Database User has no parameterless ctor. The
+        // default mocked Users list is empty, which is exactly what this test wants.
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+
+        Assert.Null(h.Controller.GetJellyfinUsername());
+    }
+
+    [Fact]
+    public void GetJellyfinUsername_ClaimMatchesUser_ReturnsUsername()
+    {
+        // Construct a real User (NSubstitute can't proxy it). The User's Id is
+        // auto-generated, so we wire the controller's currentUserId from it
+        // rather than the other way around.
+        var realUser = new Jellyfin.Database.Implementations.Entities.User(
+            "lachlan", "test-provider-id", "test-reset-id");
+        var idHex = realUser.Id.ToString("N");
+
+        using var h = new ControllerTestHarness(currentUserId: idHex);
+        h.UserManager.Users.Returns(new[] { realUser });
+
+        Assert.Equal("lachlan", h.Controller.GetJellyfinUsername());
+    }
+
+    [Fact]
+    public void GetJellyfinUsername_UsersCollectionNull_ReturnsNullDoesNotThrow()
+    {
+        // Simulates a Jellyfin build / lifecycle state where IUserManager.Users
+        // returns null. Pre-fix this NRE'd inside FirstOrDefault and bubbled out
+        // as a 500.
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.UserManager.Users.Returns((System.Collections.Generic.IReadOnlyList<Jellyfin.Database.Implementations.Entities.User>?)null!);
+
+        Assert.Null(h.Controller.GetJellyfinUsername());
+    }
+
+    [Fact]
+    public void GetJellyfinUsername_UsersAccessorThrows_SwallowedAndReturnsNull()
+    {
+        // Simulates the suspected production failure: something inside the lookup
+        // throws (DI quirk, disposed manager, auth-context oddity). The endpoint
+        // must not 500.
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.UserManager.Users.Returns(_ => throw new InvalidOperationException("simulated"));
+
+        Assert.Null(h.Controller.GetJellyfinUsername());
+    }
+
+    [Fact]
+    public void GetStats_WhenUsernameResolutionThrows_StillReturns200()
+    {
+        // End-to-end through the public endpoint: the contract reported in issue #46
+        // is that /Stats returns 500. After the defensive fix it must return 200.
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.UserManager.Users.Returns(_ => throw new InvalidOperationException("simulated"));
+
+        var result = h.Controller.GetStats();
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetHistory_WhenUsernameResolutionThrows_StillReturns200()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.UserManager.Users.Returns(_ => throw new InvalidOperationException("simulated"));
+
+        var result = h.Controller.GetHistory();
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
     // ----- GetAccount -----
 
     [Fact]

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -94,6 +94,36 @@ public class LetterboxdSyncRunnerTests : IDisposable
         });
     }
 
+    // ----- Jellyfin 10.11.9 IUserManager.Users signature change (issue #46) -----
+    // Pre-fix: a direct _userManager.Users read on 10.11.9+ throws
+    // MissingMethodException and crashes the scheduled task. Post-fix: the
+    // reflection shim (UserManagerExtensions.GetAllUsers) swallows the throw
+    // and returns empty, so the runner completes with zero pairs to process.
+
+    [Fact]
+    public async Task RunForAllAsync_WhenUsersGetterThrows_CompletesWithoutCrash()
+    {
+        _userManager.Users.Returns(_ => throw new MissingMethodException(
+            "Method not found: 'System.Collections.Generic.IEnumerable`1<...User> IUserManager.get_Users()'."));
+        var progress = new Progress<double>();
+
+        // The exception must not propagate out of the scheduled-task entry point.
+        await _runner.RunForAllAsync(progress, "scheduled", CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_WhenUsersGetterThrows_ReturnsFalse()
+    {
+        _userManager.Users.Returns(_ => throw new MissingMethodException("simulated 10.11.9 ABI break"));
+
+        var ok = await _runner.TryRunForUserAsync("ffffffffffffffffffffffffffffffff",
+            "manual", new Progress<double>(), CancellationToken.None);
+
+        // Empty user list ⇒ user not found ⇒ false. Same outcome as
+        // TryRunForUserAsync_UnknownUser below, but exercised via the throw path.
+        Assert.False(ok);
+    }
+
     // ----- TryRunForUserAsync: pre-flight gates -----
 
     [Fact]

--- a/LetterboxdSync.Tests/UserManagerExtensionsTests.cs
+++ b/LetterboxdSync.Tests/UserManagerExtensionsTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Database.Implementations.Entities;
+using LetterboxdSync;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Regression coverage for <see cref="UserManagerExtensions.GetAllUsers"/>, the
+/// reflection shim that survives the Jellyfin 10.11.9 IUserManager.Users
+/// signature change reported in issue #46.
+/// </summary>
+public class UserManagerExtensionsTests
+{
+    [Fact]
+    public void GetAllUsers_NullUserManager_ReturnsEmpty()
+    {
+        IUserManager? userManager = null;
+
+        var users = userManager.GetAllUsers().ToList();
+
+        Assert.Empty(users);
+    }
+
+    [Fact]
+    public void GetAllUsers_UsersReturnsList_ReturnsSameUsers()
+    {
+        // Happy path against the IEnumerable<User> signature we compile against.
+        // Construct real User entities (NSubstitute can't proxy User, no
+        // parameterless ctor) and stub Users with them.
+        var u1 = new User("alice", "test-provider-id", "test-reset-id");
+        var u2 = new User("bob", "test-provider-id", "test-reset-id");
+        var userManager = Substitute.For<IUserManager>();
+        userManager.Users.Returns(new[] { u1, u2 });
+
+        var result = userManager.GetAllUsers().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, u => u.Username == "alice");
+        Assert.Contains(result, u => u.Username == "bob");
+    }
+
+    [Fact]
+    public void GetAllUsers_UsersGetterThrows_SwallowsAndReturnsEmpty()
+    {
+        // Models the production failure mode reported in #46: the property's
+        // getter throws (MissingMethodException on Jellyfin 10.11.9+ when the
+        // plugin is compiled against 10.11.0). The shim catches and falls back
+        // to empty, so callers don't 500 / crash scheduled tasks.
+        var userManager = Substitute.For<IUserManager>();
+        userManager.Users.Returns(_ => throw new MissingMethodException(
+            "Method not found: 'System.Collections.Generic.IEnumerable`1<...User> IUserManager.get_Users()'."));
+
+        var users = userManager.GetAllUsers().ToList();
+
+        Assert.Empty(users);
+    }
+
+    [Fact]
+    public void GetAllUsers_UsersReturnsEmptyEnumeration_ReturnsEmpty()
+    {
+        // No users configured on the Jellyfin server: shim returns the same
+        // empty enumeration rather than null or anything else surprising.
+        var userManager = Substitute.For<IUserManager>();
+        userManager.Users.Returns(Array.Empty<User>());
+
+        var users = userManager.GetAllUsers().ToList();
+
+        Assert.Empty(users);
+    }
+
+    [Fact]
+    public void GetAllUsers_CrossSignatureCompatibility_ReadOnlyListCastSucceeds()
+    {
+        // Proves the cast-to-IEnumerable<User> in the shim accepts an
+        // IReadOnlyList<User>, which is what IUserManager.Users returns from
+        // Jellyfin 10.11.9 onward. We can't change the static signature of
+        // IUserManager.Users in this test (it's IEnumerable<User> in the SDK
+        // we compile against), but we can prove the underlying type system
+        // contract: the value the shim's reflection call would receive on a
+        // 10.11.9+ host (an IReadOnlyList<User>) is assignable to the
+        // IEnumerable<User> we cast to.
+        IReadOnlyList<User> newSignatureValue = new List<User>
+        {
+            new User("alice", "test-provider-id", "test-reset-id")
+        };
+
+        // Mirror the cast UserManagerExtensions.GetAllUsers performs.
+        var asEnumerable = newSignatureValue as IEnumerable<User>;
+
+        Assert.NotNull(asEnumerable);
+        Assert.Single(asEnumerable!);
+    }
+}

--- a/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
@@ -88,6 +88,34 @@ public class WatchlistSyncRunnerTests : IDisposable
         });
     }
 
+    // ----- Jellyfin 10.11.9 IUserManager.Users signature change (issue #46) -----
+    // The scheduled task entry point (RunForAllAsync) and the manual one
+    // (TryRunForUserAsync) must both survive _userManager.Users throwing
+    // MissingMethodException, because that's the production failure mode
+    // on 10.11.9+ when the plugin is compiled against the 10.11.0 SDK.
+
+    [Fact]
+    public async Task RunForAllAsync_WhenUsersGetterThrows_CompletesWithoutCrash()
+    {
+        _userManager.Users.Returns(_ => throw new MissingMethodException(
+            "Method not found: 'System.Collections.Generic.IEnumerable`1<...User> IUserManager.get_Users()'."));
+
+        // Exception must not propagate; scheduled task would otherwise fail with
+        // "Sync Letterboxd watchlist to playlist Failed after 0 minute(s)" in the log.
+        await _runner.RunForAllAsync(new Progress<double>(), "scheduled", CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_WhenUsersGetterThrows_ReturnsFalse()
+    {
+        _userManager.Users.Returns(_ => throw new MissingMethodException("simulated 10.11.9 ABI break"));
+
+        var ok = await _runner.TryRunForUserAsync("ffffffffffffffffffffffffffffffff",
+            "manual", new Progress<double>(), CancellationToken.None);
+
+        Assert.False(ok);
+    }
+
     // ----- Pre-flight gates -----
 
     [Fact]

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -55,15 +55,35 @@ public class LetterboxdController : ControllerBase
     private string? GetCurrentUserId()
         => User.Claims.FirstOrDefault(c => c.Type == "Jellyfin-UserId")?.Value?.Replace("-", "");
 
-    private string? GetJellyfinUsername()
+    // internal (not private) so unit tests in LetterboxdSync.Tests can exercise the
+    // defensive paths directly. See InternalsVisibleTo in the csproj.
+    internal string? GetJellyfinUsername()
     {
-        var userId = GetCurrentUserId();
-        if (string.IsNullOrEmpty(userId)) return null;
+        // Defensive: every reported 500 on /Stats and /History (issue #46) collapsed
+        // into this method's frame. Without the exception type/message we cannot
+        // pin the root cause, but the read endpoints don't need a username to work
+        // (SyncHistory.GetStats/GetPage treat a null username as "no filter"), so
+        // failing closed to null is strictly better than 500ing the dashboard.
+        try
+        {
+            if (User is null || _userManager is null) return null;
 
-        // Resolve Jellyfin user ID to username for SyncHistory filtering
-        // SyncHistory stores the Jellyfin username (e.g. "lachlan"), not the Letterboxd username
-        var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userId);
-        return user?.Username;
+            var userId = GetCurrentUserId();
+            if (string.IsNullOrEmpty(userId)) return null;
+
+            // Resolve Jellyfin user ID to username for SyncHistory filtering.
+            // SyncHistory stores the Jellyfin username (e.g. "lachlan"), not the Letterboxd username.
+            var users = _userManager.Users;
+            if (users is null) return null;
+
+            var user = users.FirstOrDefault(u => u.Id.ToString("N") == userId);
+            return user?.Username;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetJellyfinUsername failed; returning null (history/stats will be unfiltered)");
+            return null;
+        }
     }
 
     [HttpGet("Progress")]

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -59,28 +59,25 @@ public class LetterboxdController : ControllerBase
     // defensive paths directly. See InternalsVisibleTo in the csproj.
     internal string? GetJellyfinUsername()
     {
-        // Defensive: every reported 500 on /Stats and /History (issue #46) collapsed
-        // into this method's frame. Without the exception type/message we cannot
-        // pin the root cause, but the read endpoints don't need a username to work
-        // (SyncHistory.GetStats/GetPage treat a null username as "no filter"), so
-        // failing closed to null is strictly better than 500ing the dashboard.
+        // Resolution goes through UserManagerExtensions.GetAllUsers (reflection-
+        // based) because Jellyfin 10.11.9 changed IUserManager.Users's return type
+        // and a direct binding throws MissingMethodException on that and later
+        // patches. See UserManagerExtensions and issue #46.
         try
         {
-            if (User is null || _userManager is null) return null;
-
+            if (User is null) return null;
             var userId = GetCurrentUserId();
             if (string.IsNullOrEmpty(userId)) return null;
 
-            // Resolve Jellyfin user ID to username for SyncHistory filtering.
             // SyncHistory stores the Jellyfin username (e.g. "lachlan"), not the Letterboxd username.
-            var users = _userManager.Users;
-            if (users is null) return null;
-
-            var user = users.FirstOrDefault(u => u.Id.ToString("N") == userId);
+            var user = _userManager.GetAllUsers().FirstOrDefault(u => u.Id.ToString("N") == userId);
             return user?.Username;
         }
         catch (Exception ex)
         {
+            // Fail closed: SyncHistory.GetStats/GetPage treat a null username as
+            // "no filter", so the dashboard degrades to unfiltered results rather
+            // than 500. The log line gives us the exception type for diagnostics.
             _logger.LogWarning(ex, "GetJellyfinUsername failed; returning null (history/stats will be unfiltered)");
             return null;
         }
@@ -654,7 +651,7 @@ public class LetterboxdController : ControllerBase
         if (!jellyfinRating.HasValue)
             return;
 
-        var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userId);
+        var user = _userManager.GetAllUsers().FirstOrDefault(u => u.Id.ToString("N") == userId);
         if (user == null)
             return;
 

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -41,7 +41,7 @@ public class DiaryImportTask : IScheduledTask
 
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var users = _userManager.Users.ToList();
+        var users = _userManager.GetAllUsers().ToList();
 
         foreach (var user in users)
         {

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -56,7 +56,7 @@ public class LetterboxdSyncRunner
         {
             // Fan out across every (user, account) pair. Each account's sync is
             // independent so one failing or rate-limited account never blocks the others.
-            var pairs = _userManager.Users
+            var pairs = _userManager.GetAllUsers()
                 .SelectMany(u => Config.GetEnabledAccountsForUser(u.Id.ToString("N"))
                     .Select(a => (User: u, Account: a)))
                 .ToList();
@@ -100,7 +100,7 @@ public class LetterboxdSyncRunner
 
         try
         {
-            var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
+            var user = _userManager.GetAllUsers().FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
             if (user == null)
             {
                 _logger.LogWarning("User {UserId} not found, cannot start sync", userJellyfinId);

--- a/LetterboxdSync/UserManagerExtensions.cs
+++ b/LetterboxdSync/UserManagerExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+
+namespace LetterboxdSync;
+
+/// <summary>
+/// Shim around <see cref="IUserManager.Users"/> that survives signature changes
+/// across Jellyfin patch releases.
+///
+/// In 10.11.9 Jellyfin changed the property's return type from
+/// <c>IEnumerable&lt;User&gt;</c> to <c>IReadOnlyList&lt;User&gt;</c>. A plugin
+/// compiled against the 10.11.0 SDK embeds a metadata reference to the old
+/// getter, and the runtime throws <c>System.MissingMethodException</c> on
+/// 10.11.9+ because that exact signature no longer exists. Bumping the SDK
+/// just flips the breakage to the inverse direction (older servers stop
+/// working). Reflecting the property at call time and casting the result to
+/// the common base interface lets a single build target every 10.11.x patch.
+///
+/// Reported in issue #46. Replaces every direct <c>_userManager.Users</c> read
+/// in the plugin.
+/// </summary>
+internal static class UserManagerExtensions
+{
+    public static IEnumerable<User> GetAllUsers(this IUserManager? userManager)
+    {
+        if (userManager is null) return Array.Empty<User>();
+
+        try
+        {
+            var prop = userManager.GetType().GetProperty(
+                "Users",
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            if (prop is null) return Array.Empty<User>();
+
+            // Both old (IEnumerable<User>) and new (IReadOnlyList<User>) types
+            // are assignable to IEnumerable<User>, so a single cast handles both.
+            return prop.GetValue(userManager) as IEnumerable<User> ?? Array.Empty<User>();
+        }
+        catch
+        {
+            // Fail closed: callers degrade to "no users" rather than 500.
+            return Array.Empty<User>();
+        }
+    }
+}

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -53,7 +53,7 @@ public class WatchlistSyncRunner
         {
             using var jellyseerr = CreateJellyseerrClient();
 
-            var pairs = _userManager.Users
+            var pairs = _userManager.GetAllUsers()
                 .SelectMany(u => Config.GetEnabledAccountsForUser(u.Id.ToString("N"))
                     .Where(a => a.EnableWatchlistSync)
                     .Select(a => (User: u, Account: a)))
@@ -101,7 +101,7 @@ public class WatchlistSyncRunner
 
         try
         {
-            var user = _userManager.Users.FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
+            var user = _userManager.GetAllUsers().FirstOrDefault(u => u.Id.ToString("N") == userJellyfinId);
             if (user == null)
             {
                 _logger.LogWarning("User {UserId} not found, cannot start watchlist sync", userJellyfinId);


### PR DESCRIPTION
## Summary

Issue #46 root-caused. New comments from @bigrichwood revealed the actual exception:

```
System.MissingMethodException: Method not found:
'System.Collections.Generic.IEnumerable<...User> MediaBrowser.Controller.Library.IUserManager.get_Users()'.
```

Jellyfin changed `IUserManager.Users`'s return type between 10.11.8 and 10.11.9 (most likely `IEnumerable<User>` → `IReadOnlyList<User>`). The plugin is compiled against `Jellyfin.Controller` 10.11.0, so it embeds a binding for the old getter signature. On 10.11.9+ that exact method doesn't exist, so the runtime throws `MissingMethodException` on every read.

The throw hits 7 call sites in 4 files. Symptoms users see: dashboard `/Stats` and `/History` 500, `Sync watched movies to Letterboxd` scheduled task fails immediately, `Sync Letterboxd watchlist to playlist` scheduled task fails immediately, manual `Run Sync Now` / `Run Watchlist Now` both 500.

## Fix

Bumping the SDK is not an option: it would flip the breakage to the inverse direction (10.11.0–10.11.8 users, including my own 10.11.8 server, would 500 with the same error). Instead, this PR adds a tiny reflection shim that reads `IUserManager.Users` via `PropertyInfo.GetValue` and casts the result to the common base interface `IEnumerable<User>`. Both old (`IEnumerable<User>`) and new (`IReadOnlyList<User>`) signatures satisfy that cast, so one build covers every 10.11.x patch.

- **`LetterboxdSync/UserManagerExtensions.cs`** (new): `GetAllUsers(this IUserManager?)` extension, fails closed to `Array.Empty<User>()` on null / missing property / throw.
- **All 7 `_userManager.Users` call sites replaced** across `LetterboxdController.cs`, `DiaryImportTask.cs`, `WatchlistSyncRunner.cs`, `LetterboxdSyncRunner.cs`.
- **`GetJellyfinUsername` from the first commit** kept its try/catch + null-User guard (belt-and-braces for unrelated auth-context edge cases) but now resolves the user list through the shim.

## Tests

482/482 unit tests pass locally. New tests:

| File | Test | What it pins |
|---|---|---|
| `UserManagerExtensionsTests.cs` (new) | `NullUserManager_ReturnsEmpty` | Null input is safe |
| | `UsersReturnsList_ReturnsSameUsers` | Happy path, old signature |
| | `UsersGetterThrows_SwallowsAndReturnsEmpty` | The exact #46 production failure: getter throws `MissingMethodException` → empty, no propagation |
| | `UsersReturnsEmptyEnumeration_ReturnsEmpty` | Zero-user server is safe |
| | `CrossSignatureCompatibility_ReadOnlyListCastSucceeds` | Locks in the type-system contract: `IReadOnlyList<User>` (the 10.11.9+ runtime type) is assignable to `IEnumerable<User>` (what the shim casts to) |
| `LetterboxdControllerTests.cs` (from commit 1) | 7 defensive-path tests | Dashboard endpoints return 200 instead of 500 across every failure mode of `GetJellyfinUsername` |

## Verification

- 482/482 unit tests pass
- I did not sideload the locally-built DLL onto my running Jellyfin server to verify; awaiting either CI green + merge or explicit go-ahead to deploy to my 10.11.8 box for a regression check before release. (My server is 10.11.8 where the bug doesn't manifest, so testing it confirms only "we didn't break the happy path", not "we fixed the 10.11.9 path". The latter has to wait for reporters retrying on v1.12.1.)

## Release plan after merge

1. Cut v1.12.1 with this fix
2. Comment on #46 asking bigrichwood to update to 1.12.1 from the plugin catalog and confirm the dashboard and the scheduled tasks both recover

## Test plan
- [x] `dotnet test -c Release --filter "Category!=Integration"` passes locally (482/482)
- [x] CI green on this PR
- [ ] (Post-release) @bigrichwood confirms dashboard + sync tasks work on 10.11.9 / 10.11.10