### PR TITLE
ci: enforce version bump on every PR, auto-release on merge, rebuild site on release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,16 @@ on:
       - 'manifest.json'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
+  # Auto-deploy after every successful Release. The Release workflow's
+  # manifest auto-commit is authenticated with GITHUB_TOKEN, which
+  # deliberately does NOT trigger other workflows (anti-loop safety). Without
+  # this trigger the site would stay stale on every plugin release. See the
+  # post-v1.12.0 / v1.13.0 incident: the site was missing two releases until
+  # this was added.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -20,6 +30,9 @@ concurrency:
 
 jobs:
   build:
+    # When triggered by Release completion, only deploy if Release succeeded.
+    # For other triggers (push, workflow_dispatch) always run.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+# PR titles must follow Conventional Commits so that the squash-merge commit
+# subject (which becomes the GitHub Release body and the changelog text in
+# manifest.json) is consistently formatted. Breaking changes are not signalled
+# via "!" suffix; the version-bump magnitude carries that signal (major bump
+# = breaking).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            test
+            perf
+            build
+            style
+          requireScope: false
+          subjectPattern: ^.{4,}$
+          subjectPatternError: |
+            The PR title subject after the type prefix is too short. Use something descriptive (4+ characters), e.g. `fix(plugin): handle null user list` or `docs: explain release pipeline`.
+          # We intentionally do NOT allow "!" for breaking changes. The
+          # version-bump magnitude (major/minor/patch) is the canonical signal.
+          disallowScopes: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,108 +1,128 @@
 name: Release
 
+# Fires on every push to main. If Directory.Build.props's AssemblyVersion
+# already has a matching git tag, the workflow exits cleanly (idempotent, so
+# our own auto-commit re-triggering this workflow is a harmless no-op). If
+# there's no tag, it builds, tests, packages, creates the GitHub Release,
+# inserts the manifest entry (using targetAbi.txt for the floor), and pushes
+# the auto-commit + tag together.
+#
+# Version bumps happen in regular PRs (gated by version-gate.yml). This
+# workflow doesn't decide the version; it just ships whatever the project
+# files say. That keeps the dev experience simple: bump version in your PR,
+# write a Conventional-Commits title, merge, done.
+
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+
+permissions:
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
-      - name: Checkout main
-        # Check out main directly (not the tag's detached HEAD) so the
-        # manifest commit at the end of this job lands on main cleanly.
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 0
 
-      - name: Resolve version from tag
+      - name: Read project version
         id: version
         run: |
           set -e
-          TAG="${{ github.ref_name }}"
-          VERSION="${TAG#v}"
-          ASSEMBLY="${VERSION}.0"
-          echo "tag=$TAG"           >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION"   >> "$GITHUB_OUTPUT"
+          ASSEMBLY=$(grep -oE '<AssemblyVersion>[^<]+' Directory.Build.props | head -1 | sed 's/<AssemblyVersion>//')
+          if [ -z "$ASSEMBLY" ]; then
+            echo "::error::Could not read AssemblyVersion from Directory.Build.props"
+            exit 1
+          fi
+          # Tag is vX.Y.Z (strip the trailing .0 from the 4-part AssemblyVersion)
+          TAG="v$(echo "$ASSEMBLY" | sed -E 's/\.0$//')"
           echo "assembly=$ASSEMBLY" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"           >> "$GITHUB_OUTPUT"
+          echo "AssemblyVersion: $ASSEMBLY"
+          echo "Tag: $TAG"
 
-      - name: Verify project version matches tag
-        # If the dev tags without bumping Directory.Build.props/csproj the
-        # built DLL's AssemblyVersion won't match the manifest entry we're
-        # about to write, and Jellyfin will refuse to load it. Fail loud.
-        run: |
-          set -e
-          ASSEMBLY="${{ steps.version.outputs.assembly }}"
-          PROJ=$(grep -oE '<AssemblyVersion>[^<]+' Directory.Build.props | head -1 | sed 's/<AssemblyVersion>//')
-          if [ "$PROJ" != "$ASSEMBLY" ]; then
-            echo "::error::Directory.Build.props AssemblyVersion ($PROJ) does not match tag (${ASSEMBLY}). Bump versions on main before tagging."
-            exit 1
-          fi
-          CSPROJ=$(grep -oE '<AssemblyVersion>[^<]+' LetterboxdSync/LetterboxdSync.csproj | head -1 | sed 's/<AssemblyVersion>//')
-          if [ "$CSPROJ" != "$ASSEMBLY" ]; then
-            echo "::error::LetterboxdSync.csproj AssemblyVersion ($CSPROJ) does not match tag (${ASSEMBLY})."
-            exit 1
-          fi
-
-      - name: Read changelog from tag annotation
-        # Annotated tag message becomes the user-facing changelog text in
-        # both the GitHub release body and the manifest entry. Lightweight
-        # tags (no annotation) are rejected — the changelog is required.
+      - name: Skip if tag already exists
+        id: check
         run: |
           set -e
           TAG="${{ steps.version.outputs.tag }}"
-          MSG=$(git tag -l --format='%(contents)' "$TAG")
-          # Strip any trailing PGP signature block
-          MSG=$(printf '%s' "$MSG" | sed '/^-----BEGIN PGP SIGNATURE-----/,$d')
-          MSG=$(printf '%s' "$MSG" | sed -e 's/[[:space:]]*$//')
-          if [ "${#MSG}" -lt 20 ]; then
-            echo "::error::Tag $TAG must be an annotated tag with a changelog message of at least 20 chars. Use: git tag -a $TAG -F release-notes.md && git push origin $TAG"
+          # Look at remote tags too, so a tag pushed by a previous run of this
+          # workflow (race-y rerun, manual push) short-circuits us cleanly.
+          if git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1 \
+             || git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify csproj matches Directory.Build.props
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          set -e
+          ASSEMBLY="${{ steps.version.outputs.assembly }}"
+          CSPROJ=$(grep -oE '<AssemblyVersion>[^<]+' LetterboxdSync/LetterboxdSync.csproj | head -1 | sed 's/<AssemblyVersion>//')
+          if [ "$CSPROJ" != "$ASSEMBLY" ]; then
+            echo "::error::LetterboxdSync.csproj AssemblyVersion ($CSPROJ) does not match Directory.Build.props ($ASSEMBLY). version-gate.yml should have caught this on the PR."
             exit 1
           fi
-          printf '%s' "$MSG" > /tmp/changelog.txt
-          echo "Changelog (${#MSG} chars):"
-          head -c 400 /tmp/changelog.txt; echo
+
+      - name: Capture release body
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          # HEAD is the squash-merge commit on main; subject is the PR title
+          # (Conventional Commits), body is whatever was included on merge.
+          git log -1 --format='%B' HEAD > /tmp/release-body.txt
+          echo "--- release body preview ---"
+          head -c 500 /tmp/release-body.txt
+          echo
 
       - name: Setup .NET
+        if: steps.check.outputs.skip == 'false'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 
       - name: Restore
+        if: steps.check.outputs.skip == 'false'
         run: dotnet restore
 
       - name: Build
+        if: steps.check.outputs.skip == 'false'
         run: dotnet build -c Release --no-restore
 
       - name: Test
+        if: steps.check.outputs.skip == 'false'
         run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=Integration"
 
       - name: Package
+        if: steps.check.outputs.skip == 'false'
         run: |
           cd LetterboxdSync/bin/Release/net9.0
           zip -j /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip LetterboxdSync.dll HtmlAgilityPack.dll
 
       - name: Compute checksum
+        if: steps.check.outputs.skip == 'false'
         id: cs
         run: |
           CS=$(md5sum /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip | awk '{print $1}')
           echo "checksum=$CS" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
+        if: steps.check.outputs.skip == 'false'
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
           files: /tmp/jellyfin-plugin-letterboxd-${{ steps.version.outputs.tag }}.zip
-          body_path: /tmp/changelog.txt
+          body_path: /tmp/release-body.txt
 
       - name: Insert manifest entry
-        # Manifest is CI-managed: the only writer is this step, after the
-        # release artifact actually exists. Idempotent on re-run (updates
-        # in place if the version already exists in the manifest).
+        # Manifest is CI-managed: only release.yml writes to it. Idempotent on
+        # re-run (updates existing entry in place if present).
+        if: steps.check.outputs.skip == 'false'
         run: |
           set -e
           ASSEMBLY="${{ steps.version.outputs.assembly }}"
@@ -110,20 +130,13 @@ jobs:
           CS="${{ steps.cs.outputs.checksum }}"
           URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/jellyfin-plugin-letterboxd-${TAG}.zip"
           TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          # targetAbi is the minimum Jellyfin version the plugin supports.
-          # Source of truth is targetAbi.txt in the repo root, bumped whenever
-          # the dev's Jellyfin.Controller / Jellyfin.Model PackageReference is
-          # raised to a version that introduced ABI changes the plugin now
-          # depends on (e.g. 10.11.9 turned IUserManager.Users into GetUsers).
-          # Fallback to the previous entry's value keeps re-runs idempotent
-          # for releases predating the file.
           if [ -f targetAbi.txt ]; then
             ABI=$(tr -d '[:space:]' < targetAbi.txt)
           else
             ABI=$(jq -r '.[0].versions[0].targetAbi // "10.11.0.0"' manifest.json)
           fi
           echo "targetAbi for this release: $ABI"
-          CHANGELOG=$(cat /tmp/changelog.txt)
+          CHANGELOG=$(cat /tmp/release-body.txt)
 
           if jq -e --arg v "$ASSEMBLY" '.[0].versions | any(.version == $v)' manifest.json > /dev/null; then
             echo "Updating existing $ASSEMBLY entry in place"
@@ -146,6 +159,7 @@ jobs:
           mv manifest.tmp manifest.json
 
       - name: Commit manifest update
+        if: steps.check.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -1,0 +1,52 @@
+name: Version Gate
+
+# Every PR to main must bump Directory.Build.props's AssemblyVersion. Without
+# this gate, a PR could land on main without a corresponding release (the
+# Release workflow short-circuits when a tag for the current version already
+# exists), leaving the change un-shipped and users unaware. Patch-level bumps
+# are fine for docs / CI / refactor changes; magnitude is a human judgement
+# call, the gate only enforces "something changed".
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compare versions
+        run: |
+          set -e
+          extract() {
+            grep -oE '<AssemblyVersion>[^<]+' "$1" | head -1 | sed 's/<AssemblyVersion>//'
+          }
+          PR_V=$(extract Directory.Build.props)
+          MAIN_V=$(git show origin/main:Directory.Build.props | grep -oE '<AssemblyVersion>[^<]+' | head -1 | sed 's/<AssemblyVersion>//')
+          echo "PR  Directory.Build.props AssemblyVersion: $PR_V"
+          echo "main Directory.Build.props AssemblyVersion: $MAIN_V"
+
+          if [ -z "$PR_V" ] || [ -z "$MAIN_V" ]; then
+            echo "::error::Could not read AssemblyVersion from one of the files."
+            exit 1
+          fi
+
+          if [ "$PR_V" = "$MAIN_V" ]; then
+            echo "::error::Version was not bumped (still $PR_V). Bump AssemblyVersion/FileVersion in Directory.Build.props and LetterboxdSync/LetterboxdSync.csproj before merging. Patch bumps (e.g. 1.13.0.0 -> 1.13.1.0) are fine for docs/CI changes."
+            exit 1
+          fi
+
+          # Also verify both files agree, so the Release workflow won't fail
+          # later for a reason that's easier to catch here.
+          CSPROJ_V=$(extract LetterboxdSync/LetterboxdSync.csproj)
+          if [ "$CSPROJ_V" != "$PR_V" ]; then
+            echo "::error::LetterboxdSync.csproj AssemblyVersion ($CSPROJ_V) does not match Directory.Build.props ($PR_V). Bump both together."
+            exit 1
+          fi
+
+          echo "Version bump OK: $MAIN_V -> $PR_V"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@ obj/
 release/
 .gstack/
 
+# Editor / agent scratch directories that get auto-generated alongside the
+# project; never useful in version control.
+.baselines/
+.claude/
+.cursor/
+TestResults/
+
+# Old manual-release artifact; the new release.yml uses the squash-merge
+# commit message instead of a release-notes file.
+release-notes.md
+
 # Local-only secrets for integration tests. The integration test suite reads
 # Letterboxd credentials from environment variables; never commit them.
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,25 +54,29 @@ Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `Letterb
 
 ## Releasing
 
-`manifest.json` is **CI-managed**. `release.yml` is the only writer. Do not pre-add `PLACEHOLDER` entries by hand; `ci.yml` will refuse the PR. Past incident: a v1.12.0.0 manifest entry was merged to main without the tag ever being pushed, leaving the manifest advertising a release whose ZIP did not exist (404 on install for every user). The workflow now inserts the manifest entry only after the build succeeds, so that state is unreachable.
+**Every merge to `main` ships a release.** No manual tag pushes, no release-notes files. The pipeline is:
 
-Steps:
+1. Open a PR. The PR must:
+   - Have a **Conventional Commits** title (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`). Enforced by `pr-title.yml`.
+   - **Bump `AssemblyVersion` / `FileVersion`** in both `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`. Patch bumps (e.g. `1.13.0.0` → `1.13.1.0`) are fine for docs / CI / refactor changes; every PR ships. Enforced by `version-gate.yml`.
+   - If the `Jellyfin.Controller` / `Jellyfin.Model` PackageReference is bumped and the new SDK introduces an ABI break the plugin now depends on, also bump `targetAbi.txt` to the minimum Jellyfin version that has the new ABI. This is the floor Jellyfin's plugin catalog uses to gate the release.
 
-1. Bump versions on `main`:
-   - `Directory.Build.props`, set `<Version>` / `<AssemblyVersion>` / `<FileVersion>`
-   - `LetterboxdSync/LetterboxdSync.csproj`, set `<AssemblyVersion>` / `<FileVersion>`
-   - If the `Jellyfin.Controller` / `Jellyfin.Model` PackageReference is bumped and the new SDK introduces an ABI break the plugin now depends on, also bump `targetAbi.txt` to the minimum Jellyfin version that has the new ABI. This is the floor Jellyfin's plugin catalog uses to gate the release: users below it stay on the previous plugin version. Past incident (v1.13.0): Jellyfin 10.11.9 removed `IUserManager.Users` (replaced by `GetUsers()`), so v1.13.0 bumped the SDK to 10.11.10 and `targetAbi.txt` to `10.11.9.0`.
-2. Write the user-facing changelog into `release-notes.md` (or pass `-m` inline). The release workflow uses this verbatim for both the GitHub release body and the `changelog` field in `manifest.json`.
-3. Create an **annotated** tag and push it:
+2. Merge with **Squash and merge**. The PR title becomes the squash commit subject, which becomes the GitHub Release body and the `changelog` field in `manifest.json`.
 
-   ```bash
-   git tag -a vX.Y.Z -F release-notes.md
-   git push origin vX.Y.Z
-   ```
+3. `release.yml` fires automatically on the push to `main`. It reads `AssemblyVersion` from `Directory.Build.props`, checks no tag for that version exists yet (idempotent), builds + tests, packages, creates the GitHub Release, inserts the manifest entry using `targetAbi.txt`, and pushes the auto-commit + tag together.
 
-   Lightweight tags (no annotation) are rejected by the workflow.
+4. `deploy-docs.yml` fires via `workflow_run` on Release completion, rebuilding letterboxdsync.dev with the fresh manifest. (The `GITHUB_TOKEN`-authenticated auto-commit can't fire push-based workflows, hence the explicit `workflow_run` trigger.)
 
-`release.yml` then verifies the tag matches the project's `AssemblyVersion`, builds + tests, packages the ZIP, creates the GitHub release, and inserts a new entry into `manifest.json` on `main` with the real md5 checksum, the release `sourceUrl`, and the tag annotation as the changelog. Re-running the workflow on the same tag is idempotent (updates the entry in place).
+### Breaking changes
+
+The version-bump magnitude is the canonical signal, not a `!` in the PR title. Going `1.x.y` → `2.0.0` means breaking; we do not use `feat!:` / `fix!:`.
+
+### Past incidents this pipeline prevents
+
+- **v1.12.0.0** manifest entry was merged to main with `"checksum": "PLACEHOLDER"` and no tag ever got pushed, leaving the manifest advertising a 404'ing release for every user. `release.yml` is now the *only* writer of `manifest.json`, and `ci.yml`'s manifest validator refuses any PR that touches it with a `PLACEHOLDER` or 404 `sourceUrl`.
+- **v1.13.0** was cut manually after the merge, which works but doesn't enforce that *every* merge ships. The version-gate now guarantees a release on every merge.
+- **v1.12.0 and v1.13.0 site staleness**: the manifest auto-commit didn't trigger Deploy site (GitHub token limitation). The `workflow_run` trigger now fires Deploy site after every Release.
+- **v1.13.0 SDK ABI break**: Jellyfin 10.11.9 removed `IUserManager.Users` (replaced by `GetUsers()`), so v1.13.0 bumped the SDK to 10.11.10 and `targetAbi.txt` to `10.11.9.0`. See `feedback_jellyfin_plugin_abi_break` in the user's memory.
 
 ## OpenSpec
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.13.0.0</Version>
-        <AssemblyVersion>1.13.0.0</AssemblyVersion>
-        <FileVersion>1.13.0.0</FileVersion>
+        <Version>1.13.1.0</Version>
+        <AssemblyVersion>1.13.1.0</AssemblyVersion>
+        <FileVersion>1.13.1.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
-    <FileVersion>1.13.0.0</FileVersion>
+    <AssemblyVersion>1.13.1.0</AssemblyVersion>
+    <FileVersion>1.13.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Hardens the release pipeline against the two failures we just hit:

1. **v1.13.0 did not ship automatically on merge.** PR #49 merged to main, but the release only happened because I manually tagged + pushed afterwards. If I'd forgotten, main and the catalog would have drifted apart silently. Every merge should ship.
2. **letterboxdsync.dev was stale for v1.12.0 *and* v1.13.0.** The `release.yml` auto-commit to `manifest.json` is authenticated with the default `GITHUB_TOKEN`, which deliberately does not fire other workflows (anti-loop safety). So Deploy site's `on: push` trigger never woke up. Users had no idea two releases had shipped.

## The new system

### Required PR checks
- **`.github/workflows/version-gate.yml`**: fails if `Directory.Build.props`'s `AssemblyVersion` on the PR equals main's. Patch bumps (e.g. `1.13.0.0` → `1.13.1.0`) are fine for docs/CI changes — every PR ships, magnitude is your call.
- **`.github/workflows/pr-title.yml`**: enforces Conventional Commits PR titles via `amannn/action-semantic-pull-request@v5`. Allowed types: `feat`, `fix`, `chore`, `docs`, `ci`, `refactor`, `test`, `perf`, `build`, `style`. **No `!` for breaking changes** — the version-bump magnitude is the canonical breaking signal (going `1.x` → `2.0` = breaking, you decide that, not the title).

These two together guarantee that every PR landed on main produces a versioned release whose changelog text reads like English.

### Release on every push to main
- **`.github/workflows/release.yml` rewritten** to trigger on `push: branches: [main]` (was: `push: tags: ['v*']`).
- Reads `AssemblyVersion` from `Directory.Build.props`. If a tag for that version already exists (locally or on origin), exits cleanly. This makes the workflow idempotent: its own auto-commit re-triggers the workflow, the rerun sees the tag exists and exits as a no-op.
- Verifies csproj matches Directory.Build.props.
- Builds, tests (`Category!=Integration`), packages the ZIP.
- Creates the GitHub Release using the squash-merge commit message as the body (`git log -1 --format='%B' HEAD`). PR titles → Conventional Commits → readable release notes.
- Inserts the manifest entry using `targetAbi.txt` for the floor (same as before).
- Pushes the auto-commit + tag together at the end.
- **No more manual `git tag -a vX.Y.Z` step.** No more `release-notes.md` file (the squash commit is the source of truth).

### Site rebuilds after every release
- **`.github/workflows/deploy-docs.yml`** gains a `workflow_run` trigger on the Release workflow completing successfully. The existing `push` trigger stays in place for direct site/manifest edits by humans. Gated on `github.event.workflow_run.conclusion == 'success'` so a failed release doesn't deploy a half-baked site.

### Documentation
- **`CLAUDE.md`** Releasing section rewritten to one short flow: bump version in your PR, Conventional Commits title, merge, done. The three past incidents (manifest PLACEHOLDER, manual tag drift, site staleness) are listed with the protections that now prevent each.

### Hygiene
- `.gitignore` picks up the scratch dirs that leak into `git status` (`.baselines/`, `.claude/`, `.cursor/`, `TestResults/`) plus the now-obsolete `release-notes.md`.

## What ships as v1.13.1

This PR itself: `Directory.Build.props` and `LetterboxdSync.csproj` bumped to `1.13.1.0`. The "version bump on every PR" rule is self-enforcing: this PR ships v1.13.1 (the systems-work patch) the moment it merges.

## Bootstrap detail

GitHub uses the *base branch's* workflow definitions for PR-triggered runs (security: prevents PRs from injecting arbitrary CI). So `version-gate.yml` and `pr-title.yml` won't run on this PR (they don't exist on main yet). They'll start enforcing on the next PR opened after this one merges.

The new `release.yml` *will* fire on this PR's merge, because `push: branches: [main]` reads the workflow file from the just-pushed commit (main). It'll see `AssemblyVersion = 1.13.1.0`, no tag yet, build + release + manifest-insert + tag-push + `workflow_run` triggers Deploy site. **Net result: the staleness fixes itself as part of the merge.** letterboxdsync.dev will show v1.12.0, v1.13.0, and v1.13.1 once this lands.

## Test plan
- [x] `dotnet build -c Release` clean
- [x] `dotnet test --filter "Category!=Integration"`: 470/470
- [x] All 6 workflow files parse as YAML
- [ ] CI green on this PR
- [ ] After merge: Release workflow auto-fires, v1.13.1 GitHub Release published, manifest auto-commit lands, Deploy site fires via workflow_run, letterboxdsync.dev shows all three recent versions