### PR TITLE
docs: backfill v1.13.0/v1.13.1 changelogs, source release notes from PR body

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,22 @@
 <!-- Ticket link, e.g. Closes #123. If there isn't one, write "No linked issue." -->
 
+## Release notes
+
+<!--
+The user-facing prose for this release.
+
+Everything between this H2 and the next H2 lands verbatim in manifest.json's
+changelog field and as the GitHub Release body. Write one paragraph, present-
+tense, no internal jargon (no symbol names, no `MissingMethodException`, no
+"PR #50"). Past entries on https://letterboxdsync.dev/releases set the tone.
+
+Don't leave this empty. release.yml falls back to the PR title if the section
+is missing, which is almost never what end-users browsing their plugin catalog
+should see.
+-->
+
+(Replace with one paragraph describing what's in this release for users.)
+
 ## What's broken
 
 <!--

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,50 @@ jobs:
             exit 1
           fi
 
-      - name: Capture release body
+      - name: Extract release body from merged PR
         if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SQUASH_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          # HEAD is the squash-merge commit on main; subject is the PR title
-          # (Conventional Commits), body is whatever was included on merge.
-          git log -1 --format='%B' HEAD > /tmp/release-body.txt
+          set -e
+          # The squash-merge commit subject ends with " (#NN)" where NN is the
+          # PR number. Extract the PR number, fetch the PR body via gh CLI,
+          # and pull out the text between the "## Release notes" header and
+          # the next H2 (or EOF). That section is the user-facing prose that
+          # lands in manifest.json's changelog field and as the GitHub Release
+          # body. The pull_request_template.md primes every PR with the
+          # section so this is the path of least resistance.
+          SUBJECT=$(printf '%s' "$SQUASH_MESSAGE" | head -1)
+          PR=$(printf '%s' "$SUBJECT" | grep -oE '#[0-9]+' | tr -d '#' | tail -1 || true)
+          if [ -z "$PR" ]; then
+            echo "::warning::No PR number in commit subject; using subject as changelog."
+            printf '%s\n' "$SUBJECT" > /tmp/release-body.txt
+          else
+            echo "Fetching PR body for PR #$PR"
+            gh pr view "$PR" --json body --jq .body > /tmp/pr-body.txt
+            python3 << 'PY'
+          import os, re, sys
+          body = open('/tmp/pr-body.txt').read()
+          m = re.search(
+              r'^##\s+Release notes\s*$(.*?)(?=^##\s|\Z)',
+              body, re.MULTILINE | re.DOTALL)
+          notes = m.group(1).strip() if m else ''
+          with open('/tmp/release-body.txt', 'w') as f:
+              if notes:
+                  f.write(notes + '\n')
+              else:
+                  subj = os.environ.get('SQUASH_MESSAGE', '').split('\n', 1)[0]
+                  fallback = re.sub(r' \(#\d+\)$', '', subj)
+                  f.write(fallback + '\n')
+                  sys.stderr.write(
+                      "::warning::No '## Release notes' section in PR body; "
+                      "falling back to PR title. Add the section to keep the "
+                      "manifest changelog consistent with the older releases.\n")
+          PY
+          fi
           echo "--- release body preview ---"
-          head -c 500 /tmp/release-body.txt
+          head -c 800 /tmp/release-body.txt
           echo
 
       - name: Setup .NET

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,13 @@ Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `Letterb
 1. Open a PR. The PR must:
    - Have a **Conventional Commits** title (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`). Enforced by `pr-title.yml`.
    - **Bump `AssemblyVersion` / `FileVersion`** in both `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`. Patch bumps (e.g. `1.13.0.0` → `1.13.1.0`) are fine for docs / CI / refactor changes; every PR ships. Enforced by `version-gate.yml`.
+   - Fill in the **`## Release notes`** section in the PR body. `release.yml` extracts text between that heading and the next H2 and uses it verbatim as the manifest changelog field and the GitHub Release body. The PR template primes the section so it's the path of least resistance. Past entries on https://letterboxdsync.dev/releases set the tone: one paragraph, user-facing prose, no symbol names / internal jargon.
+   - Add a structured entry to **`site/src/data/release-notes.ts`** for the new version (headline + summary + categorised highlights). The site renders these on the Releases page above the raw manifest changelog. Same tone as the manifest changelog but split into `new` / `improvements` / `fixes` / `breaking` bullets.
    - If the `Jellyfin.Controller` / `Jellyfin.Model` PackageReference is bumped and the new SDK introduces an ABI break the plugin now depends on, also bump `targetAbi.txt` to the minimum Jellyfin version that has the new ABI. This is the floor Jellyfin's plugin catalog uses to gate the release.
 
-2. Merge with **Squash and merge**. The PR title becomes the squash commit subject, which becomes the GitHub Release body and the `changelog` field in `manifest.json`.
+2. Merge with **Squash and merge**. The squash subject is the PR title with `(#NN)` appended; the release workflow extracts the PR number from that and fetches the PR body via `gh pr view` (the squash commit body itself is not reliable across merge methods).
 
-3. `release.yml` fires automatically on the push to `main`. It reads `AssemblyVersion` from `Directory.Build.props`, checks no tag for that version exists yet (idempotent), builds + tests, packages, creates the GitHub Release, inserts the manifest entry using `targetAbi.txt`, and pushes the auto-commit + tag together.
+3. `release.yml` fires automatically on the push to `main`. It reads `AssemblyVersion` from `Directory.Build.props`, checks no tag for that version exists yet (idempotent), builds + tests, packages, creates the GitHub Release with the PR body's `## Release notes` section, inserts the manifest entry using `targetAbi.txt`, and pushes the auto-commit + tag together.
 
 4. `deploy-docs.yml` fires via `workflow_run` on Release completion, rebuilding letterboxdsync.dev with the fresh manifest. (The `GITHUB_TOKEN`-authenticated auto-commit can't fire push-based workflows, hence the explicit `workflow_run` trigger.)
 
@@ -77,6 +79,7 @@ The version-bump magnitude is the canonical signal, not a `!` in the PR title. G
 - **v1.13.0** was cut manually after the merge, which works but doesn't enforce that *every* merge ships. The version-gate now guarantees a release on every merge.
 - **v1.12.0 and v1.13.0 site staleness**: the manifest auto-commit didn't trigger Deploy site (GitHub token limitation). The `workflow_run` trigger now fires Deploy site after every Release.
 - **v1.13.0 SDK ABI break**: Jellyfin 10.11.9 removed `IUserManager.Users` (replaced by `GetUsers()`), so v1.13.0 bumped the SDK to 10.11.10 and `targetAbi.txt` to `10.11.9.0`. See `feedback_jellyfin_plugin_abi_break` in the user's memory.
+- **v1.13.0 and v1.13.1 changelog drift**: v1.13.0's manifest changelog was written as a multi-paragraph incident report (markdown headings, code backticks, "MissingMethodException", PR refs) instead of the single-paragraph user prose of v1.0–v1.12. v1.13.1's was even worse: just the squash-merge commit subject `ci: enforce version bump on every PR, auto-release on merge, rebuild site on release (#50)`, because the earlier pipeline read `git log -1 --format='%B' HEAD` and `gh pr merge --squash` only puts the PR title there. release.yml now extracts the changelog from a `## Release notes` section in the PR body (via `gh pr view`), with the PR template seeding the section. Backfilled in v1.13.2.
 
 ## OpenSpec
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.13.1.0</Version>
-        <AssemblyVersion>1.13.1.0</AssemblyVersion>
-        <FileVersion>1.13.1.0</FileVersion>
+        <Version>1.13.2.0</Version>
+        <AssemblyVersion>1.13.2.0</AssemblyVersion>
+        <FileVersion>1.13.2.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.1.0</AssemblyVersion>
-    <FileVersion>1.13.1.0</FileVersion>
+    <AssemblyVersion>1.13.2.0</AssemblyVersion>
+    <FileVersion>1.13.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "versions": [
       {
         "version": "1.13.1.0",
-        "changelog": "ci: enforce version bump on every PR, auto-release on merge, rebuild site on release (#50)",
+        "changelog": "Maintenance release: stronger release pipeline. Every PR now bumps the version (gated by a required CI check) and auto-ships on merge to main, PR titles must follow Conventional Commits, and letterboxdsync.dev rebuilds on every release. No plugin behaviour changes. Past incident behind this work: v1.13.0 was cut manually after merge and the site Releases page was stale through both v1.12.0 and v1.13.0 because the manifest auto-commit could not trigger Deploy site.",
         "targetAbi": "10.11.9.0",
         "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.13.1/jellyfin-plugin-letterboxd-v1.13.1.zip",
         "checksum": "34e7334045954fa558364fd11be5b73e",
@@ -17,7 +17,7 @@
       },
       {
         "version": "1.13.0.0",
-        "changelog": "Required update for Jellyfin 10.11.9 and newer.\n\nJellyfin 10.11.9 changed the `IUserManager` ABI (the `Users` property was removed, replaced by a `GetUsers()` method). The plugin was compiled against the 10.11.0 SDK, so on Jellyfin 10.11.9 and 10.11.10 every read of the user list throws `MissingMethodException`. Symptoms reported in #46: the in-dashboard Stats and History endpoints return 500, the \"Sync watched movies to Letterboxd\" scheduled task fails immediately, and \"Sync Letterboxd watchlist to playlist\" fails the same way.\n\nThis release recompiles the plugin against `Jellyfin.Controller` / `Jellyfin.Model` 10.11.10 and rewrites the seven `_userManager.Users` call sites against the new `GetUsers()` method. The plugin's behaviour is otherwise unchanged from v1.12.0.\n\nCompatibility: `targetAbi` is now `10.11.9.0`. Jellyfin's plugin catalog will only offer v1.13.0 to servers running Jellyfin 10.11.9 or newer. If you are on Jellyfin 10.11.0 through 10.11.8 you will continue to be served v1.12.0 by the catalog, which still works for you; upgrade Jellyfin if you want future plugin updates.\n\nFixes #46.",
+        "changelog": "Required update for Jellyfin 10.11.9 and newer. Jellyfin 10.11.9 removed the Users property from IUserManager and replaced it with a GetUsers() method, so the plugin (compiled against the 10.11.0 SDK) threw MissingMethodException on every user-list read on 10.11.9 and 10.11.10. Symptoms before this fix: the dashboard Stats and History endpoints returned 500, the Sync watched movies to Letterboxd scheduled task failed immediately, and Sync Letterboxd watchlist to playlist failed the same way. Plugin behaviour is otherwise unchanged from v1.12.0. targetAbi is now 10.11.9.0, so Jellyfin 10.11.0 through 10.11.8 servers stay on v1.12.0 via the catalog gate; upgrade Jellyfin to 10.11.9 or newer to receive future plugin updates. Fixes #46.",
         "targetAbi": "10.11.9.0",
         "sourceUrl": "https://github.com/builtbyproxy/jellyfin-plugin-letterboxd/releases/download/v1.13.0/jellyfin-plugin-letterboxd-v1.13.0.zip",
         "checksum": "bdb9fc1d28d712542c063947fc37ae0b",

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,47 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.13.2',
+    headline: 'Release notes pipeline: prose-style changelogs back, sourced from the PR body',
+    summary:
+      "Restores the v1.0–v1.12 manifest-changelog tone after v1.13.0 and v1.13.1 drifted into incident-report prose and a conventional-commit subject line respectively. Backfills both on letterboxdsync.dev's Releases page.",
+    highlights: {
+      improvements: [
+        "release.yml now fetches the merged PR's body via the GitHub API and extracts text between a '## Release notes' header and the next H2 as the manifest changelog. Falls back to the PR title only if the section is missing.",
+        "New .github/pull_request_template.md primes every PR with the section so it's the path of least resistance.",
+        'Backfills the manifest changelog for v1.13.0 and v1.13.1 to match the single-paragraph user-facing prose of v1.0 through v1.12.',
+        'Backfills letterboxdsync.dev with structured Release notes entries for v1.13.0 and v1.13.1 (previously missing).',
+      ],
+    },
+  },
+  {
+    version: '1.13.1',
+    headline: 'Maintenance: stronger release pipeline',
+    summary: 'No plugin behaviour changes.',
+    highlights: {
+      improvements: [
+        'Every PR now bumps the version (gated by a required CI check) and auto-ships on merge to main, replacing the manual `git tag` step.',
+        'PR titles must follow Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`). Enforced by CI on every PR.',
+        'letterboxdsync.dev rebuilds on every release via a `workflow_run` trigger, so the Releases page is never stale (the manifest auto-commit otherwise cannot fire push-based workflows).',
+      ],
+    },
+  },
+  {
+    version: '1.13.0',
+    headline: 'Required update for Jellyfin 10.11.9 and newer',
+    summary: 'Fixes #46. Restores sync on the new SDK ABI; no other plugin behaviour changes.',
+    highlights: {
+      fixes: [
+        'Jellyfin 10.11.9 removed the `Users` property from `IUserManager` and replaced it with a `GetUsers()` method. The plugin was compiled against the 10.11.0 SDK, so on Jellyfin 10.11.9 and 10.11.10 every read of the user list threw `MissingMethodException`: the dashboard Stats and History endpoints returned 500, and both scheduled sync tasks failed immediately. Recompiled against 10.11.10 and rewrote all seven `_userManager.Users` call sites to use `GetUsers()`.',
+      ],
+      breaking: [
+        '`targetAbi` is now `10.11.9.0`. The Jellyfin plugin catalog will only offer this release to servers running 10.11.9 or newer; Jellyfin 10.11.0 through 10.11.8 servers stay on v1.12.0 (which still works for them).',
+      ],
+    },
+    upgradeNotes:
+      'If your Jellyfin server is on 10.11.0 through 10.11.8 the catalog will not offer v1.13.0 by design; upgrade Jellyfin to 10.11.9 or newer to receive this and future plugin updates.',
+  },
+  {
     version: '1.12.0',
     headline: 'Multi-account support: one Jellyfin user, many Letterboxd accounts',
     summary: 'Shared TV logins (e.g. two people on the same family Jellyfin profile) can now each have their own Letterboxd diary, ratings, and watchlist.',


### PR DESCRIPTION
Closes #46 (final cleanup). No linked issue for the pipeline change.

## Release notes

Maintenance release. The manifest changelog field and the letterboxdsync.dev Releases page now match the v1.0–v1.12 single-paragraph user-facing prose style after v1.13.0 (rendered as a multi-paragraph incident report) and v1.13.1 (rendered as the raw conventional-commit subject line) drifted away from it. The release workflow now pulls the manifest changelog from a `## Release notes` section in the merged PR's body via the GitHub API, so the prose that lands in users' plugin catalogs is deliberate and reviewable. Backfills the two missing structured entries on the Releases page and rewrites the two stale manifest entries inline. No plugin behaviour changes.

## What's broken

Two related drifts on letterboxdsync.dev's Releases page and in the manifest changelog field:

- **v1.13.0**: the changelog landed as a multi-paragraph incident report (headings, code backticks, `MissingMethodException`, PR refs). Doesn't match the v1.0–v1.12 single-paragraph user prose style. Renders awkwardly in the plugin catalog UI and on the Releases page.
- **v1.13.1**: the changelog is literally just `ci: enforce version bump on every PR, auto-release on merge, rebuild site on release (#50)`. Useless to end users.

Plus: `site/src/data/release-notes.ts` (the source of the structured highlights on the Releases page) had no entry for either version, so the page is silent on what shipped.

## Why it happens

1. v1.13.0's changelog was hand-written by me into `release-notes.md` (the file the old `release.yml` used for tag annotations). I wrote it like a GitHub PR description, not a release note. The workflow shoved it into the manifest verbatim. I never compared against the existing entries.
2. v1.13.1's changelog came from the new `release.yml` running `git log -1 --format='%B' HEAD`. After `gh pr merge --squash`, that commit message contains only the PR title + `(#NN)`; the PR description is dropped. The workflow had no fallback to "go fetch the PR body via the API."
3. `release-notes.ts` is manually maintained (always was), and I forgot to update it in the two prior PRs.

## What this PR does

- **Backfills `manifest.json`**: rewrites the changelog field for v1.13.0 and v1.13.1 into single-paragraph user-facing prose matching v1.0–v1.12.
- **Backfills `site/src/data/release-notes.ts`**: adds structured `ReleaseNotes` entries for v1.13.0 (fixes + breaking + upgradeNotes) and v1.13.1 (improvements). Also adds v1.13.2 for this PR.
- **`.github/workflows/release.yml`**: the "Capture release body" step is rewritten to fetch the merged PR's body via `gh pr view`, parse out the text between `## Release notes` and the next H2, and use that as the manifest changelog. Falls back to the PR title (warning) only if the section is missing.
- **`.github/pull_request_template.md`**: adds a `## Release notes` section at the top of the existing template, with inline guidance on tone. Path of least resistance for future PRs.
- **`CLAUDE.md`**: Releasing section updated to require both the PR body section and a matching `release-notes.ts` entry; adds the changelog-drift incident to the past-incidents list.
- **`Directory.Build.props` + `LetterboxdSync.csproj`**: bumped to `1.13.2.0`.

## How to test

- `dotnet build -c Release` clean, 470/470 unit tests pass locally.
- `npm run build` in `site/` produces a Releases page with v1.13.0 and v1.13.1 entries visible (verified by grepping the built HTML).
- After merge: the new release.yml will extract this PR body's `## Release notes` section above and ship it as v1.13.2's manifest changelog + GitHub Release body. The Releases page rebuilds via `workflow_run` and shows all three new entries.

## Follow-ups (not in this PR)

- Required branch protection on `main` for the `check` (version-gate), `check` (pr-title), `build-and-test`, `integration` checks. UI-only, needs admin.
- Optional CI guard: when `targetAbi.txt` changes in a PR, require at least a minor bump.