### PR TITLE
ci: dependabot for jellyfin sdk, version-gate links targetAbi to minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+# Watch the Jellyfin SDK for ABI surprises (incident: 10.11.9 silently removed
+# IUserManager.Users, broke v1.12.0 on every 10.11.9+ server, only surfaced
+# via user reports). With this in place, Dependabot opens a PR the day a new
+# Jellyfin.Controller / Jellyfin.Model ships, CI runs the test suite against
+# the new ABI, and a human decides whether to take the bump.
+#
+# When merging a Dependabot PR: bump AssemblyVersion / FileVersion in the
+# same branch (push a follow-up commit to the Dependabot PR before merging,
+# or open your own PR that incorporates the bump). version-gate.yml will
+# refuse the merge otherwise.
+#
+# Scoped narrowly to Jellyfin.* for now; expand if other deps start causing
+# surprises. PR commit prefix is "build" so pr-title.yml accepts it.
+
+updates:
+  - package-ecosystem: nuget
+    directory: /LetterboxdSync
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "Jellyfin.*"
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - dependencies
+      - jellyfin-sdk
+
+  # Tests project: same allowlist, lower frequency. Test-only dep bumps don't
+  # ship to users, so weekly is plenty.
+  - package-ecosystem: nuget
+    directory: /LetterboxdSync.Tests
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "Jellyfin.*"
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - dependencies
+      - jellyfin-sdk

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -50,3 +50,22 @@ jobs:
           fi
 
           echo "Version bump OK: $MAIN_V -> $PR_V"
+
+          # If targetAbi.txt changed, require at least a minor bump. A bump
+          # in the Jellyfin compatibility floor is a meaningful change for
+          # users (older Jellyfin patches stop being offered the new plugin
+          # version), so it should not hide inside a patch release.
+          PR_ABI=$(cat targetAbi.txt 2>/dev/null | tr -d '[:space:]' || true)
+          MAIN_ABI=$(git show origin/main:targetAbi.txt 2>/dev/null | tr -d '[:space:]' || true)
+          if [ -n "$PR_ABI" ] && [ "$PR_ABI" != "$MAIN_ABI" ]; then
+            echo "targetAbi.txt changed: '$MAIN_ABI' -> '$PR_ABI'"
+            PR_MAJOR=$(echo "$PR_V" | cut -d. -f1)
+            PR_MINOR=$(echo "$PR_V" | cut -d. -f2)
+            MAIN_MAJOR=$(echo "$MAIN_V" | cut -d. -f1)
+            MAIN_MINOR=$(echo "$MAIN_V" | cut -d. -f2)
+            if [ "$PR_MAJOR" -eq "$MAIN_MAJOR" ] && [ "$PR_MINOR" -eq "$MAIN_MINOR" ]; then
+              echo "::error::targetAbi.txt changed ('$MAIN_ABI' -> '$PR_ABI') but version bump is patch-only ($MAIN_V -> $PR_V). Moving the Jellyfin compatibility floor is a meaningful release; bump at least the minor (e.g. ${PR_MAJOR}.$((PR_MINOR + 1)).0.0)."
+              exit 1
+            fi
+            echo "targetAbi shift gated by minor+ bump: OK"
+          fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.13.2.0</Version>
-        <AssemblyVersion>1.13.2.0</AssemblyVersion>
-        <FileVersion>1.13.2.0</FileVersion>
+        <Version>1.13.3.0</Version>
+        <AssemblyVersion>1.13.3.0</AssemblyVersion>
+        <FileVersion>1.13.3.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.2.0</AssemblyVersion>
-    <FileVersion>1.13.2.0</FileVersion>
+    <AssemblyVersion>1.13.3.0</AssemblyVersion>
+    <FileVersion>1.13.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.13.3',
+    headline: 'Maintenance: Dependabot watches the Jellyfin SDK, version-gate links targetAbi to minor bumps',
+    summary:
+      'Two preventative measures aimed at the next ABI surprise. No plugin behaviour changes.',
+    highlights: {
+      improvements: [
+        "Dependabot now opens a PR the day Jellyfin ships a new Jellyfin.Controller / Jellyfin.Model patch, so the next 10.11.x ABI break is caught by CI on our timeline rather than via a user report (incident: v1.13.0 only existed because 10.11.9's silent IUserManager.Users removal surfaced as a bigrichwood bug report).",
+        'version-gate now refuses a patch-only bump when targetAbi.txt changes in the same PR. Moving the Jellyfin compatibility floor stops a cohort of users from being offered the next plugin update; that warrants at least a minor version bump so the change is visible in the release notes.',
+      ],
+    },
+  },
+  {
     version: '1.13.2',
     headline: 'Release notes pipeline: prose-style changelogs back, sourced from the PR body',
     summary:


### PR DESCRIPTION
No linked issue.

## Release notes

Maintenance release. Two preventative changes aimed at the next Jellyfin SDK ABI surprise. Dependabot now watches the `Jellyfin.Controller` and `Jellyfin.Model` packages and opens a PR the day a new patch ships, so any breaking ABI change is caught by CI on our timeline rather than via a user bug report (the v1.13.0 fix only existed because Jellyfin 10.11.9's silent removal of `IUserManager.Users` surfaced as bigrichwood's report). And the version-gate CI check now refuses a patch-only version bump when `targetAbi.txt` changes in the same PR, because moving the Jellyfin compatibility floor stops a cohort of users from being offered the next plugin update and that warrants at least a minor bump so the change shows up clearly in the release notes. No plugin behaviour changes.

## What's broken

Two adjacent gaps in the release pipeline that landed in v1.13.x:

1. We learn about Jellyfin SDK ABI breaks from end users, not CI. v1.13.0 was a reactive fix; if `Jellyfin.Controller` is bumped daily in the wild and we don't track it, we'll keep being late.
2. `targetAbi.txt` can be raised in the same PR as a `docs:` or other patch-level change. The user would be silently dropped to a stale plugin version with no signal in the changelog.

## Why it happens

1. No dep-update automation. The csproj pins `Jellyfin.Controller` = `10.11.10` and nothing tells us when 10.11.11 ships.
2. version-gate.yml enforces "different from main" only; it has no semver intelligence linking targetAbi changes to version-bump magnitude.

## What this PR does

- **`.github/dependabot.yml`** new: NuGet ecosystem watcher scoped to `Jellyfin.*` packages only. Daily on `LetterboxdSync/`, weekly on `LetterboxdSync.Tests/`. Commit prefix `build` so pr-title.yml accepts the auto-generated PRs.
- **`.github/workflows/version-gate.yml`** extended: detects `targetAbi.txt` change vs main, fails the PR if the version bump is patch-only. Error message points at the next minor version.
- **`site/src/data/release-notes.ts`**: structured entry for v1.13.3.
- **`Directory.Build.props`** + **`LetterboxdSync.csproj`**: bumped to `1.13.3.0`.

## How to test

- `dotnet build -c Release` clean.
- `dotnet test --filter "Category!=Integration"` passes 470/470.
- YAML parses for all 7 workflow files including `dependabot.yml`.
- The new gate is only exercised when `targetAbi.txt` changes in a PR; this PR doesn't change it so the gate is dormant. Will be exercised next time the SDK floor moves.

## Follow-ups (not in this PR)

- Required branch protection on `main` for the four PR checks (`check`/`check`/`build-and-test`/`integration`). Still UI-only.
- Consider expanding Dependabot beyond `Jellyfin.*` to other deps (HtmlAgilityPack, Newtonsoft.Json, xunit, NSubstitute) if PR volume stays reasonable.