### PR TITLE
test: expand plugin coverage to 89.8% line / 81.4% branch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.13.3.0</Version>
-        <AssemblyVersion>1.13.3.0</AssemblyVersion>
-        <FileVersion>1.13.3.0</FileVersion>
+        <Version>1.13.4.0</Version>
+        <AssemblyVersion>1.13.4.0</AssemblyVersion>
+        <FileVersion>1.13.4.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/ApiClientGapTests.cs
+++ b/LetterboxdSync.Tests/ApiClientGapTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using LetterboxdSync;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Covers the LetterboxdApiClient branches the happy-path tests don't reach:
+/// the not-authenticated guard, error responses on diary writes, token refresh
+/// and refresh-fallback, the test-only cleanup helper, and slug fallbacks.
+/// Reuses ApiMockHandler / ApiTestHelpers from ApiClientTests.
+/// </summary>
+public class ApiClientGapTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("test");
+
+    [Fact]
+    public async Task MarkAsWatchedAsync_NotAuthenticated_Throws()
+    {
+        using var client = new LetterboxdApiClient(TestLogger);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.MarkAsWatchedAsync("fight-club", "2a9q", DateTime.Now, liked: false));
+    }
+
+    [Fact]
+    public async Task GetDiaryInfoAsync_NonSuccess_ReturnsEmpty()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true &&
+                request.Method == HttpMethod.Get)
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var info = await client.GetDiaryInfoAsync("2a9q", "user");
+
+        Assert.False(info.HasAnyEntry);
+        Assert.Null(info.LastDate);
+    }
+
+    [Fact]
+    public async Task MarkAsWatchedAsync_Unauthorized_ClearsTokenAndThrows()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(request =>
+        {
+            if (request.Method == HttpMethod.Post &&
+                request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true)
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+
+        var ex = await Assert.ThrowsAsync<Exception>(() =>
+            client.MarkAsWatchedAsync("film", "lid", DateTime.Now, liked: false));
+        Assert.Contains("token expired", ex.Message);
+    }
+
+    [Fact]
+    public async Task MarkAsWatchedAsync_ServerError_Throws()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(request =>
+        {
+            if (request.Method == HttpMethod.Post &&
+                request.RequestUri?.AbsolutePath.EndsWith("/log-entries") == true)
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("validation failed")
+                };
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+
+        var ex = await Assert.ThrowsAsync<Exception>(() =>
+            client.MarkAsWatchedAsync("film", "lid", DateTime.Now, liked: false));
+        Assert.Contains("Failed to log film", ex.Message);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_ExpiredCachedToken_RefreshesInsteadOfFullAuth()
+    {
+        var grantTypes = new List<string>();
+        var handler = new ApiMockHandler(request =>
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "";
+            if (path.EndsWith("/auth/token"))
+            {
+                var body = request.Content?.ReadAsStringAsync().Result ?? "";
+                grantTypes.Add(body.Contains("grant_type=refresh_token") ? "refresh" : "password");
+                // First (password) grant expires almost immediately so the second
+                // AuthenticateAsync sees an expired cache entry and refreshes.
+                var token = body.Contains("grant_type=refresh_token") ? "refreshed" : "initial";
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        access_token = token,
+                        expires_in = 1,
+                        refresh_token = "rt-123"
+                    }))
+                };
+            }
+            if (path.EndsWith("/me"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"member\":{\"id\":\"m1\",\"username\":\"u\"}}")
+                };
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var username = "refresh_" + Guid.NewGuid().ToString("N");
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync(username, "pass"); // full password auth
+        await client.AuthenticateAsync(username, "pass"); // cache expired → refresh
+
+        Assert.Equal("password", grantTypes[0]);
+        Assert.Contains("refresh", grantTypes);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_RefreshFails_FallsBackToFullAuth()
+    {
+        var grantTypes = new List<string>();
+        var handler = new ApiMockHandler(request =>
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "";
+            if (path.EndsWith("/auth/token"))
+            {
+                var body = request.Content?.ReadAsStringAsync().Result ?? "";
+                var isRefresh = body.Contains("grant_type=refresh_token");
+                grantTypes.Add(isRefresh ? "refresh" : "password");
+                // Refresh grant fails → client must fall back to a fresh password auth.
+                if (isRefresh)
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new StringContent("{\"error\":\"invalid_grant\"}")
+                    };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        access_token = "ok",
+                        expires_in = 1,
+                        refresh_token = "rt-123"
+                    }))
+                };
+            }
+            if (path.EndsWith("/me"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"member\":{\"id\":\"m1\",\"username\":\"u\"}}")
+                };
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var username = "refreshfail_" + Guid.NewGuid().ToString("N");
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync(username, "pass"); // full auth, caches refresh token
+        await client.AuthenticateAsync(username, "pass"); // refresh attempted then falls back
+
+        // Second call tried refresh, then a second password grant.
+        Assert.Contains("refresh", grantTypes);
+        Assert.Equal(2, grantTypes.Count(g => g == "password"));
+    }
+
+    [Fact]
+    public async Task DeleteAllLogEntriesForFilmAsync_DeletesEveryEntry()
+    {
+        var deleted = new List<string>();
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(request =>
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "";
+            if (request.Method == HttpMethod.Get && path.EndsWith("/log-entries"))
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"items\":[{\"id\":\"e1\"},{\"id\":\"e2\"}]}")
+                };
+            if (request.Method == HttpMethod.Delete && path.Contains("/log-entry/"))
+            {
+                deleted.Add(path.Split("/log-entry/").Last());
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            }
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        await client.DeleteAllLogEntriesForFilmAsync("lid-1");
+
+        Assert.Equal(new[] { "e1", "e2" }, deleted);
+    }
+
+    [Fact]
+    public async Task LookupFilmByTmdbIdAsync_NoLetterboxdLink_FallsBackToTopLevelLink()
+    {
+        var handler = ApiTestHelpers.CreateAuthenticatedHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/films") == true)
+                // No links[].type == "letterboxd"; slug must come from top-level "link".
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new
+                    {
+                        items = new[]
+                        {
+                            new
+                            {
+                                id = "xyz1",
+                                link = "https://letterboxd.com/film/the-thing/",
+                                links = new[] { new { type = "tmdb", id = "1091", url = "https://www.themoviedb.org/movie/1091" } }
+                            }
+                        }
+                    }))
+                };
+            return null;
+        });
+
+        using var client = new LetterboxdApiClient(TestLogger, handler);
+        await client.AuthenticateAsync("user", "pass");
+        var result = await client.LookupFilmByTmdbIdAsync(1091);
+
+        Assert.Equal("xyz1", result.FilmId);
+        Assert.Equal("the-thing", result.Slug);
+    }
+}

--- a/LetterboxdSync.Tests/JellyseerrClientTests.cs
+++ b/LetterboxdSync.Tests/JellyseerrClientTests.cs
@@ -345,6 +345,55 @@ public class JellyseerrClientTests
         Assert.Equal("9", sentHeader);
     }
 
+    [Fact]
+    public async Task AddToWatchlistAsync_ServerError_ReturnsFalse()
+    {
+        // A non-conflict failure (500) is a genuine failure, not an idempotent dup.
+        var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("boom")
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.False(await client.AddToWatchlistAsync(42, 9));
+    }
+
+    [Fact]
+    public async Task RemoveFromWatchlistAsync_ServerError_ReturnsFalse()
+    {
+        var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("boom")
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.False(await client.RemoveFromWatchlistAsync(42, 9));
+    }
+
+    [Fact]
+    public async Task GetUserWatchlistTmdbIdsAsync_FetchFails_ReturnsEmpty()
+    {
+        // A failed page fetch must not throw; it returns whatever was gathered (nothing).
+        var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("nope")
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var ids = await client.GetUserWatchlistTmdbIdsAsync(9);
+        Assert.Empty(ids);
+    }
+
+    [Fact]
+    public async Task GetMovieMediaStatusAsync_TransportThrows_ReturnsNull()
+    {
+        // Network-layer exceptions are swallowed so a status pre-check never breaks a run.
+        var handler = new SeerrHandler(_ => throw new HttpRequestException("connection reset"));
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        Assert.Null(await client.GetMovieMediaStatusAsync(100));
+    }
+
     private static HttpResponseMessage JsonResponse(string body)
         => new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
 

--- a/LetterboxdSync.Tests/LetterboxdControllerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdControllerTests.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
 using LetterboxdSync;
 using LetterboxdSync.Api;
 using LetterboxdSync.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
@@ -755,5 +760,282 @@ public class LetterboxdControllerTests
         // The last 10 lines should be returned, ordered.
         Assert.Contains("line 99", returned[^1]);
         Assert.Equal(100, Prop<int>(result, "totalMatches"));
+    }
+
+    [Fact]
+    public void GetLogs_LogDirectoryMissing_ReturnsErrorPayload()
+    {
+        using var h = new ControllerTestHarness();
+        // Point the log directory at a path that doesn't exist → directory-not-found branch.
+        h.AppPaths.LogDirectoryPath.Returns(
+            System.IO.Path.Combine(h.TempDir, "does-not-exist-" + Guid.NewGuid().ToString("N")));
+
+        var result = h.Controller.GetLogs();
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Empty(Prop<string[]>(result, "lines")!);
+        Assert.Contains("log directory not found", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    // ----- StartSync: conflict + named-account targeting -----
+
+    [Fact]
+    public void StartSync_SyncAlreadyRunning_ReturnsConflict()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy");
+
+        // Hold the global gate so LetterboxdSyncRunner.IsRunning reports true.
+        Assert.True(SyncGate.Instance.Wait(0));
+        try
+        {
+            var result = h.Controller.StartSync();
+            Assert.IsType<ConflictObjectResult>(result);
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    [Fact]
+    public void StartSync_NamedAccountNotFound_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy");
+
+        var result = h.Controller.StartSync(letterboxdUsername: "someone-else");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("someone-else", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    [Fact]
+    public void StartSync_NamedAccountFound_Returns202Accepted()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy");
+
+        var result = h.Controller.StartSync(letterboxdUsername: "8bitproxy");
+
+        Assert.IsType<AcceptedResult>(result);
+    }
+
+    // ----- StartWatchlistSync: user, conflict, named-account -----
+
+    [Fact]
+    public void StartWatchlistSync_NoUserClaim_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: null);
+
+        var result = h.Controller.StartWatchlistSync();
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void StartWatchlistSync_SyncAlreadyRunning_ReturnsConflict()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy", watchlistSync: true);
+
+        Assert.True(SyncGate.Instance.Wait(0));
+        try
+        {
+            var result = h.Controller.StartWatchlistSync();
+            Assert.IsType<ConflictObjectResult>(result);
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    [Fact]
+    public void StartWatchlistSync_NamedAccountNotFound_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy", watchlistSync: true);
+
+        var result = h.Controller.StartWatchlistSync(letterboxdUsername: "ghost");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("ghost", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    [Fact]
+    public void StartWatchlistSync_NamedAccountWatchlistDisabled_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy", watchlistSync: false);
+
+        var result = h.Controller.StartWatchlistSync(letterboxdUsername: "8bitproxy");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("disabled", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    [Fact]
+    public void StartWatchlistSync_NamedAccountEnabled_Returns202Accepted()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy", watchlistSync: true);
+
+        var result = h.Controller.StartWatchlistSync(letterboxdUsername: "8bitproxy");
+
+        Assert.IsType<AcceptedResult>(result);
+    }
+
+    // ----- TestConnection: success + failure via the factory seam -----
+
+    [Fact]
+    public async Task TestConnection_AuthSucceeds_ReturnsOk()
+    {
+        using var h = new ControllerTestHarness();
+
+        var service = Substitute.For<ILetterboxdService>();
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+            System.Threading.Tasks.Task.FromResult(service);
+        try
+        {
+            var result = await h.Controller.TestConnection(new TestConnectionRequest
+            {
+                LetterboxdUsername = "8bitproxy",
+                LetterboxdPassword = "secret"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.True(Prop<bool>(result, "success"));
+            Assert.Equal("8bitproxy", Prop<string>(result, "letterboxdUsername"));
+        }
+        finally
+        {
+            LetterboxdServiceFactory.OverrideForTesting = null;
+        }
+    }
+
+    [Fact]
+    public async Task TestConnection_AuthThrows_ReturnsBadRequestWithError()
+    {
+        using var h = new ControllerTestHarness();
+
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+            throw new Exception("bad credentials");
+        try
+        {
+            var result = await h.Controller.TestConnection(new TestConnectionRequest
+            {
+                LetterboxdUsername = "8bitproxy",
+                LetterboxdPassword = "wrong"
+            });
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.False(Prop<bool>(result, "success"));
+            Assert.Contains("bad credentials", Prop<string>(result, "error") ?? string.Empty);
+        }
+        finally
+        {
+            LetterboxdServiceFactory.OverrideForTesting = null;
+        }
+    }
+
+    // ----- PostReview: named-account targeting + Jellyfin rating writeback -----
+
+    [Fact]
+    public async Task PostReview_NamedAccountNotFound_ReturnsBadRequest()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy");
+
+        var result = await h.Controller.PostReview(new ReviewRequest
+        {
+            FilmSlug = "sinners",
+            ReviewText = "great",
+            LetterboxdUsername = "not-mine"
+        });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("not-mine", Prop<string>(result, "error") ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task PostReview_NamedAccountFound_PostsToThatAccountOnly()
+    {
+        using var h = new ControllerTestHarness(currentUserId: UserId);
+        h.AddAccount(UserId, "8bitproxy");
+        h.AddAccount(UserId, "deb");
+
+        var service = Substitute.For<ILetterboxdService>();
+        // Capture which Letterboxd username the factory was asked to authenticate.
+        var authedUsernames = new System.Collections.Generic.List<string>();
+        LetterboxdServiceFactory.OverrideForTesting = (u, _, _, _, _) =>
+        {
+            authedUsernames.Add(u);
+            return System.Threading.Tasks.Task.FromResult(service);
+        };
+        try
+        {
+            var result = await h.Controller.PostReview(new ReviewRequest
+            {
+                FilmSlug = "sinners",
+                ReviewText = "great",
+                LetterboxdUsername = "deb"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            // Only the named account was targeted, not the fan-out across both.
+            Assert.Equal(new[] { "deb" }, authedUsernames);
+        }
+        finally
+        {
+            LetterboxdServiceFactory.OverrideForTesting = null;
+        }
+    }
+
+    [Fact]
+    public async Task PostReview_SuccessWithRating_MirrorsRatingIntoJellyfin()
+    {
+        // Real User/Movie instances: the controller matches the claim id against
+        // User.Id.ToString("N"), and User has no parameterless ctor to substitute.
+        var user = new User("lachlan", "test-provider-id", "test-reset-id");
+        var userId = user.Id.ToString("N");
+
+        using var h = new ControllerTestHarness(currentUserId: userId);
+        h.AddAccount(userId, "8bitproxy");
+        h.UserManager.GetUsers().Returns(new[] { user });
+
+        var movie = new Movie { Name = "Sinners" };
+        movie.SetProviderId(MetadataProvider.Tmdb, "1233413");
+        h.LibraryManager.GetItemList(Arg.Any<InternalItemsQuery>())
+            .Returns(new List<BaseItem> { movie });
+
+        var userData = new UserItemData { Key = "k" };
+        h.UserDataManager.GetUserData(user, movie).Returns(userData);
+
+        var service = Substitute.For<ILetterboxdService>();
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+            System.Threading.Tasks.Task.FromResult(service);
+        try
+        {
+            var result = await h.Controller.PostReview(new ReviewRequest
+            {
+                FilmSlug = "sinners",
+                ReviewText = "great",
+                Rating = 4.5,
+                TmdbId = 1233413
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            // 4.5 Letterboxd stars → 9.0 Jellyfin rating, written back and persisted.
+            Assert.Equal(9.0, userData.Rating);
+            h.UserDataManager.Received(1).SaveUserData(
+                user, movie, userData,
+                MediaBrowser.Model.Entities.UserDataSaveReason.UpdateUserRating,
+                Arg.Any<System.Threading.CancellationToken>());
+        }
+        finally
+        {
+            LetterboxdServiceFactory.OverrideForTesting = null;
+        }
     }
 }

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -473,4 +473,204 @@ public class LetterboxdSyncRunnerTests : IDisposable
         Assert.True(ok);
         Assert.True(factoryHit, "real playback after diary import should re-enable export");
     }
+
+    // ----- SyncGate contention -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_GateAlreadyHeld_ReturnsFalse()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        Assert.True(await SyncGate.Instance.WaitAsync(0));
+        try
+        {
+            var ok = await _runner.TryRunForUserAsync(userId, "manual",
+                new Progress<double>(), CancellationToken.None);
+
+            Assert.False(ok);
+            _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    [Fact]
+    public async Task RunForAllAsync_GateAlreadyHeld_SkipsImmediately()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        Assert.True(await SyncGate.Instance.WaitAsync(0));
+        try
+        {
+            await _runner.RunForAllAsync(new Progress<double>(), "scheduled", CancellationToken.None);
+
+            _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    // ----- Named-account targeting -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_NamedAccountNotFound_ReturnsFalse()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId); // username "lb-user"
+
+        var ok = await _runner.TryRunForUserAsync(userId, "manual",
+            new Progress<double>(), CancellationToken.None, letterboxdUsername: "someone-else");
+
+        Assert.False(ok);
+        _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_NamedAccountFound_RunsThatAccountOnly()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId); // username "lb-user"
+
+        // Empty library so SyncOneUserAsync exits before authenticating; we only need to
+        // prove the named-account lookup resolved and the run reached the library query.
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var ok = await _runner.TryRunForUserAsync(userId, "manual",
+            new Progress<double>(), CancellationToken.None, letterboxdUsername: "lb-user");
+
+        Assert.True(ok);
+        _libraryManager.Received(1).GetItemList(Arg.Any<InternalItemsQuery>());
+    }
+
+    // ----- SkipPreviouslySynced filtering -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_SkipPreviouslySynced_FiltersAll_NoAuthAttempt()
+    {
+        // Account skips films already in local history. The one library film was
+        // successfully synced for its viewing date, so BuildSyncQueue drops it and the
+        // runner exits before authenticating.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId, skipPreviouslySynced: true);
+
+        var viewing = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(new UserItemData
+        {
+            Key = "k", Played = true, LastPlayedDate = viewing
+        });
+
+        SyncHistory.Record(new SyncEvent
+        {
+            FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
+            Timestamp = DateTime.UtcNow, ViewingDate = viewing,
+            Status = SyncStatus.Success, Source = "test"
+        });
+
+        var factoryHit = false;
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(Substitute.For<ILetterboxdService>());
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "test",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.False(factoryHit);
+    }
+
+    // ----- StopOnFailure -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_StopOnFailure_HaltsAfterFirstFailure()
+    {
+        // Two films, both lookups throw, StopOnFailure on → the runner must break after
+        // the first failure rather than attempting the second.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId, LetterboxdUsername = "lb-user", LetterboxdPassword = "secret",
+            Enabled = true, SkipPreviouslySynced = false, StopOnFailure = true
+        });
+
+        var m1 = MakeMovie(1233413, "Sinners");
+        var m2 = MakeMovie(550, "Fight Club");
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>())
+            .Returns(new List<BaseItem> { m1, m2 });
+
+        var service = Substitute.For<ILetterboxdService>();
+        // Throwing on lookup happens before the runner's inter-film delay, keeping this fast.
+        service.LookupFilmByTmdbIdAsync(Arg.Any<int>())
+            .Returns<Task<FilmResult>>(_ => throw new Exception("Cloudflare 403"));
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        var ok = await _runner.TryRunForUserAsync(userId, "test",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        // Only the first film was attempted; the break stopped the second.
+        await service.Received(1).LookupFilmByTmdbIdAsync(Arg.Any<int>());
+    }
+
+    // ----- Local-history duplicate backstop -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_LocalHistoryShowsRecentSync_SuppressesDuplicate()
+    {
+        // Letterboxd's own duplicate check comes back empty (null lastDate, e.g. a
+        // Cloudflare 403), but our append-only history shows a successful sync for this
+        // film on the same viewing date. The backstop must suppress the re-post rather
+        // than risk a duplicate diary entry.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId); // SkipPreviouslySynced defaults to false here
+
+        var viewing = DateTime.UtcNow;
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(new UserItemData
+        {
+            Key = "k", Played = true, LastPlayedDate = viewing
+        });
+
+        // Prior successful sync on the same viewing date → not a rewatch → suppress.
+        SyncHistory.Record(new SyncEvent
+        {
+            FilmTitle = "Sinners", FilmSlug = "sinners-2025", TmdbId = 1233413, Username = "lachlan",
+            Timestamp = DateTime.UtcNow.AddHours(-1), ViewingDate = viewing.Date,
+            Status = SyncStatus.Success, Source = "test"
+        });
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.LookupFilmByTmdbIdAsync(Arg.Any<int>())
+            .Returns(new FilmResult("sinners-2025", "KQMM", "PROD-1"));
+        // Null diary date → Letterboxd-side IsDuplicate is false, forcing the local backstop.
+        service.GetDiaryInfoAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(new DiaryInfo(null, false));
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        var ok = await _runner.TryRunForUserAsync(userId, "test",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        // Backstop fired: the film is never marked as watched on Letterboxd.
+        await service.DidNotReceive().MarkAsWatchedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<bool>(),
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<double?>());
+    }
 }

--- a/LetterboxdSync.Tests/ScraperTests.cs
+++ b/LetterboxdSync.Tests/ScraperTests.cs
@@ -158,6 +158,37 @@ public class ScraperTests
     }
 
     [Fact]
+    public void ExtractFilmIdentifiers_MalformedPosteredJson_IgnoredAndFilmIdStillExtracted()
+    {
+        // The data-postered-identifier JSON is garbage; the parse must be swallowed and
+        // the film-id still read from the element, leaving productionId null.
+        var html = @"<div data-postered-identifier='{not valid json' />
+                     <div data-film-slug=""test"" data-film-id=""777""></div>";
+        var http = new LetterboxdHttpClient(TestLogger);
+        var scraper = new LetterboxdScraper(http, TestLogger);
+
+        var (filmId, productionId) = scraper.ExtractFilmIdentifiers(html, "test");
+
+        Assert.Equal("777", filmId);
+        Assert.Null(productionId);
+        http.Dispose();
+    }
+
+    [Fact]
+    public void ExtractFilmIdentifiers_EmptyFilmId_Throws()
+    {
+        // The element is found but data-film-id is blank → explicit failure rather than
+        // silently returning an empty id that would corrupt later API calls.
+        var html = "<div data-film-slug=\"test\" data-film-id=\"\"></div>";
+        var http = new LetterboxdHttpClient(TestLogger);
+        var scraper = new LetterboxdScraper(http, TestLogger);
+
+        var ex = Assert.Throws<Exception>(() => scraper.ExtractFilmIdentifiers(html, "test"));
+        Assert.Contains("empty", ex.Message);
+        http.Dispose();
+    }
+
+    [Fact]
     public async Task GetDiaryInfo_NoDiaryEntries_ReturnsEmpty()
     {
         var handler = new ScraperMockHandler((request, http) =>

--- a/LetterboxdSync.Tests/SidebarControllerTests.cs
+++ b/LetterboxdSync.Tests/SidebarControllerTests.cs
@@ -1,0 +1,24 @@
+using LetterboxdSync.Api;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Serves the embedded sidebar.js asset. The script is compiled into the plugin
+/// assembly as an embedded resource, so the happy path returns it as JavaScript.
+/// </summary>
+public class SidebarControllerTests
+{
+    [Fact]
+    public void GetSidebarJs_EmbeddedResourcePresent_ReturnsJavaScriptFile()
+    {
+        var controller = new SidebarController();
+
+        var result = controller.GetSidebarJs();
+
+        var file = Assert.IsType<FileStreamResult>(result);
+        Assert.Equal("application/javascript", file.ContentType);
+        Assert.True(file.FileStream.Length > 0, "embedded sidebar.js should not be empty");
+    }
+}

--- a/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
@@ -527,4 +527,344 @@ public class WatchlistSyncRunnerTests : IDisposable
             Plugin.Instance!.Configuration.JellyseerrApiKey = null;
         }
     }
+
+    // ----- SyncGate contention -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_GateAlreadyHeld_ReturnsFalse()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        // Simulate another scrape already in progress by taking the global gate.
+        Assert.True(await SyncGate.Instance.WaitAsync(0));
+        try
+        {
+            var ok = await _runner.TryRunForUserAsync(userId, "manual",
+                new Progress<double>(), CancellationToken.None);
+
+            Assert.False(ok);
+            // Refused before doing any work.
+            _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    [Fact]
+    public async Task RunForAllAsync_GateAlreadyHeld_SkipsImmediately()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        Assert.True(await SyncGate.Instance.WaitAsync(0));
+        try
+        {
+            await _runner.RunForAllAsync(new Progress<double>(), "scheduled", CancellationToken.None);
+
+            // Gate was held, so the scheduled run is a no-op.
+            _userManager.DidNotReceive().GetUsers();
+            _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        }
+        finally
+        {
+            SyncGate.Instance.Release();
+        }
+    }
+
+    // ----- RunForAllAsync: real fan-out -----
+
+    [Fact]
+    public async Task RunForAllAsync_RealUserWithMatch_CreatesPlaylist()
+    {
+        // Exercises the actual per-(user, account) sync loop in RunForAllAsync, not just
+        // the empty/skipped short-circuits the other RunForAll tests cover.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int> { 1233413 });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        var movie = MakeMovie(1233413);
+        // First query → movies; second query → existing playlists (none) → create path.
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>())
+            .Returns(new List<BaseItem> { movie }, new List<BaseItem>());
+
+        await _runner.RunForAllAsync(new Progress<double>(), "scheduled", CancellationToken.None);
+
+        await _playlistManager.Received(1).CreatePlaylist(Arg.Is<PlaylistCreationRequest>(
+            req => req.UserId == user.Id && req.ItemIdList.Contains(movie.Id)));
+    }
+
+    // ----- Named-account targeting -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_NamedAccountNotFound_ReturnsFalse()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId); // username "lb-user"
+
+        // Caller asks for a Letterboxd account that isn't configured for this user.
+        var ok = await _runner.TryRunForUserAsync(userId, "manual",
+            new Progress<double>(), CancellationToken.None, letterboxdUsername: "someone-else");
+
+        Assert.False(ok);
+        _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_NamedAccountFound_RunsThatAccountOnly()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId); // username "lb-user"
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int>());
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var ok = await _runner.TryRunForUserAsync(userId, "manual",
+            new Progress<double>(), CancellationToken.None, letterboxdUsername: "lb-user");
+
+        Assert.True(ok);
+        await service.Received(1).GetWatchlistTmdbIdsAsync("lb-user");
+    }
+
+    // ----- Jellyseerr auto-request -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_AutoRequest_RequestsUnmatchedFilm()
+    {
+        // Account auto-requests, the watchlist film is NOT in the library, Jellyseerr is
+        // configured → the runner should POST a movie request for the unmatched TMDb id.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId, autoRequest: true);
+
+        Plugin.Instance!.Configuration.JellyseerrUrl = "http://jellyseerr.test";
+        Plugin.Instance!.Configuration.JellyseerrApiKey = "key";
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int> { 1233413 });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        // Library has nothing matching → film is unmatched → eligible for auto-request.
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var handler = new JellyseerrHandler(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (req.Method == HttpMethod.Get && path.EndsWith("/api/v1/user"))
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent(
+                        "{\"results\":[{\"id\":7,\"jellyfinUserId\":\"" + user.Id.ToString("N") + "\"}]}")
+                };
+            // Movie status pre-check returns no mediaInfo → status null → POST proceeds.
+            if (req.Method == HttpMethod.Get && path.Contains("/api/v1/movie/"))
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent("{}")
+                };
+            if (req.Method == HttpMethod.Post && path.EndsWith("/api/v1/request"))
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.Created);
+            return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+        });
+        WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
+            new JellyseerrClient(url, key, log, handler);
+        try
+        {
+            var ok = await _runner.TryRunForUserAsync(userId, "test",
+                new Progress<double>(), CancellationToken.None);
+
+            Assert.True(ok);
+            Assert.Contains(handler.Calls, r =>
+                r.Method == HttpMethod.Post && r.RequestUri!.AbsolutePath.EndsWith("/api/v1/request"));
+        }
+        finally
+        {
+            WatchlistSyncRunner.JellyseerrClientFactoryOverride = null;
+            Plugin.Instance!.Configuration.JellyseerrUrl = null;
+            Plugin.Instance!.Configuration.JellyseerrApiKey = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_AutoRequest_TalliesAlreadyExistsFailedAndErrored()
+    {
+        // Three unmatched films exercise every RequestResult branch plus the per-film
+        // exception catch: one already on Jellyseerr (skipped), one POST that 500s
+        // (Failed), and one whose POST throws (errored). The run must absorb all of it.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId, autoRequest: true);
+
+        Plugin.Instance!.Configuration.JellyseerrUrl = "http://jellyseerr.test";
+        Plugin.Instance!.Configuration.JellyseerrApiKey = "key";
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int> { 100, 200, 300 });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var handler = new JellyseerrHandler(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (req.Method == HttpMethod.Get && path.EndsWith("/api/v1/user"))
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent(
+                        "{\"results\":[{\"id\":7,\"jellyfinUserId\":\"" + user.Id.ToString("N") + "\"}]}")
+                };
+            if (req.Method == HttpMethod.Get && path.EndsWith("/api/v1/movie/100"))
+                // Status 5 (available) → pre-check returns AlreadyExists, no POST.
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent("{\"mediaInfo\":{\"status\":5}}")
+                };
+            if (req.Method == HttpMethod.Get && path.Contains("/api/v1/movie/"))
+                // 200 and 300 have no media record → status null → proceed to POST.
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent("{}")
+                };
+            if (req.Method == HttpMethod.Post && path.EndsWith("/api/v1/request"))
+            {
+                var body = req.Content!.ReadAsStringAsync().Result;
+                if (body.Contains("\"mediaId\":300"))
+                    throw new System.Net.Http.HttpRequestException("connection reset");
+                // 200 → server error → RequestResult.Failed.
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError);
+            }
+            return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+        });
+        WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
+            new JellyseerrClient(url, key, log, handler);
+        try
+        {
+            var ok = await _runner.TryRunForUserAsync(userId, "test",
+                new Progress<double>(), CancellationToken.None);
+
+            // The loop swallows every per-film outcome and completes successfully.
+            Assert.True(ok);
+            // Film 100 was already available, so only 200 and 300 should reach a POST.
+            Assert.Equal(2, handler.Calls.Count(r =>
+                r.Method == HttpMethod.Post && r.RequestUri!.AbsolutePath.EndsWith("/api/v1/request")));
+        }
+        finally
+        {
+            WatchlistSyncRunner.JellyseerrClientFactoryOverride = null;
+            Plugin.Instance!.Configuration.JellyseerrUrl = null;
+            Plugin.Instance!.Configuration.JellyseerrApiKey = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_JellyseerrUserMapErrors_SkipsGracefully()
+    {
+        // The Jellyseerr user-map fetch fails (500). The runner must log and bail out of
+        // the Jellyseerr branch without throwing, posting, or deleting anything.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId, autoRequest: true);
+
+        Plugin.Instance!.Configuration.JellyseerrUrl = "http://jellyseerr.test";
+        Plugin.Instance!.Configuration.JellyseerrApiKey = "key";
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int> { 1233413 });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var handler = new JellyseerrHandler(_ =>
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError));
+        WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
+            new JellyseerrClient(url, key, log, handler);
+        try
+        {
+            var ok = await _runner.TryRunForUserAsync(userId, "test",
+                new Progress<double>(), CancellationToken.None);
+
+            Assert.True(ok);
+            Assert.DoesNotContain(handler.Calls, r => r.Method == HttpMethod.Post);
+        }
+        finally
+        {
+            WatchlistSyncRunner.JellyseerrClientFactoryOverride = null;
+            Plugin.Instance!.Configuration.JellyseerrUrl = null;
+            Plugin.Instance!.Configuration.JellyseerrApiKey = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_MirrorOnNonPrimaryAccount_SkipsMirror()
+    {
+        // Two accounts on one Jellyfin user, both with mirror on. Only the primary owns
+        // the Jellyseerr-watchlist destination, so running the secondary must not POST or
+        // DELETE against the Jellyseerr watchlist (would clobber the primary's diff).
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId, LetterboxdUsername = "primary-lb", LetterboxdPassword = "x",
+            Enabled = true, EnableWatchlistSync = true, MirrorJellyseerrWatchlist = true, IsPrimary = true
+        });
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId, LetterboxdUsername = "secondary-lb", LetterboxdPassword = "x",
+            Enabled = true, EnableWatchlistSync = true, MirrorJellyseerrWatchlist = true, IsPrimary = false
+        });
+
+        Plugin.Instance!.Configuration.JellyseerrUrl = "http://jellyseerr.test";
+        Plugin.Instance!.Configuration.JellyseerrApiKey = "key";
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetWatchlistTmdbIdsAsync(Arg.Any<string>()).Returns(new List<int> { 1233413 });
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
+
+        var handler = new JellyseerrHandler(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (req.Method == HttpMethod.Get && path.EndsWith("/api/v1/user"))
+                return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent(
+                        "{\"results\":[{\"id\":7,\"jellyfinUserId\":\"" + user.Id.ToString("N") + "\"}]}")
+                };
+            return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new System.Net.Http.StringContent("{\"results\":[]}")
+            };
+        });
+        WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
+            new JellyseerrClient(url, key, log, handler);
+        try
+        {
+            // Target only the non-primary account.
+            var ok = await _runner.TryRunForUserAsync(userId, "test",
+                new Progress<double>(), CancellationToken.None, letterboxdUsername: "secondary-lb");
+
+            Assert.True(ok);
+            // Secondary must not mirror: no watchlist add/remove.
+            Assert.DoesNotContain(handler.Calls, r =>
+                r.Method == HttpMethod.Post && r.RequestUri!.AbsolutePath.EndsWith("/api/v1/watchlist"));
+            Assert.DoesNotContain(handler.Calls, r => r.Method == HttpMethod.Delete);
+        }
+        finally
+        {
+            WatchlistSyncRunner.JellyseerrClientFactoryOverride = null;
+            Plugin.Instance!.Configuration.JellyseerrUrl = null;
+            Plugin.Instance!.Configuration.JellyseerrApiKey = null;
+        }
+    }
 }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.3.0</AssemblyVersion>
-    <FileVersion>1.13.3.0</FileVersion>
+    <AssemblyVersion>1.13.4.0</AssemblyVersion>
+    <FileVersion>1.13.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Adds 45 tests (470 to 515 passing) across the sync engines, controller, and API/Jellyseerr/scraper clients. Lifts coverage from 82.0% line / 73.5% branch to 89.8% line / 81.4% branch. Tests-only, no production behaviour changes, plus a 1.13.3.0 to 1.13.4.0 patch bump to clear the CI version-gate.

## Coverage added

- **WatchlistSyncRunner**: SyncGate contention (held gate skips), real-user match creates playlist, named-account targeting, auto-request branches (requests unmatched film; tallies already-exists / failed / errored via scripted Jellyseerr handler), Jellyseerr user-map errors, non-primary-account mirror skip.
- **LetterboxdSyncRunner**: SyncGate contention, named-account found/not-found, skip-previously-synced filters all with no auth attempt, stop-on-failure halts after first failure, local recent-sync history suppresses duplicate.
- **LetterboxdController**: GetLogs missing-dir, StartSync conflict + named-account, StartWatchlistSync no-user/conflict/named-account, TestConnection success+failure, PostReview named-account targeting and rating mirrored into Jellyfin user data.
- **SidebarController** (new): embedded sidebar.js served as application/javascript.
- **ApiClient gaps** (new): not-authenticated guards, 400/401 handling, token refresh + refresh-failure fallback, DeleteAllLogEntriesForFilm, slug fallback.
- **JellyseerrClient**: watchlist add/remove server-error paths, fetch-fails-returns-empty, transport-throws-returns-null.
- **Scraper**: malformed postered-identifier JSON swallowed, empty film-id throws.

## Verification

`dotnet test -c Release`: 515 passed, 0 failed, 11 skipped (live-network integration tests).