### PR TITLE
fix(sync): stop phantom daily rewatches and endless retries of failing films

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.13.3.0</Version>
-        <AssemblyVersion>1.13.3.0</AssemblyVersion>
-        <FileVersion>1.13.3.0</FileVersion>
+        <Version>1.14.0.0</Version>
+        <AssemblyVersion>1.14.0.0</AssemblyVersion>
+        <FileVersion>1.14.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -187,6 +187,8 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var movie = MakeMovie(1233413);
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow });
 
         LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
             throw new Exception("auth failed");
@@ -286,6 +288,9 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var movie = MakeMovie(1233413);
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        // Real watch today so viewingDate is today and matches the diary entry below.
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.Now });
 
         // Diary already has an entry for today → IsDuplicate = true → MarkAsWatched is NOT called.
         var service = Substitute.For<ILetterboxdService>();
@@ -313,6 +318,8 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var movie = MakeMovie(1233413);
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow });
 
         var service = Substitute.For<ILetterboxdService>();
         service.LookupFilmByTmdbIdAsync(Arg.Any<int>())
@@ -341,6 +348,8 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var movie = MakeMovie(1233413);
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow });
 
         // Letterboxd lookup throws (e.g. Cloudflare 403). Runner should catch,
         // record a failed sync event, and complete — exception doesn't escape.
@@ -472,5 +481,115 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         Assert.True(ok);
         Assert.True(factoryHit, "real playback after diary import should re-enable export");
+    }
+
+    // ----- No-watch-date suppression (generalises the issue #32 fix) -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_PlayedFilmWithoutLastPlayedDate_NotImported_DoesNotExport()
+    {
+        // A film marked played on Jellyfin (manually, or before tracking) with no
+        // LastPlayedDate and no diary-import marker. viewingDate would otherwise default to
+        // today and drift, posting a phantom rewatch on every other run. The runner must
+        // skip it outright until a real play date exists.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = null });
+
+        var factoryHit = false;
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(Substitute.For<ILetterboxdService>());
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.False(factoryHit);
+    }
+
+    // ----- Repeated-failure abandonment -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_FilmWithMaxConsecutiveFailures_NotRetried()
+    {
+        // A film that has failed MaxConsecutiveSyncFailures times in a row must be left
+        // alone, not re-queued (and certainly not prioritised) every run.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        // A real watch date, so only the failure-abandon filter can remove it.
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow });
+
+        for (var i = 0; i < LetterboxdSyncRunner.MaxConsecutiveSyncFailures; i++)
+            SyncHistory.Record(new SyncEvent
+            {
+                FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
+                Timestamp = DateTime.UtcNow.AddMinutes(-i), Status = SyncStatus.Failed
+            });
+
+        var factoryHit = false;
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(Substitute.For<ILetterboxdService>());
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.False(factoryHit);
+    }
+
+    [Fact]
+    public async Task TryRunForUserAsync_FilmBelowFailureThreshold_StillRetried()
+    {
+        // One fewer than the threshold: still worth another attempt (could be a transient
+        // Cloudflare/rate-limit error), so the runner must get past the abandon filter.
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+        _userDataManager.GetUserData(user, movie).Returns(
+            new UserItemData { Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow });
+
+        for (var i = 0; i < LetterboxdSyncRunner.MaxConsecutiveSyncFailures - 1; i++)
+            SyncHistory.Record(new SyncEvent
+            {
+                FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
+                Timestamp = DateTime.UtcNow.AddMinutes(-i), Status = SyncStatus.Failed
+            });
+
+        var factoryHit = false;
+        var service = Substitute.For<ILetterboxdService>();
+        // Throw on lookup so we don't sit through the runner's inter-call delay; we only
+        // care that the film survived the abandon filter and reached authentication.
+        service.LookupFilmByTmdbIdAsync(Arg.Any<int>())
+            .Returns<Task<FilmResult>>(_ => throw new Exception("stop here"));
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(service);
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(factoryHit, "a film below the failure threshold should still be retried");
     }
 }

--- a/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
+++ b/LetterboxdSync.Tests/SyncHistoryLookupTests.cs
@@ -229,4 +229,66 @@ public class SyncHistoryLookupTests
 
         Assert.True(SyncHistory.WasImportedFromDiary(events, User, FilmA));
     }
+
+    [Fact]
+    public void GetConsecutiveFailureCount_ZeroOnEmptyHistory()
+    {
+        Assert.Equal(0, SyncHistory.GetConsecutiveFailureCount(new List<SyncEvent>(), User, FilmA));
+    }
+
+    [Fact]
+    public void GetConsecutiveFailureCount_CountsTrailingFailures()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 1)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 2)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 3)),
+        };
+
+        Assert.Equal(3, SyncHistory.GetConsecutiveFailureCount(events, User, FilmA));
+    }
+
+    [Fact]
+    public void GetConsecutiveFailureCount_StopsAtMostRecentNonFailure()
+    {
+        // A later success breaks the streak: only failures after it count, and here there
+        // are none, so the film is no longer considered a repeat-failure.
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 1)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 2)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Success, recordedAt: new DateTime(2026, 4, 3)),
+        };
+
+        Assert.Equal(0, SyncHistory.GetConsecutiveFailureCount(events, User, FilmA));
+    }
+
+    [Fact]
+    public void GetConsecutiveFailureCount_CountsOnlyFailuresAfterLastSuccess()
+    {
+        // Failures, then a success that resets the streak, then fresh failures: only the
+        // post-success failures count toward abandoning the film.
+        var events = new List<SyncEvent>
+        {
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 1)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Success, recordedAt: new DateTime(2026, 4, 2)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 3)),
+            Event(User, FilmA, ViewedToday, SyncStatus.Failed, recordedAt: new DateTime(2026, 4, 4)),
+        };
+
+        Assert.Equal(2, SyncHistory.GetConsecutiveFailureCount(events, User, FilmA));
+    }
+
+    [Fact]
+    public void GetConsecutiveFailureCount_IgnoresOtherUsersAndFilms()
+    {
+        var events = new List<SyncEvent>
+        {
+            Event(OtherUser, FilmA, ViewedToday, SyncStatus.Failed),
+            Event(User, FilmB, ViewedToday, SyncStatus.Failed),
+        };
+
+        Assert.Equal(0, SyncHistory.GetConsecutiveFailureCount(events, User, FilmA));
+    }
 }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.3.0</AssemblyVersion>
-    <FileVersion>1.13.3.0</FileVersion>
+    <AssemblyVersion>1.14.0.0</AssemblyVersion>
+    <FileVersion>1.14.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -42,6 +42,13 @@ public class LetterboxdSyncRunner
 
     public static bool IsRunning => SyncGate.IsRunning;
 
+    /// <summary>
+    /// After this many consecutive Failed sync events for the same film, stop retrying it.
+    /// Rides out transient errors (Cloudflare 403, rate limits) over a few runs, then gives
+    /// up so a permanently unsyncable film doesn't sit at the head of the queue forever.
+    /// </summary>
+    internal const int MaxConsecutiveSyncFailures = 3;
+
     private static PluginConfiguration Config => Plugin.Instance!.Configuration;
 
     public async Task RunForAllAsync(IProgress<double> progress, string source, CancellationToken cancellationToken)
@@ -179,34 +186,52 @@ public class LetterboxdSyncRunner
             return;
         }
 
-        // Suppress films that DiaryImportTask marked played from the user's Letterboxd
-        // diary, unless they've since been actually watched on Jellyfin (LastPlayedDate
-        // set). Without this, the daily sync would invent a phantom rewatch every time
-        // it ran for the same imported film, because viewingDate defaults to today
-        // when LastPlayedDate is null and the LB-side same-day duplicate check
-        // therefore never matches the original (older) diary date. See issue #32.
-        var skippedDiaryImports = 0;
+        // Skip films marked played on Jellyfin that have no LastPlayedDate. There's no real
+        // watch date to log: viewingDate would otherwise fall back to DateTime.Now (today),
+        // which drifts forward on every run and slips past every same-date duplicate check,
+        // posting a phantom rewatch to Letterboxd roughly every other day. Wait until Jellyfin
+        // records an actual play date. This also closes the import-then-export loop from
+        // issue #32 — DiaryImportTask marks films played without a LastPlayedDate.
+        var skippedNoPlayDate = 0;
         movies = movies.Where(m =>
         {
-            var tmdbStr = m.GetProviderId(MetadataProvider.Tmdb);
-            if (!int.TryParse(tmdbStr, out var tmdbId)) return true;
-
             var ud = _userDataManager.GetUserData(user, m);
             if (ud?.LastPlayedDate.HasValue == true) return true;
+            skippedNoPlayDate++;
+            return false;
+        }).ToList();
 
-            if (SyncHistory.WasImportedFromDiary(user.Username ?? string.Empty, tmdbId))
+        if (skippedNoPlayDate > 0)
+            _logger.LogInformation(
+                "Skipping {Count} films for {Username}: marked played but no LastPlayedDate (no real watch date to log)",
+                skippedNoPlayDate, user.Username);
+
+        if (movies.Count == 0)
+        {
+            SyncProgress.Complete();
+            return;
+        }
+
+        // Abandon films that have failed to sync repeatedly. BuildSyncQueue pushes
+        // previously-failed films to the head of the queue, so a film that fails every run
+        // (not on Letterboxd, bad TMDb match, region-locked) would retry forever. After
+        // MaxConsecutiveSyncFailures consecutive failures, leave it alone.
+        var abandonedFailures = 0;
+        movies = movies.Where(m =>
+        {
+            if (!int.TryParse(m.GetProviderId(MetadataProvider.Tmdb), out var tmdbId)) return true;
+            if (SyncHistory.GetConsecutiveFailureCount(user.Username ?? string.Empty, tmdbId) >= MaxConsecutiveSyncFailures)
             {
-                skippedDiaryImports++;
+                abandonedFailures++;
                 return false;
             }
             return true;
         }).ToList();
 
-        if (skippedDiaryImports > 0)
+        if (abandonedFailures > 0)
             _logger.LogInformation(
-                "Skipping {Count} films for {Username}: previously imported from Letterboxd diary " +
-                "and not played on Jellyfin since",
-                skippedDiaryImports, user.Username);
+                "Skipping {Count} films for {Username}: {Threshold}+ consecutive sync failures, no longer retrying",
+                abandonedFailures, user.Username, MaxConsecutiveSyncFailures);
 
         if (movies.Count == 0)
         {

--- a/LetterboxdSync/SyncHistory.cs
+++ b/LetterboxdSync/SyncHistory.cs
@@ -249,6 +249,35 @@ public static class SyncHistory
         return latest?.Status;
     }
 
+    /// <summary>
+    /// Number of consecutive Failed events at the tail of this user/film's history
+    /// (most recent first), stopping at the first non-Failed event. The runner uses this
+    /// to abandon a film that fails on every run instead of retrying it indefinitely —
+    /// BuildSyncQueue otherwise pushes previously-failed films to the head of the queue.
+    /// </summary>
+    public static int GetConsecutiveFailureCount(string username, int tmdbId)
+    {
+        lock (_lock)
+        {
+            return GetConsecutiveFailureCount(LoadEvents(), username, tmdbId);
+        }
+    }
+
+    internal static int GetConsecutiveFailureCount(IEnumerable<SyncEvent> events, string username, int tmdbId)
+    {
+        var ordered = events
+            .Where(e => e.TmdbId == tmdbId && string.Equals(e.Username, username, StringComparison.Ordinal))
+            .OrderByDescending(e => e.Timestamp);
+
+        var count = 0;
+        foreach (var e in ordered)
+        {
+            if (e.Status != SyncStatus.Failed) break;
+            count++;
+        }
+        return count;
+    }
+
     internal static bool WasSuccessfullySynced(IEnumerable<SyncEvent> events, string username, int tmdbId, DateTime viewingDate)
     {
         var target = viewingDate.Date;


### PR DESCRIPTION
Two user-reported sync bugs, both rooted in the dedup logic in `LetterboxdSyncRunner.SyncOneUserAsync`.

## Problem 1, film reported as watched every day

A film marked played on Jellyfin but with no `LastPlayedDate` (manually marked, or played before tracking) had its viewing date fall back to `DateTime.Now` (today). "Today" drifts forward each run and slips past every same-date duplicate check, so the runner re-logged the film to Letterboxd roughly every other day as a phantom rewatch.

The previous issue-#32 guard only suppressed films that `DiaryImportTask` imported; locally marked-watched films still fell through.

**Fix:** generalise the suppression. Any played film with no `LastPlayedDate` is skipped entirely, since there is no real watch date to log. It will sync once Jellyfin records an actual play date. This also still covers the issue-#32 import-then-export loop.

## Problem 2, failing film retried every day

A `Failed` sync event was never suppressed, and `BuildSyncQueue` puts previously-failed films at the head of the queue. A film that fails every run (not on Letterboxd, bad TMDb match, region-locked) retried forever.

**Fix:** new `SyncHistory.GetConsecutiveFailureCount` (trailing run of `Failed` events, resets at the first non-failure) plus a pre-queue filter gated by `MaxConsecutiveSyncFailures = 3`. After 3 failures in a row the film is left alone. A later success resets the streak so a film that recovers is not permanently abandoned. Three attempts ride out transient Cloudflare/rate-limit errors before giving up.

## Behaviour change

Films that previously synced via the moving-today fallback (no real `LastPlayedDate`) now skip until they have a genuine play date. Hence the minor version bump (1.13.3.0 to 1.14.0.0).

## Tests

- Updated 4 runner tests that used null user-data as shorthand for "watched" to set a real `LastPlayedDate`, so they still exercise the deep path.
- Added 3 runner tests: non-diary null-date suppression, at-threshold not retried, below-threshold still retried.
- Added 5 `SyncHistory` tests for the consecutive-failure counter.
- Full suite: 478 passed, 11 pre-existing skips, 0 failures.