### PR TITLE
feat: backfill attributed Jellyseerr requests for already-available watchlist films

### DIFF
--- a/LetterboxdSync.Tests/JellyseerrClientTests.cs
+++ b/LetterboxdSync.Tests/JellyseerrClientTests.cs
@@ -120,6 +120,103 @@ public class JellyseerrClientTests
     }
 
     [Fact]
+    public async Task RequestMovieAsync_Backfill_AvailableWithNoRequest_PostsAttributedRequest()
+    {
+        // The backfill case: media is AVAILABLE (status 5) but nobody has a request for it
+        // (entered the library outside Jellyseerr). Backfill mode must still POST so a requester
+        // trail exists. Default mode would have skipped on status 5.
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100,\"mediaInfo\":{\"status\":5,\"requests\":[]}}");
+
+            if (req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/request"))
+            {
+                posted = true;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
+
+        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.True(posted, "backfill should request an available title that has no request");
+    }
+
+    [Fact]
+    public async Task RequestMovieAsync_Backfill_UserAlreadyHasRequest_DoesNotPost()
+    {
+        // Per-user dedup: if THIS user (7) already holds a request, backfill must not pile on.
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100,\"mediaInfo\":{\"status\":5,\"requests\":[{\"requestedBy\":{\"id\":7}}]}}");
+
+            if (req.Method == HttpMethod.Post) posted = true;
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
+
+        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.False(posted, "backfill must not duplicate this user's own request");
+    }
+
+    [Fact]
+    public async Task RequestMovieAsync_Backfill_AvailableButOtherUserRequested_PostsForThisUser()
+    {
+        // Another user (9) has a request; user 7 still gets their own attributed request when
+        // Jellyseerr accepts it. (If Jellyseerr's single-active-request rule rejects it, the
+        // POST 409 path classifies it AlreadyExists — covered separately.)
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100,\"mediaInfo\":{\"status\":5,\"requests\":[{\"requestedBy\":{\"id\":9}}]}}");
+
+            if (req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/request"))
+            {
+                posted = true;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
+
+        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.True(posted);
+    }
+
+    [Fact]
+    public async Task RequestMovieAsync_Backfill_Blocklisted_DoesNotPost()
+    {
+        var posted = false;
+        var handler = new SeerrHandler(req =>
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/movie/100"))
+                return JsonResponse("{\"id\":100,\"mediaInfo\":{\"status\":6,\"requests\":[]}}"); // BLOCKLISTED
+
+            if (req.Method == HttpMethod.Post) posted = true;
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
+
+        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.False(posted, "blocklisted media must never be requested");
+    }
+
+    [Fact]
     public async Task GetUserWatchlistTmdbIdsAsync_PaginatesViaPageParamAndFiltersToMovies()
     {
         // Jellyseerr paginates the user-watchlist endpoint with `page=N`, NOT take/skip

--- a/LetterboxdSync/Api/AccountUpdateRequest.cs
+++ b/LetterboxdSync/Api/AccountUpdateRequest.cs
@@ -26,6 +26,8 @@ public class AccountUpdateRequest
 
     public bool AutoRequestWatchlist { get; set; }
 
+    public bool BackfillAvailableRequests { get; set; }
+
     public bool MirrorJellyseerrWatchlist { get; set; }
 
     public bool SkipPreviouslySynced { get; set; } = true;

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -249,6 +249,7 @@ public class LetterboxdController : ControllerBase
             enableWatchlistSync = account.EnableWatchlistSync,
             enableDiaryImport = account.EnableDiaryImport,
             autoRequestWatchlist = account.AutoRequestWatchlist,
+            backfillAvailableRequests = account.BackfillAvailableRequests,
             mirrorJellyseerrWatchlist = account.MirrorJellyseerrWatchlist,
             skipPreviouslySynced = account.SkipPreviouslySynced,
             stopOnFailure = account.StopOnFailure,
@@ -283,6 +284,7 @@ public class LetterboxdController : ControllerBase
         account.EnableWatchlistSync = request.EnableWatchlistSync;
         account.EnableDiaryImport = request.EnableDiaryImport;
         account.AutoRequestWatchlist = request.AutoRequestWatchlist;
+        account.BackfillAvailableRequests = request.BackfillAvailableRequests;
         account.MirrorJellyseerrWatchlist = request.MirrorJellyseerrWatchlist;
         account.SkipPreviouslySynced = request.SkipPreviouslySynced;
         account.StopOnFailure = request.StopOnFailure;
@@ -331,6 +333,7 @@ public class LetterboxdController : ControllerBase
                 enableWatchlistSync = a.EnableWatchlistSync,
                 enableDiaryImport = a.EnableDiaryImport,
                 autoRequestWatchlist = a.AutoRequestWatchlist,
+                backfillAvailableRequests = a.BackfillAvailableRequests,
                 mirrorJellyseerrWatchlist = a.MirrorJellyseerrWatchlist,
                 skipPreviouslySynced = a.SkipPreviouslySynced,
                 stopOnFailure = a.StopOnFailure,
@@ -391,6 +394,7 @@ public class LetterboxdController : ControllerBase
                 EnableWatchlistSync = req.EnableWatchlistSync,
                 EnableDiaryImport = req.EnableDiaryImport,
                 AutoRequestWatchlist = req.AutoRequestWatchlist,
+                BackfillAvailableRequests = req.BackfillAvailableRequests,
                 MirrorJellyseerrWatchlist = req.MirrorJellyseerrWatchlist,
                 SkipPreviouslySynced = req.SkipPreviouslySynced,
                 StopOnFailure = req.StopOnFailure,

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -28,6 +28,16 @@ public class Account
 
     public bool AutoRequestWatchlist { get; set; }
 
+    /// <summary>
+    /// When true, <see cref="AutoRequestWatchlist"/> also creates an attributed Jellyseerr
+    /// request for watchlisted films that are already in the library / available, as long as
+    /// this user has no existing request for them. This backfills a requester trail for films
+    /// that entered the library outside Jellyseerr (manual Radarr add, deleted request, etc.)
+    /// so "who wanted this?" is answerable. Off by default: it creates request rows for
+    /// already-available media (harmless for downloads, Radarr already has the file).
+    /// </summary>
+    public bool BackfillAvailableRequests { get; set; }
+
     public bool MirrorJellyseerrWatchlist { get; set; }
 
     public bool SkipPreviouslySynced { get; set; } = true;

--- a/LetterboxdSync/JellyseerrClient.cs
+++ b/LetterboxdSync/JellyseerrClient.cs
@@ -95,7 +95,18 @@ public class JellyseerrClient : IDisposable
     /// 6=BLOCKLISTED, 7=DELETED.
     /// </summary>
     public async Task<int?> GetMovieMediaStatusAsync(int tmdbId)
+        => (await GetMovieInfoAsync(tmdbId).ConfigureAwait(false)).Status;
+
+    /// <summary>
+    /// Single movie lookup returning both the Jellyseerr MediaStatus and the set of Jellyseerr
+    /// user IDs that already have a request for the title. Status is null when Jellyseerr has no
+    /// record of the title (safe to request) or the call fails; the requester set is empty in
+    /// those cases. Status enum: 1=UNKNOWN, 2=PENDING, 3=PROCESSING, 4=PARTIALLY_AVAILABLE,
+    /// 5=AVAILABLE, 6=BLOCKLISTED, 7=DELETED.
+    /// </summary>
+    private async Task<(int? Status, HashSet<int> RequesterUserIds)> GetMovieInfoAsync(int tmdbId)
     {
+        var requesters = new HashSet<int>();
         var url = $"{_baseUrl}/api/v1/movie/{tmdbId}";
         try
         {
@@ -104,26 +115,41 @@ public class JellyseerrClient : IDisposable
             {
                 _logger.LogDebug("Jellyseerr movie lookup non-success for TMDb {TmdbId}: {Status}",
                     tmdbId, (int)response.StatusCode);
-                return null;
+                return (null, requesters);
             }
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.TryGetProperty("mediaInfo", out var mediaInfo) ||
                 mediaInfo.ValueKind != JsonValueKind.Object)
-                return null;
+                return (null, requesters);
 
-            if (!mediaInfo.TryGetProperty("status", out var statusEl) ||
-                statusEl.ValueKind != JsonValueKind.Number)
-                return null;
+            int? status = null;
+            if (mediaInfo.TryGetProperty("status", out var statusEl) &&
+                statusEl.ValueKind == JsonValueKind.Number)
+                status = statusEl.GetInt32();
 
-            return statusEl.GetInt32();
+            // mediaInfo.requests[].requestedBy.id — who already has a request for this title.
+            if (mediaInfo.TryGetProperty("requests", out var requests) &&
+                requests.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var req in requests.EnumerateArray())
+                {
+                    if (req.TryGetProperty("requestedBy", out var by) &&
+                        by.ValueKind == JsonValueKind.Object &&
+                        by.TryGetProperty("id", out var reqUserId) &&
+                        reqUserId.ValueKind == JsonValueKind.Number)
+                        requesters.Add(reqUserId.GetInt32());
+                }
+            }
+
+            return (status, requesters);
         }
         catch (Exception ex)
         {
             _logger.LogDebug("Jellyseerr movie lookup errored for TMDb {TmdbId}: {Message}",
                 tmdbId, ex.Message);
-            return null;
+            return (null, requesters);
         }
     }
 
@@ -141,19 +167,50 @@ public class JellyseerrClient : IDisposable
 
     /// <summary>
     /// Creates a movie request in Jellyseerr for the given TMDb ID, attributed to the given Jellyseerr user.
-    /// Pre-checks the media status and skips the POST when Jellyseerr already has a record of the title;
-    /// without this guard Jellyseerr cheerfully creates a duplicate request every run for items already
-    /// pending / processing / available, instead of returning 409.
+    /// <para>
+    /// Default (<paramref name="backfillAvailable"/> false): pre-checks media status and skips the POST when
+    /// Jellyseerr already has a record of the title (pending / processing / available), so re-runs don't pile
+    /// up duplicates for films the library already covers.
+    /// </para>
+    /// <para>
+    /// Backfill (<paramref name="backfillAvailable"/> true): skips only when the title is blocklisted or THIS
+    /// user already has a request for it. Available titles with no request from this user are still requested —
+    /// Jellyseerr 3.x accepts a request for available media as long as no active request exists, which restores
+    /// an attributed requester trail for films that entered the library outside Jellyseerr. If another user
+    /// holds the single active request, Jellyseerr returns 409 and we report <see cref="RequestResult.AlreadyExists"/>.
+    /// </para>
     /// </summary>
-    public async Task<RequestResult> RequestMovieAsync(int tmdbId, int jellyseerrUserId)
+    public async Task<RequestResult> RequestMovieAsync(int tmdbId, int jellyseerrUserId, bool backfillAvailable = false)
     {
-        var existingStatus = await GetMovieMediaStatusAsync(tmdbId).ConfigureAwait(false);
-        // Re-request DELETED (7); skip everything else above UNKNOWN (1).
-        if (existingStatus.HasValue && existingStatus.Value > 1 && existingStatus.Value != 7)
+        var (status, requesters) = await GetMovieInfoAsync(tmdbId).ConfigureAwait(false);
+
+        // Never request blocklisted media (6), regardless of mode.
+        if (status == 6)
         {
-            _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: already has status {Status}",
-                tmdbId, existingStatus.Value);
+            _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: blocklisted", tmdbId);
             return RequestResult.AlreadyExists;
+        }
+
+        if (backfillAvailable)
+        {
+            // Only this user's own existing request blocks a backfill; an available-but-unrequested
+            // title is exactly what we want to attribute.
+            if (requesters.Contains(jellyseerrUserId))
+            {
+                _logger.LogDebug("Skipping Jellyseerr backfill for TMDb {TmdbId}: user {UserId} already has a request",
+                    tmdbId, jellyseerrUserId);
+                return RequestResult.AlreadyExists;
+            }
+        }
+        else
+        {
+            // Re-request DELETED (7); skip everything else above UNKNOWN (1).
+            if (status.HasValue && status.Value > 1 && status.Value != 7)
+            {
+                _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: already has status {Status}",
+                    tmdbId, status.Value);
+                return RequestResult.AlreadyExists;
+            }
         }
 
         var url = $"{_baseUrl}/api/v1/request";
@@ -165,10 +222,11 @@ public class JellyseerrClient : IDisposable
             return RequestResult.Requested;
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        // Belt-and-braces: Jellyseerr returns 409 when already requested; treat as a no-op.
+        // Belt-and-braces: Jellyseerr returns 409 when an active request already exists; treat as a no-op.
         if ((int)response.StatusCode == 409 ||
             responseBody.Contains("REQUEST_EXISTS", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already requested", StringComparison.OrdinalIgnoreCase) ||
+            responseBody.Contains("already exists", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already available", StringComparison.OrdinalIgnoreCase))
         {
             _logger.LogDebug("Jellyseerr already has request for TMDb {TmdbId} (user {UserId}): {Body}",

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.13.4.0</AssemblyVersion>
-    <FileVersion>1.13.4.0</FileVersion>
+    <AssemblyVersion>1.14.0.0</AssemblyVersion>
+    <FileVersion>1.14.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -283,19 +283,25 @@ public class WatchlistSyncRunner
 
         if (account.AutoRequestWatchlist)
         {
-            SyncProgress.SetPhase($"Requesting missing films via Jellyseerr for {user.Username}");
-            var unmatchedTmdbIds = tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
-            if (unmatchedTmdbIds.Count == 0) return;
+            // Default: only films missing from the library. Backfill mode: the whole watchlist,
+            // so already-available films also get an attributed request (per-user dedup happens
+            // inside RequestMovieAsync, which skips titles this user already requested).
+            var requestIds = account.BackfillAvailableRequests
+                ? tmdbIds
+                : tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
+
+            SyncProgress.SetPhase($"Requesting {(account.BackfillAvailableRequests ? "watchlist" : "missing")} films via Jellyseerr for {user.Username}");
+            if (requestIds.Count == 0) return;
 
             var requested = 0;
             var alreadyExists = 0;
             var failed = 0;
-            foreach (var tmdbId in unmatchedTmdbIds)
+            foreach (var tmdbId in requestIds)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    var result = await jellyseerr!.RequestMovieAsync(tmdbId, jellyseerrUserId.Value).ConfigureAwait(false);
+                    var result = await jellyseerr!.RequestMovieAsync(tmdbId, jellyseerrUserId.Value, account.BackfillAvailableRequests).ConfigureAwait(false);
                     switch (result)
                     {
                         case JellyseerrClient.RequestResult.Requested: requested++; break;
@@ -310,8 +316,9 @@ public class WatchlistSyncRunner
                 }
             }
             _logger.LogInformation(
-                "Jellyseerr auto-request for {Username}: {Requested} new, {Existing} already on Jellyseerr, {Failed} failed of {Total} unmatched",
-                user.Username, requested, alreadyExists, failed, unmatchedTmdbIds.Count);
+                "Jellyseerr auto-request for {Username} ({Mode}): {Requested} new, {Existing} already on Jellyseerr, {Failed} failed of {Total} considered",
+                user.Username, account.BackfillAvailableRequests ? "backfill" : "unmatched-only",
+                requested, alreadyExists, failed, requestIds.Count);
         }
     }
 

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -400,6 +400,10 @@
                                 + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
                                 + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Jellyseerr (configure URL + API key above). Requests are attributed to this user\'s Jellyseerr account (matched by Jellyfin User ID). Requires Jellyseerr to be configured. Skips titles Jellyseerr already has pending, processing, or available, so re-runs no longer create duplicates.</span>'
                                 + '</span></label>'
+                                + '<label><input type="checkbox" class="backfillAvailableRequests" /><span class="lb-check-text">'
+                                + '<span class="lb-check-title">Also backfill requests for already-available watchlist films</span>'
+                                + '<span class="lb-check-desc">Extends auto-request to films that are already in the library. Creates an attributed Jellyseerr request for any watchlisted film this user has no request for, so films that arrived outside Jellyseerr (manual Radarr add, deleted request) still show a requester. Creates request rows for already-available media; it does not trigger re-downloads. Requires "Auto-request" above.</span>'
+                                + '</span></label>'
                                 + '<label><input type="checkbox" class="mirrorJellyseerrWatchlist" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Mirror Letterboxd watchlist into Jellyseerr watchlist</span>'
                                 + '<span class="lb-check-desc">Two-way mirror against your Jellyseerr user\'s own watchlist (the one shown in the Jellyseerr UI). Adds films you\'ve added on Letterboxd, removes films you\'ve taken off. Only touches movies, so manually-added Jellyseerr TV entries are left alone. Requires Jellyseerr to be configured.</span>'
@@ -443,6 +447,7 @@
                                 entry.querySelector('.dateFilterDays').value = account.DateFilterDays || 7;
                                 entry.querySelector('.enableWatchlistSync').checked = account.EnableWatchlistSync === true;
                                 entry.querySelector('.autoRequestWatchlist').checked = account.AutoRequestWatchlist === true;
+                                entry.querySelector('.backfillAvailableRequests').checked = account.BackfillAvailableRequests === true;
                                 entry.querySelector('.mirrorJellyseerrWatchlist').checked = account.MirrorJellyseerrWatchlist === true;
                                 entry.querySelector('.enableDiaryImport').checked = account.EnableDiaryImport === true;
                                 entry.querySelector('.skipPreviouslySynced').checked = account.SkipPreviouslySynced !== false;
@@ -475,6 +480,7 @@
                                     DateFilterDays: parseInt(entry.querySelector('.dateFilterDays').value, 10) || 7,
                                     EnableWatchlistSync: entry.querySelector('.enableWatchlistSync').checked,
                                     AutoRequestWatchlist: entry.querySelector('.autoRequestWatchlist').checked,
+                                    BackfillAvailableRequests: entry.querySelector('.backfillAvailableRequests').checked,
                                     MirrorJellyseerrWatchlist: entry.querySelector('.mirrorJellyseerrWatchlist').checked,
                                     EnableDiaryImport: entry.querySelector('.enableDiaryImport').checked,
                                     SkipPreviouslySynced: entry.querySelector('.skipPreviouslySynced').checked,


### PR DESCRIPTION
## Why

Watchlist auto-request already creates **attributed** Jellyseerr requests for films *missing* from the library, so "who requested this?" is answerable for them. But a film that's on a user's Letterboxd watchlist **and** entered the library through some other path (manual Radarr add, an import list, or a request that was later deleted) ends up **Available with no request record** — untraceable. Two existing guards cause this: auto-request only considers films not in the library, and `RequestMovieAsync` skips anything Jellyseerr already marks Available.

This surfaced when "Sleeping with Other People" appeared in the library with no requester anywhere in Jellyseerr, despite being on two users' watchlists.

## What

New **opt-in** per-account setting **"Also backfill requests for already-available watchlist films"** (off by default; requires Auto-request). When enabled:

- Auto-request considers the **whole watchlist**, not just films missing from the library.
- `RequestMovieAsync(tmdbId, userId, backfillAvailable: true)` skips only when the title is **blocklisted** or **this user already has a request** for it (per-user dedup via `mediaInfo.requests[].requestedBy.id`). Available-but-unrequested titles are still requested, restoring an attributed requester trail.
- Verified against the deployed Jellyseerr/seerr 3.2.0: its request-creation logic blocks only on blocklisted media or an existing non-declined/non-completed request — it does **not** reject available media — so a backfill request succeeds and does not trigger a re-download (Radarr already has the file). If another user holds the single active request, Jellyseerr returns 409 and we classify it `AlreadyExists`.

Default behavior is unchanged for everyone who leaves the box off.

## Implementation

- `Account.BackfillAvailableRequests` + config-page checkbox (load/save) + `AccountUpdateRequest` and controller mappings.
- `JellyseerrClient`: single movie lookup now returns status **and** requester user IDs; `RequestMovieAsync` gains the `backfillAvailable` mode.
- `WatchlistSyncRunner`: requests across the full watchlist when backfill is on, passing the flag.

## Tests

Added 4 `JellyseerrClientTests`: available+no-request posts; user-already-requested skips; available+other-user-requested still posts for this user; blocklisted never posts. Full suite green (519 passed, 11 skipped).

## Note

Version bumped 1.13.4.0 → 1.14.0.0. A separate local branch (`fix/sync-phantom-rewatch-and-failure-retry`) also targets 1.14.0.0 — whichever lands second will need a re-bump.

## Release notes

New opt-in per-account setting "Also backfill requests for already-available watchlist films": creates attributed Jellyseerr requests for watchlist films that entered the library without one, so "who requested this?" is always answerable. Off by default; existing behavior unchanged.
