### PR TITLE
test: await fire-and-forget syncs in controller test teardown to stop SyncGate flake

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.15.1.0</Version>
-        <AssemblyVersion>1.15.1.0</AssemblyVersion>
-        <FileVersion>1.15.1.0</FileVersion>
+        <Version>1.15.2.0</Version>
+        <AssemblyVersion>1.15.2.0</AssemblyVersion>
+        <FileVersion>1.15.2.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/ControllerTestHarness.cs
+++ b/LetterboxdSync.Tests/ControllerTestHarness.cs
@@ -175,6 +175,15 @@ internal sealed class ControllerTestHarness : IDisposable
 
     public void Dispose()
     {
+        // A 202-Accepted endpoint spawns a fire-and-forget sync that acquires the
+        // static SyncGate. Wait it out so it can't still hold (or be about to take)
+        // the gate when the next test runs and get a spurious 409 Conflict.
+        try
+        {
+            Controller.LastBackgroundSync?.Wait(TimeSpan.FromSeconds(30));
+        }
+        catch { /* the task logs its own errors; never fail teardown */ }
+
         try
         {
             if (Directory.Exists(TempDir))

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -32,6 +32,11 @@ public class LetterboxdController : ControllerBase
     private readonly LetterboxdSyncRunner _syncRunner;
     private readonly WatchlistSyncRunner _watchlistRunner;
 
+    // Holds the most recent fire-and-forget sync task from StartSync/StartWatchlistSync.
+    // Production code never reads it; tests await it so a background sync can't outlive
+    // its test and hold SyncGate while the next test runs.
+    internal Task? LastBackgroundSync { get; private set; }
+
     public LetterboxdController(
         ILogger<LetterboxdController> logger,
         IUserManager userManager,
@@ -104,7 +109,7 @@ public class LetterboxdController : ControllerBase
         }
 
         // Fire and forget. Errors during the run are logged by the runner; the UI polls /Progress.
-        _ = Task.Run(async () =>
+        LastBackgroundSync = Task.Run(async () =>
         {
             try
             {
@@ -155,7 +160,7 @@ public class LetterboxdController : ControllerBase
                 return BadRequest(new { error = "No enabled accounts with watchlist sync turned on for your user" });
         }
 
-        _ = Task.Run(async () =>
+        LastBackgroundSync = Task.Run(async () =>
         {
             try
             {

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.15.1.0</AssemblyVersion>
-    <FileVersion>1.15.1.0</FileVersion>
+    <AssemblyVersion>1.15.2.0</AssemblyVersion>
+    <FileVersion>1.15.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,26 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.15.2',
+    headline: 'Maintenance: deterministic test teardown for manual-sync endpoints',
+    summary: 'No plugin behaviour changes.',
+    highlights: {
+      improvements: [
+        'Fixes an intermittent CI failure: the manual sync endpoints return 202 and run in the background, and a background sync from one test could still hold the shared sync gate when the next test ran, turning an expected 400 into a 409. The test harness now waits for the spawned sync to finish before the next test starts.',
+      ],
+    },
+  },
+  {
+    version: '1.15.1',
+    headline: 'Maintenance: letterboxdsync.dev release notes backfill',
+    summary: 'No plugin behaviour changes.',
+    highlights: {
+      improvements: [
+        'The Releases page on letterboxdsync.dev now has structured highlights for v1.13.4 through v1.15.0, which had shipped without entries.',
+      ],
+    },
+  },
+  {
     version: '1.15.0',
     headline: 'Jellyseerr request backfill for already-available watchlist films',
     summary:


### PR DESCRIPTION
## Why

`LetterboxdControllerTests.StartSync_NamedAccountNotFound_ReturnsBadRequest` failed intermittently on CI (seen on #58's run): expected `BadRequestObjectResult`, got `ConflictObjectResult`. The manual sync endpoints check the static `SyncGate` before any per-request validation and return 409 if it's held. A 202-Accepted test spawns a fire-and-forget `Task.Run` sync; nothing awaited it, so it could still hold (or be about to take) the gate when the next test in the class ran.

## What

- `LetterboxdController` captures the spawned task in an internal `LastBackgroundSync` property instead of discarding it (no production behaviour change; `InternalsVisibleTo` already grants the test project access).
- `ControllerTestHarness.Dispose` waits for that task (30 s cap) before cleanup, so a background sync can never outlive its test.

Cross-class interference was already handled: every test class touching `Plugin.Instance`/`SyncGate` is in the serialized `[Collection("Plugin")]`.

Full suite green locally, plus 3 consecutive clean runs of the controller test class. Version bumped 1.15.1.0 -> 1.15.2.0. Also adds the missing v1.15.1 release-notes.ts entry alongside v1.15.2's.

## Release notes

Maintenance: fixes an intermittent CI-only test failure where a background sync spawned by one test could still hold the sync gate when the next test ran. No plugin behaviour changes.