### PR TITLE
chore: add OpenSpec proposal for opt-in telemetry and fleet canary

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.15.2.0</Version>
-        <AssemblyVersion>1.15.2.0</AssemblyVersion>
-        <FileVersion>1.15.2.0</FileVersion>
+        <Version>1.15.3.0</Version>
+        <AssemblyVersion>1.15.3.0</AssemblyVersion>
+        <FileVersion>1.15.3.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.15.2.0</AssemblyVersion>
-    <FileVersion>1.15.2.0</FileVersion>
+    <AssemblyVersion>1.15.3.0</AssemblyVersion>
+    <FileVersion>1.15.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openspec/changes/add-opt-in-telemetry/.openspec.yaml
+++ b/openspec/changes/add-opt-in-telemetry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/add-opt-in-telemetry/design.md
+++ b/openspec/changes/add-opt-in-telemetry/design.md
@@ -1,0 +1,53 @@
+# Design
+
+Source: office-hours design doc `~/.gstack/projects/builtbyproxy-jellyfin-plugin-letterboxd/lachlan-main-design-20260611-144403.md` (3 rounds of adversarial review, 35 findings fixed). This file records the decisions; the spec deltas record the requirements.
+
+## Decision 1: Supabase over Plausible or Cloudflare D1
+
+The load-bearing requirement is that the maintainer's AI tooling can query the data over SQL (existing Supabase MCP connection) so analysis ends in issues/PRs without manual export. Plausible's aggregate event model cannot do per-instance longitudinal queries ("active installs by version over time") and its Stats API is not SQL. D1 adds a new platform for no gain. Supabase free tier with one table and one edge function wins.
+
+## Decision 2: Opt-in, default off, one-time prompt
+
+Audience is self-hosted Jellyfin users; opt-out telemetry is a reputation-ending move in that community (Audacity 2021). A one-time honest banner on the plugin dashboard converts 5-15% vs ~1% for a buried checkbox, and n decides whether any of this is useful. The banner ships as its own release AFTER the pipe is proven end-to-end, so the ask is never broken at first impression.
+
+## Decision 3: Payload is bucketed, never raw
+
+Counts are reported in buckets (accounts 1 / 2-4 / 5+; library <500 / 500-2k / 2k-10k / 10k+; syncs-per-week 0 / 1-10 / 11-100 / 100+) so no instance is fingerprintable by an exact number. Feature flags are booleans of existing config toggles. No IPs in the dataset, no usernames, no film titles, no library content. The README states precisely that Supabase platform request logs retain caller IPs for the platform's own retention window — the promise is "no IPs in the dataset", not a claim we can't keep.
+
+## Decision 4: Identity is a regenerable random UUID
+
+Generated when telemetry is enabled, never derived from hardware or Jellyfin identifiers. Regeneration unlinks the identifier going forward; old rows remain, and at small fleet sizes configuration similarity may still allow correlation — documented honestly rather than over-promised.
+
+## Decision 5: Weekly ping + error-transition ping (revised premise)
+
+Weekly-only pings cannot detect fleet-wide breakage (Letterboxd endpoint changes are step functions) faster than GitHub issues. So: weekly ping for adoption data, plus a ping when any error category transitions clean → failing, rate-limited to one per instance per day. The transition ping carries the full five-category error-state map; if a further category trips while the cap is spent, the plugin queues and sends one consolidated ping when the window reopens — deferred, never lost. Canary rates are computed from transition pings only; weekly error counters serve ad-hoc analysis.
+
+## Decision 6: Counters and error state persist in PluginConfiguration
+
+Self-hosters restart containers constantly. Window counters (measured since the last successful weekly ping), the last-successful-ping timestamp, and the per-category error-state booleans all persist in PluginConfiguration and flush on successful ping. In-memory-only state would systematically undercount the exact fleet being measured.
+
+## Decision 7: Week handling and idempotency
+
+`week` is computed in the edge function from UTC arrival time (a Postgres generated column over `timestamptz` is non-immutable and fails). Weekly pings upsert on `(instance_id, week)`; the client gates sending until the server week has rolled over since its persisted last-ping timestamp, so ±6 h jitter can never produce two different payloads in the same week slot; `ON CONFLICT` merges counters as a backstop.
+
+## Decision 8: Key and abuse model
+
+The plugin ships only the anon key. RLS is deny-all on `pings`; `/ingest` is the sole write path and uses its internal service role after validating. The anon key is extractable by design — junk rows are the worst case, bounded by shape validation, a 2 KB payload cap, per-instance caps, a transient (never persisted) per-IP rate limit plus a global requests-per-minute cap, and a row-growth alarm in the daily canary query.
+
+## Decision 9: Canary statistics under an every-merge release cadence
+
+Single versions never accumulate useful cohorts when every merge ships. So: foreground = all versions released in the trailing 14 days, pooled; baseline = everything older, pooled; per-version detail appears only in the issue's evidence table. Cohort assignment uses the most recent ping of any type (transition pings carry `plugin_version` and move an instance immediately — otherwise break-on-upgrade inflates the baseline and hides itself). "Active" = weekly ping in the trailing 14 days; transition window = trailing 7 days. Sybil gate: only instances with ≥2 weeks of weekly-ping history count. Issue gate: both cohorts n ≥ 10 AND rate multiple ≥ 3x; silent below the gate. Dedup on (suspect version, error_category); versions referenced by an open canary issue are excluded from the baseline so an unfixed regression can't mask itself.
+
+## Decision 10: Deterministic canary, AI analysis ad hoc
+
+The canary workflow is plain SQL + thresholds — no AI in the loop, so its issues are reproducible and arguable. Deep analysis (feature adoption, scale, roadmap questions) happens in normal AI sessions over the Supabase MCP, and findings become issues/PRs through human review.
+
+## Decision 11: Free-tier keep-alive that can't die quietly
+
+Supabase free tier pauses after ~7 days of inactivity and does not auto-resume. `telemetry-keepalive.yml` runs daily (one SELECT). GitHub disables cron workflows after 60 days without repo activity, so the job commits a heartbeat timestamp to a dedicated non-main branch (`telemetry-heartbeat`) when repo activity is older than 50 days — never to main, where the release pipeline would cut a junk release or go red. Any keep-alive or canary run that cannot reach the database fails the workflow loudly.
+
+## Deferred
+
+- Public aggregate stats page (Home Assistant style) — revisit after 90 days of data.
+- User-initiated server-side erasure — out of scope; README documents that regeneration unlinks but does not erase.
+- AI-driven canary analysis — deterministic checks first.

--- a/openspec/changes/add-opt-in-telemetry/proposal.md
+++ b/openspec/changes/add-opt-in-telemetry/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The plugin is at v1.15.2 with its roadmap shipped, and the only usage signal is GitHub release download counts — installs, but nothing about which of the 12 per-account settings people enable, which versions actually run, how often syncs fail in the wild, or at what scale. Roadmap decisions are guesses. The goal is a closed loop: anonymous opt-in usage data lands in a queryable store, the maintainer's AI tooling analyses it over SQL, and insights become GitHub issues and PRs. Because every merge auto-ships a release, the same data doubles as a fleet-wide canary that detects regressions (e.g. a Cloudflare 403 spike on the newest releases) and auto-files evidence-backed issues.
+
+The audience is self-hosted Jellyfin users — the most telemetry-hostile population there is — so the privacy posture is the feature: opt-in default-off with a one-time prompt (Home Assistant model), a minimal anonymous payload, and radical transparency (exact payload documented in the README, a "preview exact JSON" button in settings).
+
+## What Changes
+
+- New Supabase backend (free tier): one `pings` table, one `/ingest` edge function (validates shape, caps size, rate-limits, never persists IPs into the dataset), RLS deny-all so the shipped anon key cannot touch the table directly.
+- New plugin config: `TelemetryEnabled` (default false), `TelemetryInstanceId` (random UUID generated on enable, user-regenerable), persisted window counters and per-category error state.
+- New `TelemetryTask : IScheduledTask`: weekly anonymous ping with ±6 h jitter; payload is plugin/Jellyfin version, feature-toggle booleans, bucketed counts (never raw numbers), and per-period error-category counts.
+- Error-transition pings: when any error category goes clean → failing, a ping carrying the full error-state map fires, capped at one per instance per day (further transitions queue and consolidate).
+- Settings UI: opt-in checkbox, UUID regenerate button, admin-only "Preview exact JSON" modal that doubles as a copy-diagnostic-bundle for bug reports (with an explicit deanonymization warning).
+- One-time dismissible opt-in banner on the plugin dashboard tab, shipped as a separate release after the pipe is proven.
+- README "Telemetry" section documenting the exact payload and the precisely-worded anonymity promise.
+- Two scheduled GitHub Actions: `telemetry-keepalive.yml` (daily DB touch so the free tier never pauses; self-sustaining against GitHub's 60-day cron auto-disable) and `telemetry-canary.yml` (daily regression check that auto-files gated, deduped GitHub issues).
+
+## Capabilities
+
+### New Capabilities
+- `telemetry-collection`: What the plugin collects, when it sends, the opt-in/consent UX, and the transparency surfaces (preview, README).
+- `telemetry-backend`: The ingest contract, storage schema, key/RLS model, abuse bounds, and keep-alive.
+- `fleet-canary`: The daily regression check — cohort definitions, statistical gates, Sybil resistance, and the auto-filed issue contract.
+
+### Modified Capabilities
+<!-- No existing specs in openspec/specs/ to modify. -->
+
+## Impact
+
+- **New plugin code**: `TelemetryTask`, payload builder, error-state tracking wired into existing failure paths, `GET /Telemetry/Preview` admin endpoint, config-page banner/checkbox/modal. Two plugin releases (pipe first, prompt second), both through the normal version-gated pipeline.
+- **New infrastructure**: one Supabase project (migration + edge function), maintained near-zero; the maintainer queries it via the existing Supabase MCP connection.
+- **New workflows**: `telemetry-keepalive.yml`, `telemetry-canary.yml`; repo secrets gain the Supabase read key. The keep-alive heartbeat commits only to a dedicated non-main branch so the every-merge-ships release pipeline is never triggered by it.
+- **README** gains the telemetry section; the privacy wording is load-bearing and reviewed like code.
+- **No behaviour change for users who don't opt in**: telemetry is dead code until the checkbox is ticked; the only visible change is the one-time banner.
+- **Shipped write key is extractable by design**: worst case is junk rows (data-quality problem bounded by validation, rate limits, and a growth alarm), never a privacy problem.

--- a/openspec/changes/add-opt-in-telemetry/specs/fleet-canary/spec.md
+++ b/openspec/changes/add-opt-in-telemetry/specs/fleet-canary/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Daily deterministic regression check
+
+A scheduled workflow SHALL run daily (plus manual dispatch) executing deterministic SQL checks — no AI in the loop — comparing error-transition rates between a foreground cohort and a baseline cohort. Daily cadence is required: the check exists to beat human bug reports to fleet-wide breakage.
+
+#### Scenario: Canary run on a healthy fleet
+
+- **WHEN** the daily run finds no cohort pair exceeding the gates
+- **THEN** the workflow succeeds silently — no issue, no noise
+
+### Requirement: Cohort definitions resilient to every-merge releases
+
+Because every merge ships a release, single versions never accumulate useful cohorts. The foreground SHALL be all versions released in the trailing 14 days, pooled; the baseline SHALL be all older versions, pooled, excluding any version referenced by a still-open canary issue. An instance's cohort SHALL be assigned from its most recent ping of ANY type (transition pings carry plugin_version and move an instance immediately). "Active" = weekly ping in the trailing 14 days; the transition window is the trailing 7 days; a transition is attributed to the plugin_version stamped on the transition ping itself. Canary rates MUST be computed from transition pings only.
+
+#### Scenario: Break-on-upgrade is attributed to the new version
+
+- **WHEN** an instance upgrades on Monday and its syncs start failing the same day, before its next weekly ping
+- **THEN** its error-transition ping (stamped with the new version) moves it into the foreground cohort immediately and the failure counts against the new release, not the baseline
+
+#### Scenario: Unfixed regression cannot poison the baseline
+
+- **WHEN** a version flagged by a still-open canary issue ages past 14 days
+- **THEN** it is excluded from the baseline pool until the issue closes, so the live regression neither masks itself nor raises the bar for detecting the next one
+
+### Requirement: Statistical and Sybil gates
+
+No issue SHALL be filed unless both cohorts contain n ≥ 10 instances and the foreground rate is ≥ 3x the baseline rate (thresholds tunable in the workflow file). Only instances with at least 2 weeks of weekly-ping history SHALL count toward either cohort, so freshly-minted UUIDs cannot trip the canary.
+
+#### Scenario: Attacker mints instances to fake a regression
+
+- **WHEN** fresh UUIDs send weekly pings claiming the newest version followed by error-transition pings
+- **THEN** none of them count toward any cohort until they have 2 weeks of history, and the canary stays silent
+
+#### Scenario: Below the gate means silence
+
+- **WHEN** the foreground cohort has 7 active instances
+- **THEN** no issue is filed regardless of the rate multiple — silence below the gate is correct behaviour, not failure
+
+### Requirement: Auto-filed issue contract
+
+When the gates trip, the workflow SHALL file a templated GitHub issue containing the error category, the per-version evidence table (versions, n, rates), the comparison window, and the exact query used. Issues MUST be deduplicated on (suspect version from the evidence table, error_category) so a sliding foreground window cannot refile the same regression daily.
+
+#### Scenario: Regression persists across days
+
+- **WHEN** the same suspect version and error category exceed the gates on consecutive daily runs while the first issue is still open
+- **THEN** no duplicate issue is filed

--- a/openspec/changes/add-opt-in-telemetry/specs/telemetry-backend/spec.md
+++ b/openspec/changes/add-opt-in-telemetry/specs/telemetry-backend/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Single-table storage with server-computed week
+
+Pings SHALL be stored in one table `pings` (id, received_at, instance_id uuid, schema_version int, plugin_version text, jellyfin_version text, ping_type check in ('weekly','error_transition'), features jsonb, buckets jsonb, errors jsonb, week date NOT NULL) with a unique constraint on (instance_id, week) for weekly pings. `week` MUST be computed in the ingest function from UTC arrival time, not by the client and not as a Postgres generated column (non-immutable over timestamptz). A `latest_per_instance` view SHALL support active-installs-by-version queries.
+
+#### Scenario: Duplicate weekly ping merges instead of destroying
+
+- **WHEN** a weekly ping arrives for an (instance_id, week) slot that already has a row
+- **THEN** the ON CONFLICT clause merges counters rather than overwriting, so an earlier window's counts are never silently destroyed
+
+### Requirement: Ingest validation and caps
+
+The `/ingest` edge function SHALL be the sole write path. It MUST validate schema_version and payload shape, reject payloads over 2 KB, enforce a per-instance daily cap on error-transition inserts (returning 204 on cap hit), apply a transient in-memory per-IP rate limit plus a global requests-per-minute cap, and never persist IP addresses into the dataset.
+
+#### Scenario: Malformed or oversized payload
+
+- **WHEN** a request arrives with an unknown schema_version, a missing field, or a body over 2 KB
+- **THEN** the function rejects it without writing a row
+
+#### Scenario: Flood of fresh UUIDs
+
+- **WHEN** a client mints new instance UUIDs and posts at high volume
+- **THEN** the per-IP and global rate limits bound ingestion volume, and the daily canary's row-growth alarm fails loudly if totals exceed expected bounds
+
+### Requirement: Key and RLS model
+
+The plugin SHALL ship only the anon key. Row Level Security MUST deny all direct access to `pings` for the anon role; the ingest function writes with its internal service role after validation. The repository's documentation SHALL state that the shipped key is publishable by design and its compromise is bounded to junk rows, never reads or privacy.
+
+#### Scenario: Extracted key cannot read the dataset
+
+- **WHEN** someone extracts the anon key from plugin source and queries the `pings` table directly
+- **THEN** RLS denies the read and the write; only `/ingest` accepts traffic
+
+### Requirement: Free-tier keep-alive that fails loudly
+
+A daily scheduled workflow SHALL touch the database (one SELECT) so the free-tier project never pauses. The workflow MUST keep itself alive against GitHub's 60-day cron auto-disable by committing a heartbeat timestamp to a dedicated non-main branch when repo activity is older than 50 days — never to main, where the every-merge-ships pipeline would cut a junk release. Any run that cannot reach the database MUST fail the workflow (red + notification), so a paused project is detected within a day.
+
+#### Scenario: Quiet repo for two months
+
+- **WHEN** no human commits land for 60+ days
+- **THEN** the heartbeat branch commits keep the cron schedule active, the daily SELECT keeps Supabase unpaused, and ingestion continues uninterrupted
+
+#### Scenario: Project paused anyway
+
+- **WHEN** the keep-alive's SELECT fails because the project is paused or unreachable
+- **THEN** the workflow run goes red the same day rather than telemetry dying silently

--- a/openspec/changes/add-opt-in-telemetry/specs/telemetry-collection/spec.md
+++ b/openspec/changes/add-opt-in-telemetry/specs/telemetry-collection/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Telemetry is opt-in and off by default
+
+Telemetry SHALL be disabled by default. No network request to the telemetry backend may ever occur unless the admin has explicitly enabled `TelemetryEnabled`. Disabling telemetry MUST stop all pings immediately.
+
+#### Scenario: Fresh install never phones home
+
+- **WHEN** the plugin is installed or upgraded and the admin has never touched telemetry settings
+- **THEN** no request is made to the telemetry backend, ever, regardless of how long the plugin runs
+
+#### Scenario: Disabling stops pings immediately
+
+- **WHEN** an admin unchecks the telemetry setting and saves
+- **THEN** scheduled and error-transition pings stop, and the persisted instance UUID, counters, and error state remain locally but are no longer transmitted
+
+### Requirement: One-time opt-in prompt
+
+A dismissible banner SHALL appear once on the plugin dashboard tab asking the admin to enable telemetry, with honest copy, a link that opens the exact-payload preview, and Enable / No thanks actions. Either action MUST permanently dismiss the banner.
+
+#### Scenario: Banner shows exactly once
+
+- **WHEN** an admin opens the plugin dashboard and has neither enabled telemetry nor dismissed the banner before
+- **THEN** the banner renders; after the admin clicks Enable or No thanks, it is never shown again on any subsequent visit
+
+### Requirement: Anonymous minimal payload
+
+The telemetry payload SHALL contain only: schema version, plugin version, Jellyfin version, ping type, the random instance UUID, feature-toggle booleans, bucketed counts, and per-period error-category counts. It MUST NOT contain IP addresses, usernames, film titles, library content, or raw (unbucketed) counts.
+
+#### Scenario: Counts are bucketed
+
+- **WHEN** a payload is built for an instance with 3 linked accounts, a 1,200-film library, and 37 syncs since the last ping
+- **THEN** the payload reports accounts "2-4", library "500-2k", syncs-per-week "11-100", and no exact numbers
+
+### Requirement: Regenerable random instance identity
+
+The instance UUID SHALL be generated randomly when telemetry is first enabled, never derived from hardware, network, or Jellyfin identifiers. Settings MUST offer a Regenerate action. Documentation MUST state that regeneration unlinks the identifier going forward but does not erase old rows, and that configuration similarity may still allow correlation at small fleet sizes.
+
+#### Scenario: Regenerate unlinks future pings
+
+- **WHEN** the admin clicks Regenerate
+- **THEN** a new random UUID replaces the old one in configuration and all subsequent pings carry only the new UUID
+
+### Requirement: Weekly ping with jitter and week-boundary gating
+
+An `IScheduledTask` SHALL send the weekly ping with a random jitter of ±6 hours. The task MUST NOT send if the server-computed week of the last successful ping has not yet rolled over, preventing two different payloads from targeting the same (instance, week) slot.
+
+#### Scenario: Jitter cannot double-send within one week
+
+- **WHEN** the previous successful weekly ping was 6.5 days ago and the scheduler fires early due to jitter
+- **THEN** the task skips sending and retries on its next scheduled run
+
+### Requirement: Persisted counters and error state
+
+Window counters (measured since the last successful weekly ping), the last-successful-ping timestamp, and per-category error-state booleans SHALL persist in PluginConfiguration and flush on each successful ping.
+
+#### Scenario: Restart does not zero the window
+
+- **WHEN** the Jellyfin container restarts mid-week after 12 syncs were counted
+- **THEN** the next weekly payload still reflects those 12 syncs in its bucket
+
+### Requirement: Error-transition pings
+
+When any error category transitions clean → failing, a ping of type `error_transition` carrying the full five-category error-state map SHALL fire, rate-limited to one per instance per day. Further transitions during a spent cap window MUST be queued and sent as one consolidated ping when the window reopens — deferred, never silently dropped client-side. Recovery (failing → clean) does not fire a ping; it is visible in the next weekly payload.
+
+#### Scenario: Second category trips during the cap window
+
+- **WHEN** cloudflare_403 transitions at 09:00 (ping sent) and tmdb_lookup transitions at 14:00 the same day
+- **THEN** the plugin queues the change and sends one consolidated transition ping carrying both categories' state after the daily window reopens
+
+### Requirement: Payload preview and diagnostic bundle
+
+An admin-authorized endpoint `GET /Telemetry/Preview` SHALL return the exact JSON the next ping would send, rendered in a settings modal. The modal MUST offer copy-as-diagnostic-bundle for bug reports and MUST warn that the bundle contains the instance UUID (pasting it publicly links that identity to the instance's ping history), offering one-click regeneration after filing.
+
+#### Scenario: Preview requires admin
+
+- **WHEN** a non-admin or unauthenticated caller requests `/Telemetry/Preview`
+- **THEN** the request is rejected with the same authorization policy as the plugin configuration page
+
+### Requirement: README documents the exact payload
+
+The README SHALL contain a Telemetry section showing the full example payload, the precise anonymity wording (no IPs/usernames/titles in the dataset; platform transport logs are the platform's, retained per its policy), the opt-in default, and the regeneration semantics.
+
+#### Scenario: A skeptical user audits the claim
+
+- **WHEN** a user reads the README Telemetry section and clicks Preview in settings
+- **THEN** the documented payload shape and the previewed JSON match field-for-field

--- a/openspec/changes/add-opt-in-telemetry/tasks.md
+++ b/openspec/changes/add-opt-in-telemetry/tasks.md
@@ -1,0 +1,38 @@
+## 1. Backend (no plugin release)
+
+- [ ] 1.1 Create the Supabase project (or reuse the existing org) and apply the `pings` migration: columns per spec, unique (instance_id, week) where ping_type='weekly', `latest_per_instance` view, RLS deny-all for anon
+- [ ] 1.2 Implement the `/ingest` edge function: schema_version + shape validation, 2 KB cap, server-computed UTC `week`, weekly upsert with counter-merging ON CONFLICT, error-transition insert with per-instance daily cap (204 on hit), transient per-IP + global rate limits, service-role write, IP never persisted
+- [ ] 1.3 curl-test the full matrix: valid weekly, duplicate same-week (verify merge), valid transition, capped transition (verify 204), oversized payload, malformed payload, direct table access with anon key (verify RLS denial)
+- [ ] 1.4 Add `.github/workflows/telemetry-keepalive.yml`: daily SELECT, loud failure on unreachable DB, heartbeat commit to `telemetry-heartbeat` branch when repo activity > 50 days old
+- [ ] 1.5 Add the Supabase read key to repo secrets; verify a Supabase MCP query returns the curl-test rows
+
+## 2. Plugin release 1 — the pipe (feat: anonymous opt-in telemetry)
+
+- [ ] 2.1 Add `TelemetryEnabled` (default false), `TelemetryInstanceId`, persisted window counters, last-successful-ping timestamp, and per-category error-state booleans to PluginConfiguration
+- [ ] 2.2 Implement the payload builder: versions, feature-toggle booleans, bucketed counts (accounts 1/2-4/5+, library <500/500-2k/2k-10k/10k+, syncs-per-week 0/1-10/11-100/100+), per-period error-category counts
+- [ ] 2.3 Implement `TelemetryTask : IScheduledTask`: weekly with ±6 h jitter, week-rollover send gate, counter flush on success
+- [ ] 2.4 Wire error-category detection (cloudflare_403, auth_failure, tmdb_lookup, jellyseerr_error, other) into the existing failure paths; rising-edge transition pings carrying the full state map; client-side queue-and-consolidate when the daily cap is spent
+- [ ] 2.5 Add admin-authorized `GET /Telemetry/Preview` returning the exact next payload
+- [ ] 2.6 Settings UI: opt-in checkbox, UUID Regenerate button, Preview modal with copy-diagnostic-bundle + deanonymization warning + post-filing regenerate shortcut
+- [ ] 2.7 README "Telemetry" section: example payload, precise anonymity wording (dataset vs platform logs), opt-in default, regeneration unlinks-not-erases
+- [ ] 2.8 Tests: payload bucketing, week-gate, transition state machine (rising edge, cap, consolidation, restart persistence), preview auth; verify a real ping from the maintainer's server lands and is queryable via MCP
+- [ ] 2.9 Version bump + release notes per the release process
+
+## 3. Plugin release 2 — the prompt (feat: telemetry opt-in banner)
+
+- [ ] 3.1 Draft the banner copy (3-4 sentences) and get reactions from real users (GitHub Discussions or the r/jellyfin thread) before shipping
+- [ ] 3.2 One-time dismissible banner on the dashboard tab: Enable / No thanks, "see exactly what's sent" link opening the preview modal, dismissed-forever state in configuration
+- [ ] 3.3 Tests: banner shows once, both actions dismiss permanently, Enable generates UUID and schedules the task
+- [ ] 3.4 Version bump + release notes
+
+## 4. Canary (no plugin release)
+
+- [ ] 4.1 Add `.github/workflows/telemetry-canary.yml`: daily + manual dispatch, SQL checks implementing the cohort definitions (14-day foreground pool, baseline exclusions, any-ping cohort assignment, transition-ping rates), Sybil gate (≥2 weeks history), issue gates (n ≥ 10 both cohorts, ≥3x multiple)
+- [ ] 4.2 Issue template with error category, per-version evidence table, window, and the exact query; dedup on (suspect version, error_category) against open issues
+- [ ] 4.3 Row-growth alarm in the same daily query (total rows + new instances outside expected bounds → red run)
+- [ ] 4.4 Dry-run against synthetic data: healthy fleet (silent), real regression (files once, not daily), minted-UUID flood (silent)
+
+## 5. Wrap-up
+
+- [ ] 5.1 Update wiki/site docs if the plugin's public feature description changes
+- [ ] 5.2 After 90 days: review n, decide whether the deferred public stats page earns its keep, and record the first data-driven roadmap decision in an issue citing telemetry numbers

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,16 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.15.3',
+    headline: 'Maintenance: telemetry design spec',
+    summary: 'No plugin behaviour changes.',
+    highlights: {
+      improvements: [
+        'Adds the OpenSpec change proposal for upcoming anonymous, opt-in usage telemetry: minimal bucketed payload, default off with a one-time prompt, full payload preview in settings, and a fleet canary that auto-detects regressions. Spec only; no telemetry code ships in this release.',
+      ],
+    },
+  },
+  {
     version: '1.15.2',
     headline: 'Maintenance: deterministic test teardown for manual-sync endpoints',
     summary: 'No plugin behaviour changes.',


### PR DESCRIPTION
## Why

Decided in today's design session: the plugin needs anonymous, opt-in usage telemetry so roadmap decisions stop being guesses, plus a fleet canary that catches regressions across the install base. The full design went through three rounds of adversarial review; this PR encodes it as an OpenSpec change so implementation can be tracked task-by-task.

## What

New OpenSpec change `add-opt-in-telemetry` (validates clean):
- **proposal.md** — why / what changes / impact
- **design.md** — 11 recorded decisions (Supabase backend, opt-in posture, bucketed payload, error-transition pings, canary statistics under every-merge releases, keep-alive that can't die quietly)
- **specs/** — requirement deltas for three new capabilities: `telemetry-collection`, `telemetry-backend`, `fleet-canary`
- **tasks.md** — 24 implementation tasks across backend, two plugin releases, and the canary workflow

Spec only — no telemetry code ships in this release. Version bumped 1.15.2.0 -> 1.15.3.0 (patch, docs/spec-only) to satisfy the version gate.

## Release notes

Adds the design spec for upcoming anonymous, opt-in usage telemetry (minimal bucketed payload, off by default, one-time prompt, full payload preview) and an automated regression canary. Spec only; no telemetry code or behaviour changes in this release.