### PR TITLE
ci: upload JUnit test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,10 @@ jobs:
         # skip silently here without secrets, but excluding them keeps the run
         # honest about what was exercised. The integration.yml workflow runs them
         # on demand with credentials wired in.
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults --filter "Category!=Integration"
+        # The junit logger writes relative to the test project unless given an
+        # absolute path, so LogFilePath is pinned to the workspace TestResults dir
+        # to sit alongside the coverage XML. Powers Codecov Test Analytics below.
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults --logger "junit;LogFilePath=${{ github.workspace }}/TestResults/junit.xml" --filter "Category!=Integration"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -60,3 +63,12 @@ jobs:
           files: ./TestResults/**/coverage.cobertura.xml
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload test results to Codecov
+        # Codecov Test Analytics: flaky-test detection + failure reporting from the
+        # JUnit XML. Runs even on test failure so failing/flaky runs are reported.
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./TestResults/junit.xml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.18.0.0</Version>
-        <AssemblyVersion>1.18.0.0</AssemblyVersion>
-        <FileVersion>1.18.0.0</FileVersion>
+        <Version>1.18.1.0</Version>
+        <AssemblyVersion>1.18.1.0</AssemblyVersion>
+        <FileVersion>1.18.1.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
+++ b/LetterboxdSync.Tests/LetterboxdSync.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.18.0.0</AssemblyVersion>
-    <FileVersion>1.18.0.0</FileVersion>
+    <AssemblyVersion>1.18.1.0</AssemblyVersion>
+    <FileVersion>1.18.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,17 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.18.1',
+    headline: 'Internal: test analytics in CI',
+    summary:
+      'No functional changes. CI now uploads JUnit test results to Codecov Test Analytics so flaky tests and failures are tracked across releases. Nothing in the plugin itself changes.',
+    highlights: {
+      improvements: [
+        'CI emits a JUnit test report and uploads it to Codecov Test Analytics for flaky-test detection and failure reporting. Developer-facing only; no change to plugin behaviour.',
+      ],
+    },
+  },
+  {
     version: '1.18.0',
     headline: 'Clearer guidance when Letterboxd login fails',
     summary:


### PR DESCRIPTION
## Summary

Enables Codecov **Test Analytics** (flaky-test detection + failure reporting) for the .NET test suite. This repo has prior flaky-CI history (the `StartSync` controller tests intermittently returned 409 instead of 400 from a leaked `SyncGate`, fixed in #60 / v1.15.2), so flaky detection has concrete value here.

Codecov's **JS Bundle Analysis** is deliberately *not* enabled: the only JS surface is the static Astro landing site, with no app bundle to regress.

## Changes

- `LetterboxdSync.Tests.csproj`: add `JunitXml.TestLogger` (6.1.0).
- `ci.yml`: the existing `dotnet test` step now also emits JUnit XML (absolute `LogFilePath`, since the logger otherwise writes relative to the test project and ignores `--results-directory`); a new `codecov/test-results-action@v1` step uploads it. Guarded with `if: ${{ !cancelled() }}` so failing/flaky runs are still reported.
- Patch version bump to 1.18.1.0 (required by version-gate; CI-only change).

## Testing

Ran the exact CI command locally: 578 passed, 0 failed; both `TestResults/junit.xml` and `coverage.cobertura.xml` produced. JUnit XML validated as well-formed.

## Merge order

Branch is cut from `main`. **Merge after #74** (the auth-guidance PR, which sets main to 1.18.0.0); this then lands as a clean 1.18.0.0 → 1.18.1.0 patch. Merging before #74 would invert their versions.

## Release notes

No functional changes. CI now uploads JUnit test results to Codecov Test Analytics so flaky tests and failures are tracked across releases. Nothing in the plugin itself changes.