### PR TITLE
chore: rename Jellyseerr to Seerr across UI, docs, and internal client

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.18.1.0</Version>
-        <AssemblyVersion>1.18.1.0</AssemblyVersion>
-        <FileVersion>1.18.1.0</FileVersion>
+        <Version>1.18.2.0</Version>
+        <AssemblyVersion>1.18.2.0</AssemblyVersion>
+        <FileVersion>1.18.2.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/RatedFilmsApiTests.cs
+++ b/LetterboxdSync.Tests/RatedFilmsApiTests.cs
@@ -70,7 +70,7 @@ public class FilmSummaryHelperTests
     // entries, with the tmdb link pointing at /tv/<id>. TMDb's movie and TV ID
     // namespaces are independent, so e.g. tv/198102 = "Hijack" and movie/198102 =
     // "Cutie Honey Flash". Without the /tv/ guard, watchlisting Hijack on
-    // Letterboxd ends up auto-requesting Cutie Honey in Jellyseerr.
+    // Letterboxd ends up auto-requesting Cutie Honey in Seerr.
     [Fact]
     public void ExtractTmdbIdFromLinks_TvShow_SkipsTvLink()
     {

--- a/LetterboxdSync.Tests/SeerrClientTests.cs
+++ b/LetterboxdSync.Tests/SeerrClientTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace LetterboxdSync.Tests;
 
-public class JellyseerrClientTests
+public class SeerrClientTests
 {
     private const string BaseUrl = "http://jellyseerr.test";
     private const string ApiKey = "test-key";
@@ -34,10 +34,10 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7);
 
-        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.Equal(SeerrClient.RequestResult.Requested, result);
         Assert.True(posted, "request endpoint should have been called");
     }
 
@@ -61,10 +61,10 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7);
 
-        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.Equal(SeerrClient.RequestResult.AlreadyExists, result);
         Assert.False(posted, "request endpoint must not be called when media is already known");
     }
 
@@ -86,17 +86,17 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7);
 
-        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.Equal(SeerrClient.RequestResult.Requested, result);
         Assert.True(posted);
     }
 
     [Fact]
     public async Task RequestMovieAsync_PostReturns409_TreatsAsAlreadyExists()
     {
-        // Belt-and-braces: if the status pre-check misses (e.g. 404 lookup) and Jellyseerr
+        // Belt-and-braces: if the status pre-check misses (e.g. 404 lookup) and Seerr
         // does return its own 409, we should still classify it as AlreadyExists so the
         // count of "new requests" stays accurate.
         var handler = new SeerrHandler(req =>
@@ -113,17 +113,17 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7);
 
-        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.Equal(SeerrClient.RequestResult.AlreadyExists, result);
     }
 
     [Fact]
     public async Task RequestMovieAsync_Backfill_AvailableWithNoRequest_PostsAttributedRequest()
     {
         // The backfill case: media is AVAILABLE (status 5) but nobody has a request for it
-        // (entered the library outside Jellyseerr). Backfill mode must still POST so a requester
+        // (entered the library outside Seerr). Backfill mode must still POST so a requester
         // trail exists. Default mode would have skipped on status 5.
         var posted = false;
         var handler = new SeerrHandler(req =>
@@ -140,10 +140,10 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
 
-        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.Equal(SeerrClient.RequestResult.Requested, result);
         Assert.True(posted, "backfill should request an available title that has no request");
     }
 
@@ -161,10 +161,10 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
 
-        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.Equal(SeerrClient.RequestResult.AlreadyExists, result);
         Assert.False(posted, "backfill must not duplicate this user's own request");
     }
 
@@ -172,7 +172,7 @@ public class JellyseerrClientTests
     public async Task RequestMovieAsync_Backfill_AvailableButOtherUserRequested_PostsForThisUser()
     {
         // Another user (9) has a request; user 7 still gets their own attributed request when
-        // Jellyseerr accepts it. (If Jellyseerr's single-active-request rule rejects it, the
+        // Seerr accepts it. (If Seerr's single-active-request rule rejects it, the
         // POST 409 path classifies it AlreadyExists — covered separately.)
         var posted = false;
         var handler = new SeerrHandler(req =>
@@ -189,10 +189,10 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
 
-        Assert.Equal(JellyseerrClient.RequestResult.Requested, result);
+        Assert.Equal(SeerrClient.RequestResult.Requested, result);
         Assert.True(posted);
     }
 
@@ -209,17 +209,17 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var result = await client.RequestMovieAsync(100, 7, backfillAvailable: true);
 
-        Assert.Equal(JellyseerrClient.RequestResult.AlreadyExists, result);
+        Assert.Equal(SeerrClient.RequestResult.AlreadyExists, result);
         Assert.False(posted, "blocklisted media must never be requested");
     }
 
     [Fact]
     public async Task GetUserWatchlistTmdbIdsAsync_PaginatesViaPageParamAndFiltersToMovies()
     {
-        // Jellyseerr paginates the user-watchlist endpoint with `page=N`, NOT take/skip
+        // Seerr paginates the user-watchlist endpoint with `page=N`, NOT take/skip
         // (which it 400s on). Drive two pages, with totalPages=2 telling us when to stop.
         var seenPageQueries = new List<string>();
         var handler = new SeerrHandler(req =>
@@ -243,7 +243,7 @@ public class JellyseerrClientTests
             return JsonResponse("{\"page\":99,\"totalPages\":2,\"results\":[]}");
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var ids = await client.GetUserWatchlistTmdbIdsAsync(7);
 
         Assert.Equal(new HashSet<int> { 1, 2, 4 }, ids);
@@ -257,7 +257,7 @@ public class JellyseerrClientTests
     public async Task GetUserWatchlistTmdbIdsAsync_SendsXApiUserHeader()
     {
         // The endpoint requires acting as the user being queried — without the impersonation
-        // header, Jellyseerr returns the calling key's default user (admin), which silently
+        // header, Seerr returns the calling key's default user (admin), which silently
         // returns the wrong watchlist.
         string? sentHeader = null;
         var handler = new SeerrHandler(req =>
@@ -266,7 +266,7 @@ public class JellyseerrClientTests
             return JsonResponse("{\"page\":1,\"totalPages\":1,\"totalResults\":0,\"results\":[]}");
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         await client.GetUserWatchlistTmdbIdsAsync(42);
         Assert.Equal("42", sentHeader);
     }
@@ -288,7 +288,7 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var ok = await client.AddToWatchlistAsync(42, 9);
 
         Assert.True(ok);
@@ -314,7 +314,7 @@ public class JellyseerrClientTests
             return JsonResponse(@"{ ""results"": [] }");
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var id = await client.GetJellyseerrUserIdAsync("def456");
 
         Assert.Equal(7, id);
@@ -324,11 +324,11 @@ public class JellyseerrClientTests
     public async Task GetJellyseerrUserIdAsync_NormalisesDashesAndCase()
     {
         // Map stores normalised IDs (no dashes, lowercase). Looking up the same user
-        // via either format should resolve to the same Jellyseerr user id.
+        // via either format should resolve to the same Seerr user id.
         var handler = new SeerrHandler(req =>
             JsonResponse(@"{ ""results"": [{ ""id"": 42, ""jellyfinUserId"": ""ABC123"" }] }"));
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
 
         Assert.Equal(42, await client.GetJellyseerrUserIdAsync("ABC123"));
         Assert.Equal(42, await client.GetJellyseerrUserIdAsync("abc-1-2-3"));
@@ -341,7 +341,7 @@ public class JellyseerrClientTests
         var handler = new SeerrHandler(req =>
             JsonResponse(@"{ ""results"": [{ ""id"": 1, ""jellyfinUserId"": ""onlyuser"" }] }"));
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.Null(await client.GetJellyseerrUserIdAsync("missing"));
     }
 
@@ -364,7 +364,7 @@ public class JellyseerrClientTests
             return JsonResponse(@"{ ""results"": [] }");
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
 
         Assert.Equal(1, await client.GetJellyseerrUserIdAsync("u1"));
         Assert.Equal(150, await client.GetJellyseerrUserIdAsync("u150"));
@@ -381,7 +381,7 @@ public class JellyseerrClientTests
     [Fact]
     public async Task GetJellyseerrUserIdAsync_SkipsResultsWithoutJellyfinId()
     {
-        // Jellyseerr admin accounts can have a null jellyfinUserId; they shouldn't
+        // Seerr admin accounts can have a null jellyfinUserId; they shouldn't
         // appear in the map. Looking up a real user should still work.
         var handler = new SeerrHandler(_ =>
             JsonResponse(@"{ ""results"": [
@@ -391,7 +391,7 @@ public class JellyseerrClientTests
                 { ""id"": 4, ""jellyfinUserId"": ""real"" }
             ] }"));
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.Equal(4, await client.GetJellyseerrUserIdAsync("real"));
         Assert.Null(await client.GetJellyseerrUserIdAsync("nonexistent"));
     }
@@ -404,7 +404,7 @@ public class JellyseerrClientTests
             Content = new StringContent("{\"message\":\"already exists on watchlist\"}")
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.True(await client.AddToWatchlistAsync(42, 9));
     }
 
@@ -412,7 +412,7 @@ public class JellyseerrClientTests
     public async Task RemoveFromWatchlistAsync_404IsSuccess()
     {
         var handler = new SeerrHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.True(await client.RemoveFromWatchlistAsync(42, 9));
     }
 
@@ -435,7 +435,7 @@ public class JellyseerrClientTests
             return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.True(await client.RemoveFromWatchlistAsync(42, 9));
         Assert.Equal("/api/v1/watchlist/42", sentPath);
         Assert.Contains("mediaType=movie", sentQuery);
@@ -451,7 +451,7 @@ public class JellyseerrClientTests
             Content = new StringContent("boom")
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.False(await client.AddToWatchlistAsync(42, 9));
     }
 
@@ -463,7 +463,7 @@ public class JellyseerrClientTests
             Content = new StringContent("boom")
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.False(await client.RemoveFromWatchlistAsync(42, 9));
     }
 
@@ -476,7 +476,7 @@ public class JellyseerrClientTests
             Content = new StringContent("nope")
         });
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         var ids = await client.GetUserWatchlistTmdbIdsAsync(9);
         Assert.Empty(ids);
     }
@@ -487,7 +487,7 @@ public class JellyseerrClientTests
         // Network-layer exceptions are swallowed so a status pre-check never breaks a run.
         var handler = new SeerrHandler(_ => throw new HttpRequestException("connection reset"));
 
-        using var client = new JellyseerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
+        using var client = new SeerrClient(BaseUrl, ApiKey, NullLogger.Instance, handler);
         Assert.Null(await client.GetMovieMediaStatusAsync(100));
     }
 

--- a/LetterboxdSync.Tests/TelemetryServiceTests.cs
+++ b/LetterboxdSync.Tests/TelemetryServiceTests.cs
@@ -69,7 +69,7 @@ public class TelemetryServiceTests : IDisposable
     [InlineData("Letterboxd returned 401 for sinners after re-authentication. Session may be permanently invalid.", TelemetryService.CatAuth)]
     [InlineData("returned 403 during login. Likely reCAPTCHA. Provide raw cookies instead.", TelemetryService.CatAuth)]
     [InlineData("Film with TMDb ID 123 not found on Letterboxd.", TelemetryService.CatTmdb)]
-    [InlineData("Jellyseerr request errored", TelemetryService.CatJellyseerr)]
+    [InlineData("Seerr request errored", TelemetryService.CatJellyseerr)]
     [InlineData("something exploded", TelemetryService.CatOther)]
     [InlineData(null, TelemetryService.CatOther)]
     public void Classify_MapsKnownPatterns(string? message, string expected)

--- a/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/WatchlistSyncRunnerTests.cs
@@ -292,7 +292,7 @@ public class WatchlistSyncRunnerTests : IDisposable
     [Fact]
     public async Task TryRunForUserAsync_AutoRequestEnabled_NoJellyseerr_SkipsRequest()
     {
-        // Account has auto-request on, but Jellyseerr URL/key aren't configured at
+        // Account has auto-request on, but Seerr URL/key aren't configured at
         // the plugin level → CreateJellyseerrClient returns null, we don't try to
         // request. This exercises the IsConfigured guard path.
         var (user, userId) = MakeUser("lachlan");
@@ -334,11 +334,11 @@ public class WatchlistSyncRunnerTests : IDisposable
         Assert.True(ok);
     }
 
-    // ----- Mirror to Jellyseerr watchlist -----
+    // ----- Mirror to Seerr watchlist -----
     // Exercises MirrorJellyseerrWatchlistAsync via the JellyseerrClientFactoryOverride.
 
     /// <summary>
-    /// Mock HttpMessageHandler that lets us drive the JellyseerrClient end-to-end
+    /// Mock HttpMessageHandler that lets us drive the SeerrClient end-to-end
     /// without hitting the network. Each test plays out a small request → response
     /// script so we can verify the runner sends the right calls.
     /// </summary>
@@ -363,23 +363,23 @@ public class WatchlistSyncRunnerTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         AddAccount(userId, mirror: true);
 
-        // Plugin-wide Jellyseerr config makes IsConfigured true.
+        // Plugin-wide Seerr config makes IsConfigured true.
         Plugin.Instance!.Configuration.JellyseerrUrl = "http://jellyseerr.test";
         Plugin.Instance!.Configuration.JellyseerrApiKey = "key";
 
         var service = Substitute.For<ILetterboxdService>();
-        // LB has only 1233413; Jellyseerr has 550. Mirror should ADD 1233413 and
+        // LB has only 1233413; Seerr has 550. Mirror should ADD 1233413 and
         // REMOVE 550 from the Seerr watchlist (since it's no longer on LB).
         service.GetWatchlistTmdbIdsAsync(Arg.Any<string>())
             .Returns(new List<int> { 1233413 });
         LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
 
         // Library has nothing (so playlist+request paths short-circuit), but the
-        // mirror flow still runs since Jellyseerr is configured + mirror flag is on.
+        // mirror flow still runs since Seerr is configured + mirror flag is on.
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
 
-        // Jellyseerr scripted responses:
-        //   GET /api/v1/user → maps lachlan's JF id to Jellyseerr id 7
+        // Seerr scripted responses:
+        //   GET /api/v1/user → maps lachlan's JF id to Seerr id 7
         //   GET /api/v1/user/7/watchlist → returns {550}, missing 1233413
         //   POST /api/v1/watchlist (with X-API-User: 7) → success for 1233413
         //   DELETE /api/v1/watchlist/550 → success (550 was on Seerr but not LB)
@@ -397,7 +397,7 @@ public class WatchlistSyncRunnerTests : IDisposable
             }
             if (req.Method == HttpMethod.Get && path.Contains("/api/v1/user/7/watchlist"))
             {
-                // Jellyseerr's watchlist endpoint returns items with tmdbId at the
+                // Seerr's watchlist endpoint returns items with tmdbId at the
                 // top level; not nested under mediaInfo.
                 return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
                 {
@@ -413,7 +413,7 @@ public class WatchlistSyncRunnerTests : IDisposable
         });
 
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -449,14 +449,14 @@ public class WatchlistSyncRunnerTests : IDisposable
         LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem>());
 
-        // Jellyseerr returns a user list that doesn't match our Jellyfin user → mapping fails.
+        // Seerr returns a user list that doesn't match our Jellyfin user → mapping fails.
         var handler = new JellyseerrHandler(req =>
             new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
             {
                 Content = new System.Net.Http.StringContent("{\"results\":[]}")
             });
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -479,7 +479,7 @@ public class WatchlistSyncRunnerTests : IDisposable
     public async Task TryRunForUserAsync_MirrorWatchlist_EmptyLetterboxdList_SkipsToAvoidMassDeletion()
     {
         // Defensive: if Letterboxd returns an empty list (e.g. watchlist deleted
-        // or fetch errored to zero), don't mass-delete the Jellyseerr watchlist.
+        // or fetch errored to zero), don't mass-delete the Seerr watchlist.
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
         AddAccount(userId, mirror: true);
@@ -509,7 +509,7 @@ public class WatchlistSyncRunnerTests : IDisposable
             };
         });
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -638,12 +638,12 @@ public class WatchlistSyncRunnerTests : IDisposable
         await service.Received(1).GetWatchlistTmdbIdsAsync("lb-user");
     }
 
-    // ----- Jellyseerr auto-request -----
+    // ----- Seerr auto-request -----
 
     [Fact]
     public async Task TryRunForUserAsync_AutoRequest_RequestsUnmatchedFilm()
     {
-        // Account auto-requests, the watchlist film is NOT in the library, Jellyseerr is
+        // Account auto-requests, the watchlist film is NOT in the library, Seerr is
         // configured → the runner should POST a movie request for the unmatched TMDb id.
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
@@ -679,7 +679,7 @@ public class WatchlistSyncRunnerTests : IDisposable
             return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
         });
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -701,7 +701,7 @@ public class WatchlistSyncRunnerTests : IDisposable
     public async Task TryRunForUserAsync_AutoRequest_TalliesAlreadyExistsFailedAndErrored()
     {
         // Three unmatched films exercise every RequestResult branch plus the per-film
-        // exception catch: one already on Jellyseerr (skipped), one POST that 500s
+        // exception catch: one already on Seerr (skipped), one POST that 500s
         // (Failed), and one whose POST throws (errored). The run must absorb all of it.
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
@@ -747,7 +747,7 @@ public class WatchlistSyncRunnerTests : IDisposable
             return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
         });
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -770,8 +770,8 @@ public class WatchlistSyncRunnerTests : IDisposable
     [Fact]
     public async Task TryRunForUserAsync_JellyseerrUserMapErrors_SkipsGracefully()
     {
-        // The Jellyseerr user-map fetch fails (500). The runner must log and bail out of
-        // the Jellyseerr branch without throwing, posting, or deleting anything.
+        // The Seerr user-map fetch fails (500). The runner must log and bail out of
+        // the Seerr branch without throwing, posting, or deleting anything.
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
         AddAccount(userId, autoRequest: true);
@@ -787,7 +787,7 @@ public class WatchlistSyncRunnerTests : IDisposable
         var handler = new JellyseerrHandler(_ =>
             new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError));
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             var ok = await _runner.TryRunForUserAsync(userId, "test",
@@ -808,8 +808,8 @@ public class WatchlistSyncRunnerTests : IDisposable
     public async Task TryRunForUserAsync_MirrorOnNonPrimaryAccount_SkipsMirror()
     {
         // Two accounts on one Jellyfin user, both with mirror on. Only the primary owns
-        // the Jellyseerr-watchlist destination, so running the secondary must not POST or
-        // DELETE against the Jellyseerr watchlist (would clobber the primary's diff).
+        // the Seerr-watchlist destination, so running the secondary must not POST or
+        // DELETE against the Seerr watchlist (would clobber the primary's diff).
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
 
@@ -847,7 +847,7 @@ public class WatchlistSyncRunnerTests : IDisposable
             };
         });
         WatchlistSyncRunner.JellyseerrClientFactoryOverride = (url, key, log) =>
-            new JellyseerrClient(url, key, log, handler);
+            new SeerrClient(url, key, log, handler);
         try
         {
             // Target only the non-primary account.

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -127,7 +127,7 @@ public class LetterboxdController : ControllerBase
     }
 
     /// <summary>
-    /// Trigger a Letterboxd → Jellyfin playlist (and optional Jellyseerr) watchlist sync
+    /// Trigger a Letterboxd → Jellyfin playlist (and optional Seerr) watchlist sync
     /// for the calling user. Same shape as <see cref="StartSync"/>: 202 immediately,
     /// 409 if any sync is in flight, 400 if the user has no watchlist-enabled account.
     /// </summary>
@@ -476,12 +476,12 @@ public class LetterboxdController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> TestJellyseerr([FromBody] JellyseerrTestRequest request)
     {
-        if (!JellyseerrClient.IsConfigured(request.Url, request.ApiKey))
+        if (!SeerrClient.IsConfigured(request.Url, request.ApiKey))
             return BadRequest(new { success = false, error = "URL and API key are required" });
 
         try
         {
-            using var client = new JellyseerrClient(request.Url!, request.ApiKey!, _logger);
+            using var client = new SeerrClient(request.Url!, request.ApiKey!, _logger);
             var userId = await client.GetJellyseerrUserIdAsync(GetCurrentUserId() ?? string.Empty)
                 .ConfigureAwait(false);
             return Ok(new
@@ -493,7 +493,7 @@ public class LetterboxdController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogWarning("Jellyseerr test failed: {Message}", ex.Message);
+            _logger.LogWarning("Seerr test failed: {Message}", ex.Message);
             return BadRequest(new { success = false, error = ex.Message });
         }
     }

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -29,10 +29,10 @@ public class Account
     public bool AutoRequestWatchlist { get; set; }
 
     /// <summary>
-    /// When true, <see cref="AutoRequestWatchlist"/> also creates an attributed Jellyseerr
+    /// When true, <see cref="AutoRequestWatchlist"/> also creates an attributed Seerr
     /// request for watchlisted films that are already in the library / available, as long as
     /// this user has no existing request for them. This backfills a requester trail for films
-    /// that entered the library outside Jellyseerr (manual Radarr add, deleted request, etc.)
+    /// that entered the library outside Seerr (manual Radarr add, deleted request, etc.)
     /// so "who wanted this?" is answerable. Off by default: it creates request rows for
     /// already-available media (harmless for downloads, Radarr already has the file).
     /// </summary>

--- a/LetterboxdSync/Configuration/PluginConfiguration.cs
+++ b/LetterboxdSync/Configuration/PluginConfiguration.cs
@@ -8,13 +8,13 @@ public class PluginConfiguration : BasePluginConfiguration
     public List<Account> Accounts { get; set; } = new List<Account>();
 
     /// <summary>
-    /// Base URL of the Jellyseerr instance, e.g. "http://192.168.1.122:5055" or "https://requests.example.com".
+    /// Base URL of the Seerr instance, e.g. "http://192.168.1.122:5055" or "https://requests.example.com".
     /// Trailing slash is stripped at use time.
     /// </summary>
     public string? JellyseerrUrl { get; set; }
 
     /// <summary>
-    /// Jellyseerr API key (Settings → General → API Key in Jellyseerr).
+    /// Seerr API key (Settings → General → API Key in Seerr).
     /// </summary>
     public string? JellyseerrApiKey { get; set; }
 

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.18.1.0</AssemblyVersion>
-    <FileVersion>1.18.1.0</FileVersion>
+    <AssemblyVersion>1.18.2.0</AssemblyVersion>
+    <FileVersion>1.18.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/SeerrClient.cs
+++ b/LetterboxdSync/SeerrClient.cs
@@ -11,10 +11,10 @@ using Microsoft.Extensions.Logging;
 namespace LetterboxdSync;
 
 /// <summary>
-/// Lightweight Jellyseerr client for fetching the Jellyfin-user-to-Jellyseerr-user
+/// Lightweight Seerr client for fetching the Jellyfin-user-to-Seerr-user
 /// mapping, creating per-user movie requests, and mirroring a user's watchlist.
 /// </summary>
-public class JellyseerrClient : IDisposable
+public class SeerrClient : IDisposable
 {
     private readonly HttpClient _http;
     private readonly ILogger _logger;
@@ -22,7 +22,7 @@ public class JellyseerrClient : IDisposable
 
     private Dictionary<string, int>? _jellyfinIdToJellyseerrId;
 
-    public JellyseerrClient(string baseUrl, string apiKey, ILogger logger, HttpMessageHandler? handler = null)
+    public SeerrClient(string baseUrl, string apiKey, ILogger logger, HttpMessageHandler? handler = null)
     {
         _baseUrl = baseUrl.TrimEnd('/');
         _logger = logger;
@@ -36,7 +36,7 @@ public class JellyseerrClient : IDisposable
         => !string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(apiKey);
 
     /// <summary>
-    /// Looks up the Jellyseerr user ID corresponding to a Jellyfin user ID (32-char hex).
+    /// Looks up the Seerr user ID corresponding to a Jellyfin user ID (32-char hex).
     /// Returns null if no matching user is found.
     /// </summary>
     public async Task<int?> GetJellyseerrUserIdAsync(string jellyfinUserId)
@@ -82,15 +82,15 @@ public class JellyseerrClient : IDisposable
             if (count < take) break;
         }
 
-        _logger.LogInformation("Jellyseerr user map loaded: {Count} users with linked Jellyfin IDs",
+        _logger.LogInformation("Seerr user map loaded: {Count} users with linked Jellyfin IDs",
             _jellyfinIdToJellyseerrId.Count);
     }
 
     /// <summary>
-    /// Looks up the current MediaStatus for a TMDb movie in Jellyseerr.
-    /// Returns null when Jellyseerr has no record of the title (so it's safe to request),
+    /// Looks up the current MediaStatus for a TMDb movie in Seerr.
+    /// Returns null when Seerr has no record of the title (so it's safe to request),
     /// or when the call fails (caller should fall through to attempting the request and
-    /// let Jellyseerr surface the real error). Status values follow Jellyseerr's enum:
+    /// let Seerr surface the real error). Status values follow Seerr's enum:
     /// 1=UNKNOWN, 2=PENDING, 3=PROCESSING, 4=PARTIALLY_AVAILABLE, 5=AVAILABLE,
     /// 6=BLOCKLISTED, 7=DELETED.
     /// </summary>
@@ -98,8 +98,8 @@ public class JellyseerrClient : IDisposable
         => (await GetMovieInfoAsync(tmdbId).ConfigureAwait(false)).Status;
 
     /// <summary>
-    /// Single movie lookup returning both the Jellyseerr MediaStatus and the set of Jellyseerr
-    /// user IDs that already have a request for the title. Status is null when Jellyseerr has no
+    /// Single movie lookup returning both the Seerr MediaStatus and the set of Seerr
+    /// user IDs that already have a request for the title. Status is null when Seerr has no
     /// record of the title (safe to request) or the call fails; the requester set is empty in
     /// those cases. Status enum: 1=UNKNOWN, 2=PENDING, 3=PROCESSING, 4=PARTIALLY_AVAILABLE,
     /// 5=AVAILABLE, 6=BLOCKLISTED, 7=DELETED.
@@ -113,7 +113,7 @@ public class JellyseerrClient : IDisposable
             using var response = await _http.GetAsync(url).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogDebug("Jellyseerr movie lookup non-success for TMDb {TmdbId}: {Status}",
+                _logger.LogDebug("Seerr movie lookup non-success for TMDb {TmdbId}: {Status}",
                     tmdbId, (int)response.StatusCode);
                 return (null, requesters);
             }
@@ -147,14 +147,14 @@ public class JellyseerrClient : IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogDebug("Jellyseerr movie lookup errored for TMDb {TmdbId}: {Message}",
+            _logger.LogDebug("Seerr movie lookup errored for TMDb {TmdbId}: {Message}",
                 tmdbId, ex.Message);
             return (null, requesters);
         }
     }
 
     /// <summary>
-    /// Outcome of a request attempt. <see cref="AlreadyExists"/> means Jellyseerr already
+    /// Outcome of a request attempt. <see cref="AlreadyExists"/> means Seerr already
     /// had the title in some non-UNKNOWN state (pending, processing, available, blocklisted)
     /// and we did NOT POST a new request; it should not be counted as a fresh request.
     /// </summary>
@@ -166,18 +166,18 @@ public class JellyseerrClient : IDisposable
     }
 
     /// <summary>
-    /// Creates a movie request in Jellyseerr for the given TMDb ID, attributed to the given Jellyseerr user.
+    /// Creates a movie request in Seerr for the given TMDb ID, attributed to the given Seerr user.
     /// <para>
     /// Default (<paramref name="backfillAvailable"/> false): pre-checks media status and skips the POST when
-    /// Jellyseerr already has a record of the title (pending / processing / available), so re-runs don't pile
+    /// Seerr already has a record of the title (pending / processing / available), so re-runs don't pile
     /// up duplicates for films the library already covers.
     /// </para>
     /// <para>
     /// Backfill (<paramref name="backfillAvailable"/> true): skips only when the title is blocklisted or THIS
     /// user already has a request for it. Available titles with no request from this user are still requested —
-    /// Jellyseerr 3.x accepts a request for available media as long as no active request exists, which restores
-    /// an attributed requester trail for films that entered the library outside Jellyseerr. If another user
-    /// holds the single active request, Jellyseerr returns 409 and we report <see cref="RequestResult.AlreadyExists"/>.
+    /// Seerr 3.x accepts a request for available media as long as no active request exists, which restores
+    /// an attributed requester trail for films that entered the library outside Seerr. If another user
+    /// holds the single active request, Seerr returns 409 and we report <see cref="RequestResult.AlreadyExists"/>.
     /// </para>
     /// </summary>
     public async Task<RequestResult> RequestMovieAsync(int tmdbId, int jellyseerrUserId, bool backfillAvailable = false)
@@ -187,7 +187,7 @@ public class JellyseerrClient : IDisposable
         // Never request blocklisted media (6), regardless of mode.
         if (status == 6)
         {
-            _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: blocklisted", tmdbId);
+            _logger.LogDebug("Skipping Seerr request for TMDb {TmdbId}: blocklisted", tmdbId);
             return RequestResult.AlreadyExists;
         }
 
@@ -197,7 +197,7 @@ public class JellyseerrClient : IDisposable
             // title is exactly what we want to attribute.
             if (requesters.Contains(jellyseerrUserId))
             {
-                _logger.LogDebug("Skipping Jellyseerr backfill for TMDb {TmdbId}: user {UserId} already has a request",
+                _logger.LogDebug("Skipping Seerr backfill for TMDb {TmdbId}: user {UserId} already has a request",
                     tmdbId, jellyseerrUserId);
                 return RequestResult.AlreadyExists;
             }
@@ -207,7 +207,7 @@ public class JellyseerrClient : IDisposable
             // Re-request DELETED (7); skip everything else above UNKNOWN (1).
             if (status.HasValue && status.Value > 1 && status.Value != 7)
             {
-                _logger.LogDebug("Skipping Jellyseerr request for TMDb {TmdbId}: already has status {Status}",
+                _logger.LogDebug("Skipping Seerr request for TMDb {TmdbId}: already has status {Status}",
                     tmdbId, status.Value);
                 return RequestResult.AlreadyExists;
             }
@@ -222,25 +222,25 @@ public class JellyseerrClient : IDisposable
             return RequestResult.Requested;
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        // Belt-and-braces: Jellyseerr returns 409 when an active request already exists; treat as a no-op.
+        // Belt-and-braces: Seerr returns 409 when an active request already exists; treat as a no-op.
         if ((int)response.StatusCode == 409 ||
             responseBody.Contains("REQUEST_EXISTS", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already requested", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already exists", StringComparison.OrdinalIgnoreCase) ||
             responseBody.Contains("already available", StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogDebug("Jellyseerr already has request for TMDb {TmdbId} (user {UserId}): {Body}",
+            _logger.LogDebug("Seerr already has request for TMDb {TmdbId} (user {UserId}): {Body}",
                 tmdbId, jellyseerrUserId, Truncate(responseBody, 200));
             return RequestResult.AlreadyExists;
         }
 
-        _logger.LogWarning("Jellyseerr request failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+        _logger.LogWarning("Seerr request failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
             tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
         return RequestResult.Failed;
     }
 
     /// <summary>
-    /// Returns the set of TMDb IDs of <paramref name="mediaType"/> currently on the given Jellyseerr
+    /// Returns the set of TMDb IDs of <paramref name="mediaType"/> currently on the given Seerr
     /// user's watchlist. Pages through results until exhausted. Returns an empty set on failure
     /// (caller should treat that as "unknown" and avoid destructive removals).
     /// </summary>
@@ -252,7 +252,7 @@ public class JellyseerrClient : IDisposable
 
         while (page <= totalPages)
         {
-            // Jellyseerr's user/:id/watchlist endpoint paginates with `page=N`. It rejects
+            // Seerr's user/:id/watchlist endpoint paginates with `page=N`. It rejects
             // unknown params with a 400, so do NOT pass take/skip here.
             var url = $"{_baseUrl}/api/v1/user/{jellyseerrUserId}/watchlist?page={page}";
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -262,7 +262,7 @@ public class JellyseerrClient : IDisposable
             if (!response.IsSuccessStatusCode)
             {
                 var errBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                _logger.LogWarning("Jellyseerr watchlist fetch failed for user {UserId}: {Status} {Body}",
+                _logger.LogWarning("Seerr watchlist fetch failed for user {UserId}: {Status} {Body}",
                     jellyseerrUserId, (int)response.StatusCode, Truncate(errBody, 300));
                 return ids;
             }
@@ -313,7 +313,7 @@ public class JellyseerrClient : IDisposable
     }
 
     /// <summary>
-    /// Adds a TMDb title to the given Jellyseerr user's watchlist. Acts as that user via
+    /// Adds a TMDb title to the given Seerr user's watchlist. Acts as that user via
     /// the X-API-User header so the entry is owned by them, not the API key's default admin.
     /// Returns true on success or "already there"; false on transient error.
     /// </summary>
@@ -335,13 +335,13 @@ public class JellyseerrClient : IDisposable
             responseBody.Contains("already on", StringComparison.OrdinalIgnoreCase))
             return true;
 
-        _logger.LogWarning("Jellyseerr watchlist add failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+        _logger.LogWarning("Seerr watchlist add failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
             tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
         return false;
     }
 
     /// <summary>
-    /// Removes a TMDb title from the given Jellyseerr user's watchlist. Acts as that user
+    /// Removes a TMDb title from the given Seerr user's watchlist. Acts as that user
     /// via the X-API-User header. 404 is treated as success (the entry was already gone).
     /// </summary>
     public async Task<bool> RemoveFromWatchlistAsync(int tmdbId, int jellyseerrUserId, string mediaType = "movie")
@@ -355,7 +355,7 @@ public class JellyseerrClient : IDisposable
             return true;
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        _logger.LogWarning("Jellyseerr watchlist remove failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
+        _logger.LogWarning("Seerr watchlist remove failed for TMDb {TmdbId} (user {UserId}): {Status} {Body}",
             tmdbId, jellyseerrUserId, (int)response.StatusCode, Truncate(responseBody, 200));
         return false;
     }

--- a/LetterboxdSync/Telemetry/TelemetryService.cs
+++ b/LetterboxdSync/Telemetry/TelemetryService.cs
@@ -62,7 +62,7 @@ internal static class TelemetryService
             || Contains(m, "Auth failed") || Contains(m, "session may be permanently invalid"))
             return CatAuth;
 
-        if (Contains(m, "Jellyseerr"))
+        if (Contains(m, "Seerr"))
             return CatJellyseerr;
 
         if (Contains(m, "Cloudflare") || Contains(m, "anti-bot") || Contains(m, "403"))
@@ -116,7 +116,7 @@ internal static class TelemetryService
         catch { /* telemetry must never break a sync */ }
     }
 
-    /// <summary>Direct error hook for failure paths that don't record a SyncEvent (auth catches, Jellyseerr aggregates).</summary>
+    /// <summary>Direct error hook for failure paths that don't record a SyncEvent (auth catches, Seerr aggregates).</summary>
     public static void RecordError(string category)
     {
         try

--- a/LetterboxdSync/WatchlistSyncRunner.cs
+++ b/LetterboxdSync/WatchlistSyncRunner.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 namespace LetterboxdSync;
 
 /// <summary>
-/// Performs the Letterboxd-watchlist → Jellyfin-playlist → Jellyseerr chain. Used by both
+/// Performs the Letterboxd-watchlist → Jellyfin-playlist → Seerr chain. Used by both
 /// the scheduled <see cref="WatchlistSyncTask"/> and the user-triggered API endpoint, gated
 /// behind <see cref="SyncGate"/> so it serialises with the diary sync.
 /// </summary>
@@ -157,23 +157,23 @@ public class WatchlistSyncRunner
 
     /// <summary>
     /// Test-only override. When set, CreateJellyseerrClient delegates to this so tests
-    /// can inject a JellyseerrClient bound to a mock HttpMessageHandler. Production
+    /// can inject a SeerrClient bound to a mock HttpMessageHandler. Production
     /// never assigns it.
     /// </summary>
-    internal static Func<string, string, ILogger, JellyseerrClient?>? JellyseerrClientFactoryOverride;
+    internal static Func<string, string, ILogger, SeerrClient?>? JellyseerrClientFactoryOverride;
 
-    private JellyseerrClient? CreateJellyseerrClient()
+    private SeerrClient? CreateJellyseerrClient()
     {
-        if (!JellyseerrClient.IsConfigured(Config.JellyseerrUrl, Config.JellyseerrApiKey))
+        if (!SeerrClient.IsConfigured(Config.JellyseerrUrl, Config.JellyseerrApiKey))
             return null;
 
         if (JellyseerrClientFactoryOverride != null)
             return JellyseerrClientFactoryOverride(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger);
 
-        return new JellyseerrClient(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger);
+        return new SeerrClient(Config.JellyseerrUrl!, Config.JellyseerrApiKey!, _logger);
     }
 
-    private async Task SyncOneUserAsync(User user, Account account, JellyseerrClient? jellyseerr, string source, CancellationToken cancellationToken)
+    private async Task SyncOneUserAsync(User user, Account account, SeerrClient? jellyseerr, string source, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Starting watchlist sync for {Username} (source={Source})", user.Username, source);
         SyncProgress.SetPhase($"Authenticating {user.Username}");
@@ -237,8 +237,8 @@ public class WatchlistSyncRunner
 
         await UpdatePlaylistAsync(user, account, watchlistItemIds, tmdbIds.Count).ConfigureAwait(false);
 
-        // Jellyseerr integration: auto-request unmatched films and/or mirror the
-        // Letterboxd watchlist into the user's Jellyseerr watchlist.
+        // Seerr integration: auto-request unmatched films and/or mirror the
+        // Letterboxd watchlist into the user's Seerr watchlist.
         var jellyseerrWanted = jellyseerr != null && (account.AutoRequestWatchlist || account.MirrorJellyseerrWatchlist);
         if (!jellyseerrWanted) return;
 
@@ -249,37 +249,37 @@ public class WatchlistSyncRunner
         }
         catch (Exception ex)
         {
-            _logger.LogWarning("Could not fetch Jellyseerr user map for {Username}: {Message}",
+            _logger.LogWarning("Could not fetch Seerr user map for {Username}: {Message}",
                 user.Username, ex.Message);
             return;
         }
 
         if (jellyseerrUserId == null)
         {
-            _logger.LogWarning("No Jellyseerr user linked to Jellyfin user {Username}; skipping Jellyseerr sync",
+            _logger.LogWarning("No Seerr user linked to Jellyfin user {Username}; skipping Seerr sync",
                 user.Username);
             return;
         }
 
         if (account.MirrorJellyseerrWatchlist)
         {
-            // The Jellyseerr watchlist is keyed by Jellyfin user, not by Letterboxd
+            // The Seerr watchlist is keyed by Jellyfin user, not by Letterboxd
             // account: running the mirror once per account would have each account
-            // overwrite the previous one's diff (toRemove = Jellyseerr - thisAccount
+            // overwrite the previous one's diff (toRemove = Seerr - thisAccount
             // wipes the other accounts' films). Only the primary account owns the
-            // Jellyseerr-watchlist destination so two accounts on one Jellyfin user
+            // Seerr-watchlist destination so two accounts on one Jellyfin user
             // can't clobber each other.
             var primary = Config.GetPrimaryAccountForUser(account.UserJellyfinId);
             if (ReferenceEquals(primary, account))
             {
-                SyncProgress.SetPhase($"Mirroring Jellyseerr watchlist for {user.Username}");
+                SyncProgress.SetPhase($"Mirroring Seerr watchlist for {user.Username}");
                 await MirrorJellyseerrWatchlistAsync(jellyseerr!, jellyseerrUserId.Value, tmdbIds, user.Username!, cancellationToken)
                     .ConfigureAwait(false);
             }
             else
             {
                 _logger.LogInformation(
-                    "Skipping Jellyseerr watchlist mirror for {LbUser}: not the primary account for {Username}",
+                    "Skipping Seerr watchlist mirror for {LbUser}: not the primary account for {Username}",
                     account.LetterboxdUsername, user.Username);
             }
         }
@@ -293,7 +293,7 @@ public class WatchlistSyncRunner
                 ? tmdbIds
                 : tmdbIds.Where(id => !matchedTmdbIds.Contains(id)).ToList();
 
-            SyncProgress.SetPhase($"Requesting {(account.BackfillAvailableRequests ? "watchlist" : "missing")} films via Jellyseerr for {user.Username}");
+            SyncProgress.SetPhase($"Requesting {(account.BackfillAvailableRequests ? "watchlist" : "missing")} films via Seerr for {user.Username}");
             if (requestIds.Count == 0) return;
 
             var requested = 0;
@@ -307,23 +307,23 @@ public class WatchlistSyncRunner
                     var result = await jellyseerr!.RequestMovieAsync(tmdbId, jellyseerrUserId.Value, account.BackfillAvailableRequests).ConfigureAwait(false);
                     switch (result)
                     {
-                        case JellyseerrClient.RequestResult.Requested: requested++; break;
-                        case JellyseerrClient.RequestResult.AlreadyExists: alreadyExists++; break;
+                        case SeerrClient.RequestResult.Requested: requested++; break;
+                        case SeerrClient.RequestResult.AlreadyExists: alreadyExists++; break;
                         default: failed++; break;
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning("Jellyseerr request errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                    _logger.LogWarning("Seerr request errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
                     failed++;
                 }
             }
             _logger.LogInformation(
-                "Jellyseerr auto-request for {Username} ({Mode}): {Requested} new, {Existing} already on Jellyseerr, {Failed} failed of {Total} considered",
+                "Seerr auto-request for {Username} ({Mode}): {Requested} new, {Existing} already on Seerr, {Failed} failed of {Total} considered",
                 user.Username, account.BackfillAvailableRequests ? "backfill" : "unmatched-only",
                 requested, alreadyExists, failed, requestIds.Count);
 
-            // Jellyseerr failures surface as return values, not SyncEvents; count the
+            // Seerr failures surface as return values, not SyncEvents; count the
             // batch once (not per film) so one outage doesn't inflate the error counter.
             if (failed > 0)
                 TelemetryService.RecordError(TelemetryService.CatJellyseerr);
@@ -404,7 +404,7 @@ public class WatchlistSyncRunner
     }
 
     private async Task MirrorJellyseerrWatchlistAsync(
-        JellyseerrClient jellyseerr,
+        SeerrClient jellyseerr,
         int jellyseerrUserId,
         List<int> letterboxdTmdbIds,
         string jellyfinUsername,
@@ -413,7 +413,7 @@ public class WatchlistSyncRunner
         if (letterboxdTmdbIds.Count == 0)
         {
             _logger.LogWarning(
-                "Empty Letterboxd watchlist for {Username}; skipping Jellyseerr mirror to avoid mass-deletion",
+                "Empty Letterboxd watchlist for {Username}; skipping Seerr mirror to avoid mass-deletion",
                 jellyfinUsername);
             return;
         }
@@ -425,7 +425,7 @@ public class WatchlistSyncRunner
         }
         catch (Exception ex)
         {
-            _logger.LogWarning("Failed to fetch Jellyseerr watchlist for {Username}: {Message}",
+            _logger.LogWarning("Failed to fetch Seerr watchlist for {Username}: {Message}",
                 jellyfinUsername, ex.Message);
             return;
         }
@@ -448,7 +448,7 @@ public class WatchlistSyncRunner
             }
             catch (Exception ex)
             {
-                _logger.LogWarning("Jellyseerr watchlist add errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                _logger.LogWarning("Seerr watchlist add errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
                 addFailed++;
             }
         }
@@ -467,13 +467,13 @@ public class WatchlistSyncRunner
             }
             catch (Exception ex)
             {
-                _logger.LogWarning("Jellyseerr watchlist remove errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
+                _logger.LogWarning("Seerr watchlist remove errored for TMDb {TmdbId}: {Message}", tmdbId, ex.Message);
                 removeFailed++;
             }
         }
 
         _logger.LogInformation(
-            "Jellyseerr watchlist mirror for {Username}: +{Added} -{Removed} (add failures {AddFailed}, remove failures {RemoveFailed})",
+            "Seerr watchlist mirror for {Username}: +{Added} -{Removed} (add failures {AddFailed}, remove failures {RemoveFailed})",
             jellyfinUsername, added, removed, addFailed, removeFailed);
     }
 }

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -89,7 +89,7 @@
                     </div>
                     <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;flex-wrap:wrap;">
                         <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
-                        <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Jellyseerr if configured)">Sync Watchlist Now</button>
+                        <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Seerr if configured)">Sync Watchlist Now</button>
                         <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
                     </div>
                     <div id="syncProgressBar" style="display:none;margin-bottom:1.5em;">
@@ -127,12 +127,12 @@
 
                 <!-- SETTINGS TAB -->
                 <div id="tab-settings" class="lb-tab-content" style="display:none;">
-                    <h3>Jellyseerr Integration <span class="c-muted" style="font-size:0.7em;">(optional)</span></h3>
-                    <p class="c-muted" style="font-size:0.9em;">Auto-request films from a user's Letterboxd watchlist that aren't yet in your Jellyfin library. Requests are attributed to each user's matching Jellyseerr account (matched by Jellyfin User ID).</p>
+                    <h3>Seerr Integration <span class="c-muted" style="font-size:0.7em;">(optional)</span></h3>
+                    <p class="c-muted" style="font-size:0.9em;">Auto-request films from a user's Letterboxd watchlist that aren't yet in your Jellyfin library. Requests are attributed to each user's matching Seerr account (matched by Jellyfin User ID).</p>
                     <div class="lb-account">
-                        <div style="margin-bottom:0.5em;"><label class="lb-field">Jellyseerr URL</label>
+                        <div style="margin-bottom:0.5em;"><label class="lb-field">Seerr URL</label>
                             <input type="text" id="jellyseerrUrl" placeholder="http://192.168.1.122:5055" /></div>
-                        <div style="margin-bottom:0.5em;"><label class="lb-field">Jellyseerr API Key</label>
+                        <div style="margin-bottom:0.5em;"><label class="lb-field">Seerr API Key</label>
                             <input type="password" id="jellyseerrApiKey" placeholder="Settings &rarr; General &rarr; API Key" /></div>
                         <div style="display:flex;gap:0.7em;align-items:center;">
                             <button type="button" class="lb-btn lb-btn-secondary" id="testJellyseerrBtn">Test Connection</button>
@@ -530,16 +530,16 @@
                                 + '<span class="lb-check-desc">Pulls your Letterboxd watchlist daily and mirrors it into a Jellyfin playlist. With multiple accounts, each gets its own playlist named "Letterboxd Watchlist (username)" by default. Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
-                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
-                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Jellyseerr (configure URL + API key above). Requests are attributed to this user\'s Jellyseerr account (matched by Jellyfin User ID). Requires Jellyseerr to be configured. Skips titles Jellyseerr already has pending, processing, or available, so re-runs no longer create duplicates.</span>'
+                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Seerr</span>'
+                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, submit a request to Seerr (configure URL + API key above). Requests are attributed to this user\'s Seerr account (matched by Jellyfin User ID). Requires Seerr to be configured. Skips titles Seerr already has pending, processing, or available, so re-runs no longer create duplicates.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="backfillAvailableRequests" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Also backfill requests for already-available watchlist films</span>'
-                                + '<span class="lb-check-desc">Extends auto-request to films that are already in the library. Creates an attributed Jellyseerr request for any watchlisted film this user has no request for, so films that arrived outside Jellyseerr (manual Radarr add, deleted request) still show a requester. Creates request rows for already-available media; it does not trigger re-downloads. Requires "Auto-request" above.</span>'
+                                + '<span class="lb-check-desc">Extends auto-request to films that are already in the library. Creates an attributed Seerr request for any watchlisted film this user has no request for, so films that arrived outside Seerr (manual Radarr add, deleted request) still show a requester. Creates request rows for already-available media; it does not trigger re-downloads. Requires "Auto-request" above.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="mirrorJellyseerrWatchlist" /><span class="lb-check-text">'
-                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Jellyseerr watchlist</span>'
-                                + '<span class="lb-check-desc">Two-way mirror against your Jellyseerr user\'s own watchlist (the one shown in the Jellyseerr UI). Adds films you\'ve added on Letterboxd, removes films you\'ve taken off. Only touches movies, so manually-added Jellyseerr TV entries are left alone. Requires Jellyseerr to be configured.</span>'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Seerr watchlist</span>'
+                                + '<span class="lb-check-desc">Two-way mirror against your Seerr user\'s own watchlist (the one shown in the Seerr UI). Adds films you\'ve added on Letterboxd, removes films you\'ve taken off. Only touches movies, so manually-added Seerr TV entries are left alone. Requires Seerr to be configured.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'
@@ -688,9 +688,9 @@
                             }).then(function (response) {
                                 response.json().then(function (data) {
                                     if (data.linkedToCurrentUser) {
-                                        statusEl.innerHTML = '<span class="c-green">Connected. Your Jellyfin user is linked to Jellyseerr user ID ' + data.jellyseerrUserId + '.</span>';
+                                        statusEl.innerHTML = '<span class="c-green">Connected. Your Jellyfin user is linked to Seerr user ID ' + data.jellyseerrUserId + '.</span>';
                                     } else {
-                                        statusEl.innerHTML = '<span class="c-blue">Connected, but no Jellyseerr user is linked to your Jellyfin account. Import Jellyfin users in Jellyseerr first.</span>';
+                                        statusEl.innerHTML = '<span class="c-blue">Connected, but no Seerr user is linked to your Jellyfin account. Import Jellyfin users in Seerr first.</span>';
                                     }
                                 });
                             }, function (err) {

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -90,7 +90,7 @@
                     <div id="syncControls">
                         <div style="display:flex;align-items:center;gap:1em;margin-bottom:0.5em;flex-wrap:wrap;">
                             <button type="button" class="lb-btn lb-btn-primary" id="runSyncBtn">Run Sync Now</button>
-                            <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Jellyseerr if configured)">Sync Watchlist Now</button>
+                            <button type="button" class="lb-btn lb-btn-secondary" id="runWatchlistSyncBtn" title="Pull your Letterboxd watchlist into the Jellyfin playlist (and Seerr if configured)">Sync Watchlist Now</button>
                             <span id="syncStatus" class="c-muted" style="font-size:0.9em;"></span>
                         </div>
                         <div id="syncProgressBar" style="display:none;margin-bottom:1.5em;">
@@ -305,12 +305,12 @@
                                 + '<span class="lb-check-desc">Pulls this account\'s Letterboxd watchlist daily and mirrors it into a Jellyfin playlist. With multiple accounts each gets its own playlist named "Letterboxd Watchlist (username)" by default. Adds new films and removes ones taken off Letterboxd. Films not in your library are skipped.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="autoRequestWatchlist" /><span class="lb-check-text">'
-                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Jellyseerr</span>'
-                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, request it through Jellyseerr. The request is attributed to your Jellyseerr account. Requires Jellyseerr to be configured in the admin plugin settings.</span>'
+                                + '<span class="lb-check-title">Auto-request unmatched watchlist films via Seerr</span>'
+                                + '<span class="lb-check-desc">When a watchlisted film is not in the Jellyfin library, request it through Seerr. The request is attributed to your Seerr account. Requires Seerr to be configured in the admin plugin settings.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="mirrorJellyseerrWatchlist" /><span class="lb-check-text">'
-                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Jellyseerr watchlist</span>'
-                                + '<span class="lb-check-desc">Two-way mirror against your Jellyseerr user\'s own watchlist. Only takes effect on the primary account, since the Jellyseerr watchlist is per-Jellyfin-user (the secondary account\'s flag is silently ignored to avoid the two accounts overwriting each other). Movies only, so manually-added Jellyseerr TV is left alone.</span>'
+                                + '<span class="lb-check-title">Mirror Letterboxd watchlist into Seerr watchlist</span>'
+                                + '<span class="lb-check-desc">Two-way mirror against your Seerr user\'s own watchlist. Only takes effect on the primary account, since the Seerr watchlist is per-Jellyfin-user (the secondary account\'s flag is silently ignored to avoid the two accounts overwriting each other). Movies only, so manually-added Seerr TV is left alone.</span>'
                                 + '</span></label>'
                                 + '<label><input type="checkbox" class="enableDiaryImport" /><span class="lb-check-text">'
                                 + '<span class="lb-check-title">Import Letterboxd diary as Jellyfin watched</span>'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Uses Letterboxd's current JSON API (`/api/v0/production-log-entries`).
 - **Rating sync, both ways** — Jellyfin ratings (0-10) mapped to Letterboxd stars (0.5-5.0), and Letterboxd ratings seed your Jellyfin user ratings
 - **Favorites** — sync Jellyfin favorites as Letterboxd likes
 - **Watchlist sync** — import your Letterboxd watchlist as a Jellyfin playlist
-- **Jellyseerr integration** — auto-request watchlist films missing from your library, attributed to the right user; optionally backfill requests for films that arrived outside Jellyseerr, and mirror your Letterboxd watchlist into Jellyseerr
+- **Seerr integration** — auto-request watchlist films missing from your library, attributed to the right user; optionally backfill requests for films that arrived outside Seerr, and mirror your Letterboxd watchlist into Seerr
 - **Diary import** — mark Jellyfin movies as played if they're in your Letterboxd diary
 - **Reviews** — write and post reviews to Letterboxd from the plugin dashboard
 - **Send logs to developer** — one-click diagnostic bundle from the Logs tab, with a full preview of what's sent and a reference code to quote in a bug report
@@ -78,9 +78,9 @@ That's it. Watch a movie and check your Letterboxd diary.
 | **Recently played only** | Limits daily catch-up to films played in the last N days |
 | **Primary account** | When one Jellyfin user links multiple Letterboxd accounts, the primary wins on rating-import conflicts and is preselected in the review modal |
 | **Watchlist to playlist** | Mirrors your Letterboxd watchlist into a Jellyfin playlist daily; each account gets its own playlist (name configurable) |
-| **Auto-request via Jellyseerr** | Watchlisted films missing from your library are requested in Jellyseerr, attributed to this user's Jellyseerr account (set the Jellyseerr URL and API key above the account list) |
-| **Backfill available requests** | Extends auto-request to films already in the library that have no request record, so films that arrived outside Jellyseerr still show a requester; never triggers re-downloads |
-| **Mirror into Jellyseerr watchlist** | Two-way mirror of your Letterboxd watchlist into your Jellyseerr user's own watchlist (movies only) |
+| **Auto-request via Seerr** | Watchlisted films missing from your library are requested in Seerr, attributed to this user's Seerr account (set the Seerr URL and API key above the account list) |
+| **Backfill available requests** | Extends auto-request to films already in the library that have no request record, so films that arrived outside Seerr still show a requester; never triggers re-downloads |
+| **Mirror into Seerr watchlist** | Two-way mirror of your Letterboxd watchlist into your Seerr user's own watchlist (movies only) |
 | **Import diary as played** | Marks Jellyfin movies as played if they appear in your Letterboxd diary |
 | **Skip previously synced** | Uses the plugin's local sync history to skip films already logged without hitting Letterboxd; recommended, especially on large libraries |
 | **Stop on failure** | Halts the run at the first failed film to avoid inflaming rate limits; the rest are picked up next run |
@@ -159,7 +159,7 @@ Unlike the anonymous telemetry above, **logs are not anonymous** — they can co
 - Jellyfin 10.11+
 - A Letterboxd account
 - [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation), required for the Letterboxd link to appear in the Jellyfin sidebar (everything else works without it)
-- Optional: a [Jellyseerr](https://github.com/seerr-team/seerr) instance for the auto-request and watchlist-mirror integrations
+- Optional: a [Seerr](https://github.com/seerr-team/seerr) instance for the auto-request and watchlist-mirror integrations
 
 ## Building from source
 

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,17 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.18.2',
+    headline: 'Jellyseerr is now called Seerr',
+    summary:
+      'Jellyseerr and Overseerr have merged into a single project called Seerr. The plugin now uses the new name everywhere you see it, in the settings page, your personal account page, and the documentation, so the labels match what you see in the app you are connecting to. Nothing about the integration changes: your existing Seerr URL, API key, and per-account settings are kept, and there is nothing to reconfigure.',
+    highlights: {
+      improvements: [
+        'The "Jellyseerr integration" settings, the auto-request and watchlist-mirror options, and the connection-test messages now all read "Seerr" to match the renamed project. Your saved URL, API key, and account settings carry over untouched.',
+      ],
+    },
+  },
+  {
     version: '1.18.1',
     headline: 'Internal: test analytics in CI',
     summary:


### PR DESCRIPTION
Closes #76.

Jellyseerr and Overseerr have merged into a single project now called **Seerr** (`seerr-team/seerr`). This updates the terminology the plugin shows users.

## What changed
- **User-facing text** renamed Jellyseerr to Seerr: admin settings page (`configPage.html`), per-user account page (`userPage.html`), README, log/exception messages, the telemetry error classifier literal, and code comments.
- **Internal type rename:** `JellyseerrClient` to `SeerrClient` (file renamed too), and the matching test file/class.

## What deliberately did NOT change (backward compatibility)
- **Serialized config property names** are untouched: `JellyseerrUrl`, `JellyseerrApiKey`, and the per-account `MirrorJellyseerrWatchlist`. These are persisted to the Jellyfin plugin config XML, so renaming them would silently wipe existing users' saved Seerr URL/API key and mirror setting on upgrade. Existing installs carry over with nothing to reconfigure.
- **Telemetry wire keys** are untouched (`jellyseerr_error`, `mirror_jellyseerr`, `jellyseerr_configured`, and the `WindowErrJellyseerr` / `StateJellyseerr` / `CatJellyseerr` fields) so the ingest backend stays compatible and historical aggregation is unbroken.
- The `TestJellyseerr` API route and the HTML JS identifiers that bind to the kept C# members are unchanged.

The error classifier (`TelemetryService.Classify`) was updated from `"Jellyseerr"` to `"Seerr"` in lockstep with the renamed exception messages, so Seerr failures still bucket correctly.

Build green, 579 tests pass.

## Release notes
Jellyseerr and Overseerr have merged into a single project called Seerr. The plugin now uses the new name everywhere you see it, in the settings page, your personal account page, and the documentation, so the labels match what you see in the app you are connecting to. Nothing about the integration changes: your existing Seerr URL, API key, and per-account settings are kept, and there is nothing to reconfigure.
