### PR TITLE
feat: classify rate-limit, server, write, and parse errors instead of "other"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.18.2.0</Version>
-        <AssemblyVersion>1.18.2.0</AssemblyVersion>
-        <FileVersion>1.18.2.0</FileVersion>
+        <Version>1.18.3.0</Version>
+        <AssemblyVersion>1.18.3.0</AssemblyVersion>
+        <FileVersion>1.18.3.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/TelemetryServiceTests.cs
+++ b/LetterboxdSync.Tests/TelemetryServiceTests.cs
@@ -70,6 +70,13 @@ public class TelemetryServiceTests : IDisposable
     [InlineData("returned 403 during login. Likely reCAPTCHA. Provide raw cookies instead.", TelemetryService.CatAuth)]
     [InlineData("Film with TMDb ID 123 not found on Letterboxd.", TelemetryService.CatTmdb)]
     [InlineData("Seerr request errored", TelemetryService.CatJellyseerr)]
+    [InlineData("Letterboxd returned 429 for some-film. Too Many Requests.", TelemetryService.CatRateLimit)]
+    [InlineData("Letterboxd returned 503 for some-film", TelemetryService.CatServerError)]
+    [InlineData("Failed to log some-film after 4 retries.", TelemetryService.CatWriteFailure)]
+    [InlineData("Failed to post review for some-film after 4 attempts", TelemetryService.CatWriteFailure)]
+    [InlineData("Could not resolve film identifiers for /film/some-film/", TelemetryService.CatParse)]
+    [InlineData("data-film-id attribute empty on /film/some-film/", TelemetryService.CatParse)]
+    [InlineData("Letterboxd API token expired. Will re-authenticate on next sync.", TelemetryService.CatAuth)]
     [InlineData("something exploded", TelemetryService.CatOther)]
     [InlineData(null, TelemetryService.CatOther)]
     public void Classify_MapsKnownPatterns(string? message, string expected)
@@ -191,10 +198,19 @@ public class TelemetryServiceTests : IDisposable
     {
         var t = Enable();
         TelemetryService.OnSyncEvent(Evt(SyncStatus.Failed, "Cloudflare is blocking"));
+        // Categories beyond Cloudflare must also clear on recovery; the reset previously
+        // omitted Jellyseerr (and now the rate/server/write/parse buckets), leaving a stuck
+        // failing-state that could never re-fire a transition ping.
+        TelemetryService.OnSyncEvent(Evt(SyncStatus.Failed, "Seerr request errored"));
+        TelemetryService.OnSyncEvent(Evt(SyncStatus.Failed, "Failed to log some-film after 4 retries."));
         Assert.True(t.StateCloudflare);
+        Assert.True(t.StateJellyseerr);
+        Assert.True(t.StateWriteFailure);
 
         TelemetryService.OnSyncEvent(Evt(SyncStatus.Success));
         Assert.False(t.StateCloudflare);
+        Assert.False(t.StateJellyseerr);
+        Assert.False(t.StateWriteFailure);
     }
 
     // ----- Rising edge + daily cap + consolidation -----

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.18.2.0</AssemblyVersion>
-    <FileVersion>1.18.2.0</FileVersion>
+    <AssemblyVersion>1.18.3.0</AssemblyVersion>
+    <FileVersion>1.18.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Telemetry/TelemetryData.cs
+++ b/LetterboxdSync/Telemetry/TelemetryData.cs
@@ -50,6 +50,10 @@ public class TelemetryData
     public int WindowErrAuth { get; set; }
     public int WindowErrTmdb { get; set; }
     public int WindowErrJellyseerr { get; set; }
+    public int WindowErrRateLimit { get; set; }
+    public int WindowErrServerError { get; set; }
+    public int WindowErrWriteFailure { get; set; }
+    public int WindowErrParse { get; set; }
     public int WindowErrOther { get; set; }
 
     // Per-category failing state for rising-edge transition detection. A category firing
@@ -59,5 +63,9 @@ public class TelemetryData
     public bool StateAuth { get; set; }
     public bool StateTmdb { get; set; }
     public bool StateJellyseerr { get; set; }
+    public bool StateRateLimit { get; set; }
+    public bool StateServerError { get; set; }
+    public bool StateWriteFailure { get; set; }
+    public bool StateParse { get; set; }
     public bool StateOther { get; set; }
 }

--- a/LetterboxdSync/Telemetry/TelemetryService.cs
+++ b/LetterboxdSync/Telemetry/TelemetryService.cs
@@ -27,6 +27,10 @@ internal static class TelemetryService
     public const string CatAuth = "auth_failure";
     public const string CatTmdb = "tmdb_lookup";
     public const string CatJellyseerr = "jellyseerr_error";
+    public const string CatRateLimit = "rate_limit";
+    public const string CatServerError = "server_error";
+    public const string CatWriteFailure = "write_failure";
+    public const string CatParse = "parse_error";
     public const string CatOther = "other";
 
     private static readonly object _lock = new();
@@ -48,10 +52,13 @@ internal static class TelemetryService
     // ---------- Classification ----------
 
     /// <summary>
-    /// Maps a failure message onto one of the five error categories. Order matters:
+    /// Maps a failure message onto one of the error categories. Order matters:
     /// auth indicators are checked before the generic 403/Cloudflare bucket because
     /// "401 after re-authentication" and login errors are auth problems even when
-    /// Cloudflare vocabulary appears alongside.
+    /// Cloudflare vocabulary appears alongside. Rate-limit (429) is checked before
+    /// the generic Cloudflare/403 bucket so throttling is reported as throttling, and
+    /// the write/parse buckets sit last so a more specific signal (auth, 429, 5xx,
+    /// TMDb) always wins over the generic "the write failed" / "the page didn't parse".
     /// </summary>
     public static string Classify(string? errorMessage)
     {
@@ -59,17 +66,32 @@ internal static class TelemetryService
         var m = errorMessage;
 
         if (Contains(m, "login error") || Contains(m, "401") || Contains(m, "reCAPTCHA")
-            || Contains(m, "Auth failed") || Contains(m, "session may be permanently invalid"))
+            || Contains(m, "Auth failed") || Contains(m, "session may be permanently invalid")
+            || Contains(m, "token expired"))
             return CatAuth;
 
         if (Contains(m, "Seerr"))
             return CatJellyseerr;
 
+        if (Contains(m, "429") || Contains(m, "Too Many Requests") || Contains(m, "rate limit"))
+            return CatRateLimit;
+
         if (Contains(m, "Cloudflare") || Contains(m, "anti-bot") || Contains(m, "403"))
             return CatCloudflare;
 
+        if (Contains(m, "returned 500") || Contains(m, "returned 502")
+            || Contains(m, "returned 503") || Contains(m, "returned 504"))
+            return CatServerError;
+
         if (Contains(m, "not found on Letterboxd") || Contains(m, "TMDb lookup") || Contains(m, "TMDb ID"))
             return CatTmdb;
+
+        if (Contains(m, "Could not resolve film") || Contains(m, "Could not find film element")
+            || Contains(m, "data-film-id") || Contains(m, "non-film URL"))
+            return CatParse;
+
+        if (Contains(m, "Failed to log") || Contains(m, "Failed to post"))
+            return CatWriteFailure;
 
         return CatOther;
     }
@@ -100,8 +122,12 @@ internal static class TelemetryService
                         // Recovery: a film made it all the way to Letterboxd, so the
                         // pipeline is healthy; flip every category back to clean. The
                         // recovery is visible in the next weekly payload (by design,
-                        // no recovery ping).
-                        d.StateCloudflare = d.StateAuth = d.StateTmdb = d.StateOther = false;
+                        // no recovery ping). Must cover every category, including
+                        // Jellyseerr and the rate/server/write/parse buckets, or a stuck
+                        // failing-state would never clear and never re-fire a transition.
+                        d.StateCloudflare = d.StateAuth = d.StateTmdb = d.StateJellyseerr =
+                            d.StateRateLimit = d.StateServerError = d.StateWriteFailure =
+                            d.StateParse = d.StateOther = false;
                         break;
                     case SyncStatus.Skipped:
                         d.WindowSkipped++;
@@ -140,6 +166,10 @@ internal static class TelemetryService
             case CatAuth: wasFailing = d.StateAuth; d.StateAuth = true; d.WindowErrAuth++; break;
             case CatTmdb: wasFailing = d.StateTmdb; d.StateTmdb = true; d.WindowErrTmdb++; break;
             case CatJellyseerr: wasFailing = d.StateJellyseerr; d.StateJellyseerr = true; d.WindowErrJellyseerr++; break;
+            case CatRateLimit: wasFailing = d.StateRateLimit; d.StateRateLimit = true; d.WindowErrRateLimit++; break;
+            case CatServerError: wasFailing = d.StateServerError; d.StateServerError = true; d.WindowErrServerError++; break;
+            case CatWriteFailure: wasFailing = d.StateWriteFailure; d.StateWriteFailure = true; d.WindowErrWriteFailure++; break;
+            case CatParse: wasFailing = d.StateParse; d.StateParse = true; d.WindowErrParse++; break;
             default: wasFailing = d.StateOther; d.StateOther = true; d.WindowErrOther++; break;
         }
 
@@ -212,7 +242,8 @@ internal static class TelemetryService
                     d.LastWeeklyPingUtc = UtcNow;
                     d.WindowSyncs = d.WindowSkipped = 0;
                     d.WindowErrCloudflare = d.WindowErrAuth = d.WindowErrTmdb =
-                        d.WindowErrJellyseerr = d.WindowErrOther = 0;
+                        d.WindowErrJellyseerr = d.WindowErrRateLimit = d.WindowErrServerError =
+                        d.WindowErrWriteFailure = d.WindowErrParse = d.WindowErrOther = 0;
                     SaveLocked();
                 }
                 logger?.LogInformation("Telemetry: weekly ping sent");
@@ -284,6 +315,10 @@ internal static class TelemetryService
                 auth_failure = d.WindowErrAuth,
                 tmdb_lookup = d.WindowErrTmdb,
                 jellyseerr_error = d.WindowErrJellyseerr,
+                rate_limit = d.WindowErrRateLimit,
+                server_error = d.WindowErrServerError,
+                write_failure = d.WindowErrWriteFailure,
+                parse_error = d.WindowErrParse,
                 other = d.WindowErrOther,
                 state = new
                 {
@@ -291,6 +326,10 @@ internal static class TelemetryService
                     auth_failure = d.StateAuth,
                     tmdb_lookup = d.StateTmdb,
                     jellyseerr_error = d.StateJellyseerr,
+                    rate_limit = d.StateRateLimit,
+                    server_error = d.StateServerError,
+                    write_failure = d.StateWriteFailure,
+                    parse_error = d.StateParse,
                     other = d.StateOther
                 }
             }

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,20 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.18.3',
+    headline: 'More precise error reporting in telemetry',
+    summary:
+      'If you have opted in to the anonymous telemetry, plugin errors are now sorted into more specific categories instead of a single generic "other" bucket. Rate-limiting, Letterboxd server outages, failed writes back to Letterboxd, and page-parsing problems are each labelled distinctly. This is purely a labelling improvement: no behaviour changes, and nothing new about you or your library is collected.',
+    highlights: {
+      improvements: [
+        'Anonymous telemetry now distinguishes four previously-uncategorised error types: rate-limiting (being throttled by Letterboxd), server errors (Letterboxd returning a 5xx), write failures (a watch or review that could not be logged after retries), and parsing errors (a Letterboxd page that no longer matches what the plugin expects). Previously these all counted as "other".',
+      ],
+      fixes: [
+        'Fixed the error-state recovery so that, after a successful sync, every error category is cleared. One category was previously skipped, which could leave a stale "still failing" flag set.',
+      ],
+    },
+  },
+  {
     version: '1.18.2',
     headline: 'Jellyseerr is now called Seerr',
     summary:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,7 +11,8 @@ export interface Env {
   INGEST_KEY: string;
 }
 
-const CATEGORIES = ["cloudflare_403", "auth_failure", "tmdb_lookup", "jellyseerr_error", "other"];
+const CATEGORIES = ["cloudflare_403", "auth_failure", "tmdb_lookup", "jellyseerr_error",
+  "rate_limit", "server_error", "write_failure", "parse_error", "other"];
 const MAX_BODY_BYTES = 2048;
 const MAX_LOG_BYTES = 262144; // 256 KB cap on a diagnostic bundle
 // Crockford base32 minus ambiguous chars, for human-quotable ref codes.


### PR DESCRIPTION
## Summary
The telemetry `errors` payload had a single `other` catch-all. Several well-known failure modes in the sync/scrape path produce messages that match none of the existing classifier keywords, so they all collapsed into `other` and lost diagnostic value. This adds dedicated categories so each bucket reflects the actual failure mode, and each maps to a different remediation.

This is a labelling-only change to the optional, opt-in anonymous telemetry. No behaviour changes and nothing new is collected; the same error counts are simply sorted more precisely.

## New categories
| Category | Catches | Why it's actionable |
|---|---|---|
| `rate_limit` | HTTP 429 / "Too Many Requests" | We're being throttled, back off |
| `server_error` | Letterboxd 5xx (`returned 500/502/503/504`) | Upstream outage, transient, not our bug |
| `write_failure` | a watch/review POST that exhausts retries (`Failed to log…`, `Failed to post…`) | Endpoint/CSRF/session drift in our write path |
| `parse_error` | scraper structure misses (`Could not resolve film…`, `Could not find film element`, `data-film-id`, `non-film URL`) | Letterboxd HTML changed, scraper needs updating |

Two correctness fixes folded in:
- `token expired` now classifies as `auth_failure` (previously `other`).
- **Recovery-reset bug:** on a successful sync, `OnSyncEvent` cleared the per-category failing-state flags but the list omitted the Jellyseerr category, so a Jellyseerr failing-state could never clear and never re-fire a rising-edge transition ping. Now resets every category (incl. the four new ones).

## Wire compatibility
- `errors` is stored as a JSON blob in D1, so **no schema migration** and `schema_version` stays `1`. The change is purely additive.
- `worker/src/index.ts` has a hardcoded `CATEGORIES` whitelist and stores only keys in it, new categories are silently dropped until the worker knows them. The whitelist is extended in this PR; missing keys default to `0`, so old plugin versions and the new worker remain mutually compatible in both directions.
- The config-page telemetry preview renders the payload generically, so the new keys appear automatically.

## Deploy note
The worker is not deployed by the release pipeline. After this merges, run `wrangler deploy` in `worker/` (ideally at or before the plugin release) so the new buckets are captured from the first ping. Until then, the new categories are simply not stored, existing categories are unaffected.

## Tests
Build green, 586 unit tests pass. Added classifier cases for each new category and the `token expired` → auth route, and extended the recovery test to assert non-Cloudflare categories clear on success (would have failed before the reset fix).

## Release notes
Plugin error reporting (the optional anonymous telemetry) now distinguishes rate-limiting, Letterboxd server errors, failed writes, and page-parsing problems instead of lumping them under a generic "other" bucket. This is purely a labelling improvement, no behaviour changes, and nothing new about you or your library is collected.
