### PR TITLE
fix: resolve film ids from data-postered-identifier markup (#79)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.18.3.0</Version>
-        <AssemblyVersion>1.18.3.0</AssemblyVersion>
-        <FileVersion>1.18.3.0</FileVersion>
+        <Version>1.18.4.0</Version>
+        <AssemblyVersion>1.18.4.0</AssemblyVersion>
+        <FileVersion>1.18.4.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
+++ b/LetterboxdSync.Tests/Integration/LetterboxdLiveTests.cs
@@ -223,6 +223,35 @@ public class LetterboxdLiveTests
         Assert.NotNull(info);
     }
 
+    /// <summary>
+    /// Forces the HTML-scraping path (bypassing the API-first factory) and asserts
+    /// LookupFilmByTmdbIdAsync still resolves a non-empty FilmId from live markup.
+    /// This is the one test that turns red when Letterboxd changes its film-page
+    /// HTML — exactly the regression in issue #79, where the API path masked a
+    /// broken scraper because every other integration test runs on the API path.
+    /// </summary>
+    [SkippableFact]
+    public async Task Scraping_LookupFilmByTmdbId_ResolvesIdentifiersFromLiveMarkup()
+    {
+        var (user, pass, cookies, ua) = RequireCreds();
+        using var service = new ScrapingLetterboxdService(_logger, ua);
+        try
+        {
+            await service.AuthenticateAsync(user, pass, cookies).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Skip.If(true, $"Skipping scraping-path test: scraper auth failed for the test account ({ex.Message}).");
+        }
+
+        var film = await service.LookupFilmByTmdbIdAsync(TmdbPulpFiction).ConfigureAwait(false);
+
+        Assert.NotNull(film);
+        Assert.Contains("pulp-fiction", film.Slug, StringComparison.OrdinalIgnoreCase);
+        Assert.False(string.IsNullOrWhiteSpace(film.FilmId),
+            "Scraping path must resolve a FilmId from the film page — empty means the markup changed (issue #79).");
+    }
+
     // ----- Write tests with self-cleanup (API path only) -----
 
     /// <summary>

--- a/LetterboxdSync.Tests/ScraperTests.cs
+++ b/LetterboxdSync.Tests/ScraperTests.cs
@@ -175,16 +175,35 @@ public class ScraperTests
     }
 
     [Fact]
-    public void ExtractFilmIdentifiers_EmptyFilmId_Throws()
+    public void ExtractFilmIdentifiers_NoIdentifiersAtAll_Throws()
     {
-        // The element is found but data-film-id is blank → explicit failure rather than
-        // silently returning an empty id that would corrupt later API calls.
+        // The element is found but carries neither a usable filmId nor a productionId
+        // → explicit failure rather than silently returning empty ids that would
+        // corrupt later API calls.
         var html = "<div data-film-slug=\"test\" data-film-id=\"\"></div>";
         var http = new LetterboxdHttpClient(TestLogger);
         var scraper = new LetterboxdScraper(http, TestLogger);
 
         var ex = Assert.Throws<Exception>(() => scraper.ExtractFilmIdentifiers(html, "test"));
-        Assert.Contains("empty", ex.Message);
+        Assert.Contains("identifiers", ex.Message);
+        http.Dispose();
+    }
+
+    [Fact]
+    public void ExtractFilmIdentifiers_NewMarkup_ExtractsBothFromPosteredIdentifier()
+    {
+        // Mid-2026 Letterboxd markup: no data-film-slug / data-film-id; ids live in the
+        // entity-encoded data-postered-identifier JSON on the data-item-link element.
+        var html = "<div class=\"react-component\" data-item-slug=\"spider-man\" " +
+                   "data-item-link=\"/film/spider-man/\" " +
+                   "data-postered-identifier='{&quot;lid&quot;:&quot;2a8i&quot;,&quot;uid&quot;:&quot;film:51561&quot;,&quot;type&quot;:&quot;film&quot;}'></div>";
+        var http = new LetterboxdHttpClient(TestLogger);
+        var scraper = new LetterboxdScraper(http, TestLogger);
+
+        var (filmId, productionId) = scraper.ExtractFilmIdentifiers(html, "spider-man");
+
+        Assert.Equal("51561", filmId);
+        Assert.Equal("2a8i", productionId);
         http.Dispose();
     }
 

--- a/LetterboxdSync/LetterboxdScraper.cs
+++ b/LetterboxdSync/LetterboxdScraper.cs
@@ -313,32 +313,55 @@ public class LetterboxdScraper
         var filmDoc = new HtmlDocument();
         filmDoc.LoadHtml(filmHtml);
 
-        if (string.IsNullOrEmpty(productionId))
+        // Letterboxd dropped the legacy data-film-slug / data-film-id attributes in mid-2026
+        // in favour of data-item-slug / data-item-link plus a data-postered-identifier JSON
+        // blob that carries both ids: {"lid":"2a8i","uid":"film:51561",...}. lid is the
+        // productionId; the numeric tail of uid is the old filmId.
+        var el = filmDoc.DocumentNode.SelectSingleNode($"//div[@data-film-slug='{filmSlug}']")
+              ?? filmDoc.DocumentNode.SelectSingleNode($"//div[@data-item-slug='{filmSlug}']")
+              ?? filmDoc.DocumentNode.SelectSingleNode($"//div[@data-item-link='/film/{filmSlug}/']")
+              ?? filmDoc.DocumentNode.SelectSingleNode("//div[@data-film-id]")
+              ?? filmDoc.DocumentNode.SelectSingleNode("//div[@data-postered-identifier]");
+
+        if (el == null)
+            throw new Exception($"Could not find film element on page /film/{filmSlug}/");
+
+        // Prefer the explicit numeric attribute when present (legacy markup).
+        var filmId = el.GetAttributeValue("data-film-id", string.Empty);
+
+        // Pull missing ids out of the data-postered-identifier JSON — on the element itself
+        // (new markup) or, failing that, the first one on the page (kept for older fixtures).
+        if (string.IsNullOrEmpty(filmId) || string.IsNullOrEmpty(productionId))
         {
-            var posterEl = filmDoc.DocumentNode.SelectSingleNode("//div[@data-postered-identifier]");
+            var posterEl = el.Attributes.Contains("data-postered-identifier")
+                ? el
+                : filmDoc.DocumentNode.SelectSingleNode("//div[@data-postered-identifier]");
             var posterJson = posterEl?.GetAttributeValue("data-postered-identifier", string.Empty);
             if (!string.IsNullOrEmpty(posterJson))
             {
                 try
                 {
-                    using var doc = JsonDocument.Parse(posterJson);
-                    if (doc.RootElement.TryGetProperty("lid", out var lid))
+                    using var doc = JsonDocument.Parse(HtmlEntity.DeEntitize(posterJson));
+                    var root = doc.RootElement;
+                    if (string.IsNullOrEmpty(productionId) && root.TryGetProperty("lid", out var lid))
                         productionId = lid.GetString();
+                    if (string.IsNullOrEmpty(filmId) && root.TryGetProperty("uid", out var uid))
+                    {
+                        var uidStr = uid.GetString();
+                        if (!string.IsNullOrEmpty(uidStr))
+                        {
+                            // uid looks like "film:51561"; the numeric tail is the legacy filmId.
+                            var colon = uidStr.LastIndexOf(':');
+                            filmId = colon >= 0 ? uidStr[(colon + 1)..] : uidStr;
+                        }
+                    }
                 }
                 catch { }
             }
         }
 
-        var el = filmDoc.DocumentNode.SelectSingleNode($"//div[@data-film-slug='{filmSlug}']")
-              ?? filmDoc.DocumentNode.SelectSingleNode($"//div[@data-item-link='/film/{filmSlug}/']")
-              ?? filmDoc.DocumentNode.SelectSingleNode("//div[@data-film-id]");
-
-        if (el == null)
-            throw new Exception($"Could not find film element on page /film/{filmSlug}/");
-
-        var filmId = el.GetAttributeValue("data-film-id", string.Empty);
-        if (string.IsNullOrEmpty(filmId))
-            throw new Exception($"data-film-id attribute empty on /film/{filmSlug}/");
+        if (string.IsNullOrEmpty(filmId) && string.IsNullOrEmpty(productionId))
+            throw new Exception($"Could not resolve film identifiers (filmId/productionId) on /film/{filmSlug}/");
 
         return (filmId, productionId);
     }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.18.3.0</AssemblyVersion>
-    <FileVersion>1.18.3.0</FileVersion>
+    <AssemblyVersion>1.18.4.0</AssemblyVersion>
+    <FileVersion>1.18.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #79.

## Problem

Letterboxd changed their film-page markup and removed the `data-film-id` and `data-film-slug` attributes the scraper relied on. The numeric film id now lives inside a JSON blob on the poster element:

```
data-postered-identifier='{"lid":"2a8i","uid":"film:51561","type":"film"}'
```

The scraper located the element via the `data-item-link` fallback but then threw `data-film-id attribute empty on /film/<slug>/`, breaking sync for everyone on the HTML-scraping path (users whose official API auth doesn't work).

## Fix

`ExtractFilmIdentifiers` now reads both ids out of `data-postered-identifier`: `lid` → productionId, and the numeric tail of `uid` (`film:51561` → `51561`) → filmId. Legacy `data-film-id` / `data-film-slug` attribute paths are kept for back-compat, and we only throw when *both* identifiers are missing (the diary payload prefers productionId anyway).

## Why no test caught it

- Unit tests assert against hand-written HTML fixtures frozen at the old markup, so a server-side change is invisible to them by construction.
- The live integration suite ran green throughout because `LetterboxdServiceFactory` tries the official API path first, and the API path resolves film ids via `/films` without ever calling the scraper. The broken code only runs on the scraping fallback, which had zero live coverage.

## Tests

- New unit fixture (`ExtractFilmIdentifiers_NewMarkup_ExtractsBothFromPosteredIdentifier`) using the real entity-encoded `data-postered-identifier` markup.
- New live integration test (`Scraping_LookupFilmByTmdbId_ResolvesIdentifiersFromLiveMarkup`) that forces the scraping path directly, so the next Letterboxd markup change turns this red instead of silently shipping.
- Updated the old `EmptyFilmId_Throws` test to the new "throw only when both ids missing" contract.
- Full suite green (587 passed, 0 failed).