### PR TITLE
fix: encrypt stored Letterboxd/Seerr credentials at rest

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.1.0</Version>
-        <AssemblyVersion>1.19.1.0</AssemblyVersion>
-        <FileVersion>1.19.1.0</FileVersion>
+        <Version>1.19.2.0</Version>
+        <AssemblyVersion>1.19.2.0</AssemblyVersion>
+        <FileVersion>1.19.2.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/AccountTests.cs
+++ b/LetterboxdSync.Tests/AccountTests.cs
@@ -37,9 +37,12 @@ public class AccountUpdateRequestTests
     public void AllAccountFieldsAreMapped()
     {
         // Every writable field on Account (except UserJellyfinId) should have
-        // a corresponding field on AccountUpdateRequest
+        // a corresponding field on AccountUpdateRequest. The *Protected shadow
+        // properties (SecretProtector's encrypted-at-rest XML view of
+        // LetterboxdPassword/RawCookies) are storage plumbing, not part of the
+        // request contract, and are deliberately excluded.
         var accountProps = typeof(Account).GetProperties()
-            .Where(p => p.Name != "UserJellyfinId")
+            .Where(p => p.Name != "UserJellyfinId" && !p.Name.EndsWith("Protected", System.StringComparison.Ordinal))
             .Select(p => p.Name)
             .ToHashSet();
 

--- a/LetterboxdSync.Tests/SecretProtectorTests.cs
+++ b/LetterboxdSync.Tests/SecretProtectorTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using LetterboxdSync.Configuration;
+using LetterboxdSync.Security;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Isolates the Data Protection key ring to a temp directory per test via
+/// SecretProtector.KeyDirectoryOverride, mirroring SyncHistoryStaticTests'
+/// DataPathOverride pattern.
+/// </summary>
+public class SecretProtectorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SecretProtectorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "lbs-secrets-" + Guid.NewGuid().ToString("N"));
+        SecretProtector.KeyDirectoryOverride = _tempDir;
+        SecretProtector.ResetForTesting();
+    }
+
+    public void Dispose()
+    {
+        SecretProtector.KeyDirectoryOverride = null;
+        SecretProtector.ResetForTesting();
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Fact]
+    public void Protect_RoundTrips()
+    {
+        var protectedValue = SecretProtector.Protect("hunter2");
+        Assert.NotNull(protectedValue);
+        Assert.NotEqual("hunter2", protectedValue);
+        Assert.StartsWith("enc:v1:", protectedValue);
+
+        Assert.Equal("hunter2", SecretProtector.Unprotect(protectedValue));
+    }
+
+    [Fact]
+    public void Protect_NullAndEmpty_PassThrough()
+    {
+        Assert.Null(SecretProtector.Protect(null));
+        Assert.Equal(string.Empty, SecretProtector.Protect(string.Empty));
+        Assert.Null(SecretProtector.Unprotect(null));
+        Assert.Equal(string.Empty, SecretProtector.Unprotect(string.Empty));
+    }
+
+    [Fact]
+    public void Unprotect_LegacyPlaintext_ReturnedAsIs()
+    {
+        // Values written before encryption was added have no "enc:v1:" prefix.
+        Assert.Equal("plaintext-password", SecretProtector.Unprotect("plaintext-password"));
+    }
+
+    [Fact]
+    public void Unprotect_CorruptCiphertext_ReturnsNull()
+    {
+        Assert.Null(SecretProtector.Unprotect("enc:v1:not-actually-valid-ciphertext"));
+    }
+
+    [Fact]
+    public void Unprotect_CiphertextFromDifferentKeyRing_ReturnsNull()
+    {
+        var protectedValue = SecretProtector.Protect("hunter2")!;
+
+        // Point at a fresh, empty key ring - simulates the key ring being lost/rotated.
+        var otherDir = Path.Combine(Path.GetTempPath(), "lbs-secrets-other-" + Guid.NewGuid().ToString("N"));
+        SecretProtector.KeyDirectoryOverride = otherDir;
+        SecretProtector.ResetForTesting();
+        try
+        {
+            Assert.Null(SecretProtector.Unprotect(protectedValue));
+        }
+        finally
+        {
+            try { if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Account_XmlRoundTrip_StoresPasswordEncrypted_ReadsBackPlaintext()
+    {
+        var account = new Account
+        {
+            UserJellyfinId = "user1",
+            LetterboxdUsername = "8bitproxy",
+            LetterboxdPassword = "correct horse battery staple",
+            RawCookies = "cf_clearance=abc123"
+        };
+
+        var xml = SerializeToString(account);
+
+        Assert.DoesNotContain("correct horse battery staple", xml);
+        Assert.DoesNotContain("cf_clearance=abc123", xml);
+        Assert.Contains("<LetterboxdPassword>enc:v1:", xml);
+        Assert.Contains("<RawCookies>enc:v1:", xml);
+
+        var roundTripped = DeserializeFromString<Account>(xml);
+        Assert.Equal("correct horse battery staple", roundTripped.LetterboxdPassword);
+        Assert.Equal("cf_clearance=abc123", roundTripped.RawCookies);
+    }
+
+    [Fact]
+    public void Account_Deserialize_LegacyPlaintextXml_MigratesTransparently()
+    {
+        // Simulates a LetterboxdSync.xml written before this change: plaintext element content.
+        const string legacyXml = """
+            <?xml version="1.0" encoding="utf-16"?>
+            <Account xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+              <UserJellyfinId>user1</UserJellyfinId>
+              <LetterboxdUsername>8bitproxy</LetterboxdUsername>
+              <LetterboxdPassword>plaintext-legacy-password</LetterboxdPassword>
+              <RawCookies>plaintext-legacy-cookie</RawCookies>
+            </Account>
+            """;
+
+        var account = DeserializeFromString<Account>(legacyXml);
+
+        Assert.Equal("plaintext-legacy-password", account.LetterboxdPassword);
+        Assert.Equal("plaintext-legacy-cookie", account.RawCookies);
+
+        // Re-serializing (as happens on the next SaveConfiguration) upgrades it to encrypted.
+        var reSerialized = SerializeToString(account);
+        Assert.DoesNotContain("plaintext-legacy-password", reSerialized);
+        Assert.Contains("<LetterboxdPassword>enc:v1:", reSerialized);
+    }
+
+    [Fact]
+    public void PluginConfiguration_XmlRoundTrip_StoresJellyseerrApiKeyEncrypted()
+    {
+        var config = new PluginConfiguration
+        {
+            JellyseerrUrl = "http://192.168.1.122:5055",
+            JellyseerrApiKey = "MTIzNDU2Nzg5MA=="
+        };
+
+        var xml = SerializeToString(config);
+
+        Assert.DoesNotContain("MTIzNDU2Nzg5MA==", xml);
+        Assert.Contains("<JellyseerrApiKey>enc:v1:", xml);
+
+        var roundTripped = DeserializeFromString<PluginConfiguration>(xml);
+        Assert.Equal("MTIzNDU2Nzg5MA==", roundTripped.JellyseerrApiKey);
+    }
+
+    [Fact]
+    public void ProtectedShadowProperties_AreNotSerializedToJson()
+    {
+        // configPage.js does getPluginConfiguration -> mutate -> updatePluginConfiguration,
+        // echoing the full JSON payload back verbatim. If the encrypted shadow properties
+        // leaked into that JSON, a stale echoed ciphertext could clobber a freshly-typed
+        // plaintext value on save (see Account.LetterboxdPasswordProtected's doc comment).
+        var account = new Account { LetterboxdPassword = "secret", RawCookies = "cookie" };
+        var json = System.Text.Json.JsonSerializer.Serialize(account);
+
+        Assert.DoesNotContain("LetterboxdPasswordProtected", json);
+        Assert.DoesNotContain("RawCookiesProtected", json);
+        Assert.Contains("\"LetterboxdPassword\":\"secret\"", json);
+
+        var config = new PluginConfiguration { JellyseerrApiKey = "key" };
+        var configJson = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("JellyseerrApiKeyProtected", configJson);
+    }
+
+    private static string SerializeToString<T>(T value)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, value);
+        return writer.ToString();
+    }
+
+    private static T DeserializeFromString<T>(string xml)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var reader = new StringReader(xml);
+        return (T)serializer.Deserialize(reader)!;
+    }
+}

--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using LetterboxdSync.Security;
 
 namespace LetterboxdSync.Configuration;
 
@@ -8,9 +11,37 @@ public class Account
 
     public string LetterboxdUsername { get; set; } = string.Empty;
 
+    [XmlIgnore]
     public string LetterboxdPassword { get; set; } = string.Empty;
 
+    /// <summary>
+    /// XML-serialized, encrypted form of <see cref="LetterboxdPassword"/> (see
+    /// <see cref="SecretProtector"/>). Exists only so the on-disk config file never holds
+    /// the password in plaintext; JsonIgnore keeps it out of the admin config page's
+    /// GET/PUT JSON round-trip (configPage.js echoes that payload back verbatim on save,
+    /// which would otherwise clobber a freshly-typed password with stale ciphertext).
+    /// Nothing outside this class and tests should read or write it directly, use
+    /// <see cref="LetterboxdPassword"/>.
+    /// </summary>
+    [XmlElement("LetterboxdPassword")]
+    [JsonIgnore]
+    public string LetterboxdPasswordProtected
+    {
+        get => SecretProtector.Protect(LetterboxdPassword) ?? string.Empty;
+        set => LetterboxdPassword = SecretProtector.Unprotect(value) ?? string.Empty;
+    }
+
+    [XmlIgnore]
     public string? RawCookies { get; set; }
+
+    /// <summary>Encrypted on-disk form of <see cref="RawCookies"/>. See <see cref="LetterboxdPasswordProtected"/>.</summary>
+    [XmlElement("RawCookies")]
+    [JsonIgnore]
+    public string? RawCookiesProtected
+    {
+        get => SecretProtector.Protect(RawCookies);
+        set => RawCookies = SecretProtector.Unprotect(value);
+    }
 
     public string? UserAgent { get; set; }
 

--- a/LetterboxdSync/Configuration/PluginConfiguration.cs
+++ b/LetterboxdSync/Configuration/PluginConfiguration.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using LetterboxdSync.Security;
 using MediaBrowser.Model.Plugins;
 
 namespace LetterboxdSync.Configuration;
@@ -16,7 +19,17 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Seerr API key (Settings → General → API Key in Seerr).
     /// </summary>
+    [XmlIgnore]
     public string? JellyseerrApiKey { get; set; }
+
+    /// <summary>Encrypted on-disk form of <see cref="JellyseerrApiKey"/>. See <see cref="Configuration.Account.LetterboxdPasswordProtected"/> for why this is JsonIgnore'd.</summary>
+    [XmlElement("JellyseerrApiKey")]
+    [JsonIgnore]
+    public string? JellyseerrApiKeyProtected
+    {
+        get => SecretProtector.Protect(JellyseerrApiKey);
+        set => JellyseerrApiKey = SecretProtector.Unprotect(value);
+    }
 
     /// <summary>
     /// Anonymous opt-in usage telemetry state. Off by default; nothing is ever sent

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.1.0</AssemblyVersion>
-    <FileVersion>1.19.1.0</FileVersion>
+    <AssemblyVersion>1.19.2.0</AssemblyVersion>
+    <FileVersion>1.19.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +24,9 @@
     <PackageReference Include="Jellyfin.Controller" Version="10.11.9" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!-- Encrypts stored secrets (Letterboxd password/cookies, Seerr API key) at rest.
+         See LetterboxdSync/Security/SecretProtector.cs for the threat model. -->
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Security/SecretProtector.cs
+++ b/LetterboxdSync/Security/SecretProtector.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace LetterboxdSync.Security;
+
+/// <summary>
+/// Encrypts secret configuration fields (Letterboxd password, raw cookies, Seerr API key)
+/// at rest so LetterboxdSync.xml never holds them in plaintext. Uses ASP.NET Core's Data
+/// Protection API with a key ring persisted next to the plugin's other data files (same
+/// convention as <see cref="SyncHistory"/>'s DataPath).
+///
+/// Threat model: this raises the bar against the config file being copied out in isolation
+/// (backups, git, pasted into a support thread/bug report) since the ciphertext is useless
+/// without the separate key ring. It does NOT protect against an attacker with full read
+/// access to the Jellyfin data volume, because the key ring has to live somewhere the
+/// plugin can reach it too, on Linux Data Protection has no OS keystore (DPAPI is
+/// Windows-only) to encrypt the key ring itself. That ceiling is inherent to any
+/// self-hosted secret storage without an external KMS.
+/// </summary>
+internal static class SecretProtector
+{
+    private const string Purpose = "LetterboxdSync.Secrets.v1";
+    private const string Prefix = "enc:v1:";
+
+    /// <summary>
+    /// Test-only hook for the key ring location, mirrors <see cref="SyncHistory.DataPathOverride"/>.
+    /// Production never assigns this; the default KeyDirectory logic uses the plugin's
+    /// configurations directory.
+    /// </summary>
+    internal static string? KeyDirectoryOverride { get; set; }
+
+    private static IDataProtector? _protector;
+    private static readonly object _lock = new();
+
+    private static IDataProtector Protector
+    {
+        get
+        {
+            if (_protector != null) return _protector;
+            lock (_lock)
+            {
+                _protector ??= CreateProtector();
+                return _protector;
+            }
+        }
+    }
+
+    /// <summary>Test hook: drop the cached protector so the next access re-derives it (e.g. after changing KeyDirectoryOverride).</summary>
+    internal static void ResetForTesting()
+    {
+        lock (_lock) { _protector = null; }
+    }
+
+    private static IDataProtector CreateProtector()
+    {
+        var dir = KeyDirectoryOverride ?? DefaultKeyDirectory();
+        Directory.CreateDirectory(dir);
+        TryRestrictPermissions(dir);
+
+        var provider = DataProtectionProvider.Create(new DirectoryInfo(dir));
+        return provider.CreateProtector(Purpose);
+    }
+
+    private static string DefaultKeyDirectory()
+    {
+        var assembly = typeof(SecretProtector).Assembly.Location;
+        var pluginDir = Path.GetDirectoryName(assembly);
+        if (!string.IsNullOrEmpty(pluginDir))
+        {
+            var configDir = Path.Combine(pluginDir, "..", "configurations");
+            if (Directory.Exists(configDir))
+                return Path.Combine(configDir, "letterboxd-sync-keys");
+
+            return Path.Combine(pluginDir, "letterboxd-sync-keys");
+        }
+
+        return "letterboxd-sync-keys";
+    }
+
+    // Best-effort on Unix; the container runs as a single non-root user (PUID/PGID) so this
+    // mainly keeps the key ring out of any accidental world-readable default. Never blocks
+    // startup over a chmod failure.
+    private static void TryRestrictPermissions(string dir)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        try
+        {
+            File.SetUnixFileMode(dir,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+        catch
+        {
+        }
+    }
+
+    /// <summary>Encrypts a plaintext secret for storage. Null/empty pass through unchanged.</summary>
+    internal static string? Protect(string? plaintext)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return plaintext;
+        return Prefix + Protector.Protect(plaintext);
+    }
+
+    /// <summary>
+    /// Decrypts a stored value. A value without the <c>enc:v1:</c> prefix is treated as
+    /// legacy plaintext, written before encryption was added, and returned as-is; the next
+    /// save re-encrypts it. Returns null if the value is prefixed but fails to decrypt
+    /// (key ring missing/rotated/corrupted), so callers can tell "no value" apart from
+    /// "value present but unreadable" if they need to.
+    /// </summary>
+    internal static string? Unprotect(string? storedValue)
+    {
+        if (string.IsNullOrEmpty(storedValue)) return storedValue;
+        if (!storedValue.StartsWith(Prefix, StringComparison.Ordinal)) return storedValue;
+
+        try
+        {
+            return Protector.Unprotect(storedValue[Prefix.Length..]);
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+}

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.19.2',
+    headline: 'Stored credentials are now encrypted at rest',
+    summary:
+      'Your Letterboxd password, session cookies, and Seerr API key are now encrypted before they are written to disk, instead of sitting in the plugin config file as plaintext. Nothing changes about how you use the plugin: existing saved credentials are picked up and upgraded automatically the next time they are saved, no re-entry needed.',
+    highlights: {
+      improvements: [
+        'Letterboxd password, raw cookies, and Seerr API key are encrypted at rest using ASP.NET Core Data Protection, with the key kept alongside the plugin’s other data files.',
+        'Existing plaintext values from earlier versions are read normally and silently upgraded to encrypted on the next save.',
+      ],
+    },
+  },
+  {
     version: '1.19.1',
     headline: 'AI transparency page and a code of conduct that fits',
     summary:


### PR DESCRIPTION
No linked issue.

## Release notes

Your Letterboxd password, session cookies, and Seerr API key are now encrypted before they are written to disk, instead of sitting in the plugin config file as plaintext. Nothing changes about how you use the plugin: existing saved credentials are picked up and upgraded automatically the next time they are saved, no re-entry needed.

## What's broken

`LetterboxdSync.xml` (and the account list inside `PluginConfiguration`) stored `LetterboxdPassword`, `RawCookies`, and `JellyseerrApiKey` as plain XML text. Anyone who could read that one file, a backup, a `docker cp`, a support-thread paste, an accidental git commit, had the Letterboxd password and any session cookies outright.

## Why it happens

1. `Account`/`PluginConfiguration` are plain POCOs; Jellyfin's stock `BasePlugin<TConfigurationType>` XML-serializes them verbatim with no encryption hook.
2. There was never a reason to add one until now, this plugin didn't previously claim any at-rest protection for these fields.

## What this PR does

- Adds `LetterboxdSync/Security/SecretProtector.cs`: wraps ASP.NET Core's Data Protection API, with the key ring persisted next to the plugin's other data files (`configurations/letterboxd-sync-keys/`, same convention as `SyncHistory.DataPath`), permissions best-effort restricted to the owning user on Unix.
- `Account.LetterboxdPassword` / `Account.RawCookies` / `PluginConfiguration.JellyseerrApiKey` stay exactly as they are today (plain in-memory properties), `[XmlIgnore]`'d so the *business logic* code (sync runners, controllers, tests) is untouched.
- Each gets a sibling `*Protected` shadow property (`[XmlElement]` pointed at the original element name) that's the only thing the XML serializer actually persists, it encrypts on the getter, decrypts on the setter. `[JsonIgnore]`'d on all three so they never appear in the admin config page's JSON round-trip (`configPage.js` does `getPluginConfiguration` → mutate → `updatePluginConfiguration`, echoing the full payload back; if the encrypted shadow leaked into that JSON, a stale echoed ciphertext could clobber a freshly-typed password on save).
- Migration is automatic and one-directional: `Unprotect` treats any value without the `enc:v1:` prefix as legacy plaintext and returns it as-is, so old configs load exactly as before. The very next save (any save, not necessarily a credential change) re-serializes through the encrypting getter and upgrades it.
- Not touched: what the admin/user config pages return over the network (`GetAccount`/`GetAccounts` still return the real password so the UI can prefill the field), that's an existing, separate UX decision this PR doesn't change. Also not touched: the Cloudflare-cookie/UA fields' semantics, or anything about how auth actually happens.

Threat model, stated plainly: this protects the config file being copied out in isolation (backups, git, a bug-report paste). It does **not** protect someone with full read access to the Jellyfin container/data volume, since the key ring has to live somewhere the plugin can reach it too, Data Protection has no OS keystore to lean on on Linux (DPAPI is Windows-only). That's the realistic ceiling for self-hosted secret storage without an external KMS.

## How to test

`LetterboxdSync.Tests/SecretProtectorTests.cs`, `dotnet test --filter "FullyQualifiedName~SecretProtectorTests"`. Covers: round-trip encrypt/decrypt, null/empty passthrough, legacy-plaintext passthrough + migration-on-reserialize, corrupt ciphertext and wrong-key-ring both return null instead of throwing, real `System.Xml.Serialization.XmlSerializer` round-trips on `Account`/`PluginConfiguration` proving the on-disk XML never contains the plaintext, and a JSON-serialization check proving the `*Protected` shadows never leak into the admin config page's payload.

Full suite: 629 passed / 12 skipped (`dotnet test -c Release`).

Manual check after merge: deploy to a server with an existing plaintext `LetterboxdSync.xml`, trigger any save (e.g. toggle a setting), confirm the file now shows `enc:v1:...` for the three fields and sync still works.

## Follow-ups (not in this PR)

- None identified. `GetAccount`/`GetAccounts` still return the real password to the browser for the edit form; that's pre-existing behavior and out of scope here.