### PR TITLE
ci: exempt docs-only PRs from the version bump and release requirement

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -1,11 +1,20 @@
 name: Version Gate
 
-# Every PR to main must bump Directory.Build.props's AssemblyVersion. Without
-# this gate, a PR could land on main without a corresponding release (the
-# Release workflow short-circuits when a tag for the current version already
-# exists), leaving the change un-shipped and users unaware. Patch-level bumps
-# are fine for docs / CI / refactor changes; magnitude is a human judgement
-# call, the gate only enforces "something changed".
+# Every PR that changes what ships must bump Directory.Build.props's
+# AssemblyVersion. Without this gate, a PR could land on main without a
+# corresponding release (the Release workflow short-circuits when a tag for
+# the current version already exists), leaving the change un-shipped and
+# users unaware. Patch-level bumps are fine for CI / refactor changes;
+# magnitude is a human judgement call, the gate only enforces "something
+# changed".
+#
+# DOCS-ONLY EXEMPTION: a PR whose entire diff sits in non-shipping paths
+# (markdown, docs/, openspec/, site/, worker/, .github/) may merge WITHOUT a
+# bump, in which case no release happens (release.yml sees the existing tag
+# and stops) and the site still redeploys via deploy-docs.yml's push-paths
+# trigger. A version-bumped docs PR is still allowed when a release is
+# actually wanted. manifest.json is deliberately NOT exempt: it is release
+# plumbing and only release.yml should write it.
 
 on:
   pull_request:
@@ -34,6 +43,28 @@ jobs:
           if [ -z "$PR_V" ] || [ -z "$MAIN_V" ]; then
             echo "::error::Could not read AssemblyVersion from one of the files."
             exit 1
+          fi
+
+          # Docs-only exemption (see header). Anything outside the allowlist
+          # (plugin source, tests, project files, manifest.json, targetAbi.txt)
+          # keeps the full gate.
+          CHANGED=$(git diff --name-only "origin/main...HEAD")
+          echo "Changed files:"
+          echo "$CHANGED"
+          DOCS_ONLY=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md) ;;
+              docs/*|openspec/*|site/*|worker/*|.github/*) ;;
+              LICENSE|.gitignore|codecov.yml) ;;
+              *) DOCS_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          if [ "$DOCS_ONLY" = true ] && [ "$PR_V" = "$MAIN_V" ]; then
+            echo "Docs-only diff with no version bump: merging this PR ships no release, and that is correct. Skipping the release checks."
+            exit 0
           fi
 
           if [ "$PR_V" = "$MAIN_V" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,11 @@ Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `Letterb
 
 ## Releasing
 
-**Every merge to `main` ships a release.** No manual tag pushes, no release-notes files. The pipeline is:
+**Every merge to `main` that changes what ships, ships a release.** No manual tag pushes, no release-notes files. **Docs-only PRs are exempt**: if the whole diff sits in non-shipping paths (any `*.md`, `docs/`, `openspec/`, `site/`, `worker/`, `.github/`), skip the version bump, the `## Release notes` section, and the `release-notes.ts` entry; the merge then ships no release (release.yml sees the existing tag and stops) and the site still redeploys for `site/**` changes via deploy-docs' push trigger. `manifest.json` is never docs-only. The full pipeline is:
 
-1. Open a PR. The PR must:
-   - Have a **Conventional Commits** title (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`). Enforced by `pr-title.yml`.
-   - **Bump `AssemblyVersion` / `FileVersion`** in both `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`. Patch bumps (e.g. `1.13.0.0` → `1.13.1.0`) are fine for docs / CI / refactor changes; every PR ships. Enforced by `version-gate.yml`.
+1. Open a PR. Unless docs-only (above), the PR must:
+   - Have a **Conventional Commits** title (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`). Enforced by `pr-title.yml` (this one applies to docs-only PRs too).
+   - **Bump `AssemblyVersion` / `FileVersion`** in both `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`. Patch bumps (e.g. `1.13.0.0` → `1.13.1.0`) are fine for CI / refactor changes. Enforced by `version-gate.yml`.
    - Fill in the **`## Release notes`** section in the PR body. `release.yml` extracts text between that heading and the next H2 and uses it verbatim as the manifest changelog field and the GitHub Release body. The PR template primes the section so it's the path of least resistance. Past entries on https://letterboxdsync.dev/releases set the tone: one paragraph, user-facing prose, no symbol names / internal jargon.
    - Add a structured entry to **`site/src/data/release-notes.ts`** for the new version (headline + summary + categorised highlights). The site renders these on the Releases page above the raw manifest changelog. Same tone as the manifest changelog but split into `new` / `improvements` / `fixes` / `breaking` bullets.
    - **SDK floor policy (issue #63)**: the `Jellyfin.Controller`/`Jellyfin.Model` PackageReference version MUST equal `targetAbi.txt`, Jellyfin assemblies have per-patch AssemblyVersions, so the SDK we compile against is the real minimum Jellyfin a release can load on. Never bump the SDK routinely (Dependabot PRs are a compile signal, not a merge queue); bump it only when we need a newer API, raising `targetAbi.txt` and the minor version in the same PR. CI enforces the SDK==targetAbi match.


### PR DESCRIPTION
Docs changes were forcing real releases: every PR needed a version bump, so a README or openspec change shipped a new plugin version to the whole fleet (and its auto-update wave) for zero functional change.

The gate now computes the PR's changed files and, when the entire diff sits in non-shipping paths (any `*.md`, `docs/`, `openspec/`, `site/`, `worker/`, `.github/`, plus LICENSE/.gitignore/codecov.yml) AND the version is unchanged, passes without requiring a bump. Merging such a PR ships no release: `release.yml` already short-circuits on an existing tag, and the site still redeploys for `site/**` changes via `deploy-docs.yml`'s push-paths trigger, so nothing goes stale. A docs PR that deliberately bumps the version still gets the full gate and a release. `manifest.json` is deliberately not exempt; only `release.yml` should write it.

Everything that ships (plugin source, tests, project files, `targetAbi.txt`, `manifest.json`) keeps the existing rules unchanged. CLAUDE.md's Releasing section is updated to match. The allowlist logic was tested against docs-only, mixed, and manifest-only file sets.

No release notes section: this PR is itself docs-only under the new rule and ships no release.