### PR TITLE
feat: add syncs_ever lifetime bucket to telemetry

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.2.0</Version>
-        <AssemblyVersion>1.19.2.0</AssemblyVersion>
-        <FileVersion>1.19.2.0</FileVersion>
+        <Version>1.19.3.0</Version>
+        <AssemblyVersion>1.19.3.0</AssemblyVersion>
+        <FileVersion>1.19.3.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/TelemetryServiceTests.cs
+++ b/LetterboxdSync.Tests/TelemetryServiceTests.cs
@@ -128,6 +128,7 @@ public class TelemetryServiceTests : IDisposable
     {
         var t = Enable();
         t.WindowSyncs = 12;
+        t.LifetimeSyncs = 150;
         t.WindowErrCloudflare = 3;
         t.LastWeeklyPingUtc = new DateTime(2026, 6, 8, 2, 0, 0, DateTimeKind.Utc);
         var now = new DateTime(2026, 6, 15, 9, 0, 0, DateTimeKind.Utc); // next Monday
@@ -139,12 +140,34 @@ public class TelemetryServiceTests : IDisposable
         using var doc = JsonDocument.Parse(ping.Json);
         Assert.Equal("weekly", doc.RootElement.GetProperty("ping_type").GetString());
         Assert.Equal("11-100", doc.RootElement.GetProperty("buckets").GetProperty("syncs_per_week").GetString());
+        Assert.Equal("100+", doc.RootElement.GetProperty("buckets").GetProperty("syncs_ever").GetString());
         Assert.Equal("500-2k", doc.RootElement.GetProperty("buckets").GetProperty("library").GetString());
         Assert.Equal(3, doc.RootElement.GetProperty("errors").GetProperty("cloudflare_403").GetInt32());
-        // Window resets after a successful send.
+        // Window resets after a successful send; the lifetime counter never does.
         Assert.Equal(0, t.WindowSyncs);
+        Assert.Equal(150, t.LifetimeSyncs);
         Assert.Equal(0, t.WindowErrCloudflare);
         Assert.Equal(now, t.LastWeeklyPingUtc);
+    }
+
+    [Fact]
+    public async Task RunScheduled_QuietWeek_StillReportsLifetimeBucket()
+    {
+        // The reason syncs_ever exists: a healthy-but-idle instance reports
+        // syncs_per_week "0" and a non-zero lifetime bucket, while a
+        // never-activated install reports "0" on both.
+        var t = Enable();
+        t.WindowSyncs = 0;
+        t.LifetimeSyncs = 5;
+        t.LastWeeklyPingUtc = new DateTime(2026, 6, 8, 2, 0, 0, DateTimeKind.Utc);
+        TelemetryService.ClockOverride = () => new DateTime(2026, 6, 15, 9, 0, 0, DateTimeKind.Utc);
+
+        await TelemetryService.RunScheduledAsync(libraryCount: 100, logger: null);
+
+        var ping = Assert.Single(_sent);
+        using var doc = JsonDocument.Parse(ping.Json);
+        Assert.Equal("0", doc.RootElement.GetProperty("buckets").GetProperty("syncs_per_week").GetString());
+        Assert.Equal("1-10", doc.RootElement.GetProperty("buckets").GetProperty("syncs_ever").GetString());
     }
 
     [Fact]
@@ -190,6 +213,7 @@ public class TelemetryServiceTests : IDisposable
         // Counters live on the PluginConfiguration object, i.e. they survive restarts
         // by construction (config persistence), not in TelemetryService memory.
         Assert.Equal(2, t.WindowSyncs);
+        Assert.Equal(2, t.LifetimeSyncs);
         Assert.Equal(1, t.WindowSkipped);
     }
 

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.2.0</AssemblyVersion>
-    <FileVersion>1.19.2.0</FileVersion>
+    <AssemblyVersion>1.19.3.0</AssemblyVersion>
+    <FileVersion>1.19.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Telemetry/TelemetryData.cs
+++ b/LetterboxdSync/Telemetry/TelemetryData.cs
@@ -42,6 +42,15 @@ public class TelemetryData
     /// </summary>
     public bool TransitionQueued { get; set; }
 
+    /// <summary>
+    /// Lifetime successful-sync counter. Unlike the window counters below it is NEVER
+    /// reset: the syncs_ever bucket it feeds exists to distinguish "installed but never
+    /// completed a sync" (an activation failure) from "no syncs this window" (a quiet
+    /// week), which syncs_per_week alone cannot. Leaves the box only as a coarse bucket
+    /// (0 / 1-10 / 11-100 / 100+), same as every other count.
+    /// </summary>
+    public int LifetimeSyncs { get; set; }
+
     // Window counters, measured since the last successful weekly ping (never cumulative,
     // so canary rates are per-period by construction). Reset on successful weekly ping.
     public int WindowSyncs { get; set; }

--- a/LetterboxdSync/Telemetry/TelemetryService.cs
+++ b/LetterboxdSync/Telemetry/TelemetryService.cs
@@ -119,6 +119,7 @@ internal static class TelemetryService
                     case SyncStatus.Success:
                     case SyncStatus.Rewatch:
                         d.WindowSyncs++;
+                        d.LifetimeSyncs++;
                         // Recovery: a film made it all the way to Letterboxd, so the
                         // pipeline is healthy; flip every category back to clean. The
                         // recovery is visible in the next weekly payload (by design,
@@ -307,7 +308,8 @@ internal static class TelemetryService
             {
                 accounts = BucketAccounts(enabled.Count),
                 library = libraryCount.HasValue ? BucketLibrary(libraryCount.Value) : "unknown",
-                syncs_per_week = BucketSyncs(d.WindowSyncs)
+                syncs_per_week = BucketSyncs(d.WindowSyncs),
+                syncs_ever = BucketSyncs(d.LifetimeSyncs)
             },
             errors = new
             {

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ When enabled, one small ping is sent per week, plus one extra ping (capped at on
   "plugin_version": "1.16.0.0",
   "jellyfin_version": "10.11.11",
   "features": { "watchlist_sync": true, "diary_import": false, "...": "booleans of which settings are enabled" },
-  "buckets": { "accounts": "1", "library": "2k-10k", "syncs_per_week": "1-10" },
+  "buckets": { "accounts": "1", "library": "2k-10k", "syncs_per_week": "1-10", "syncs_ever": "11-100" },
   "errors": { "cloudflare_403": 0, "auth_failure": 0, "tmdb_lookup": 0, "jellyseerr_error": 0, "other": 0,
               "state": { "cloudflare_403": false, "...": "which error types are currently occurring" } }
 }

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,17 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.19.3',
+    headline: 'Telemetry can now tell a quiet week from a plugin that never worked',
+    summary:
+      'A small improvement to the opt-in anonymous telemetry: alongside the existing per-week sync bucket, the weekly ping now includes a lifetime sync bucket. Until now, an instance reporting zero syncs in a week was indistinguishable from one where syncing never worked at all; the lifetime bucket separates the two, so setup problems can be spotted and fixed. Same privacy rules as everything else: a coarse bucket only (0, 1-10, 11-100, 100+), never exact numbers, and nothing is sent unless you opted in.',
+    highlights: {
+      improvements: [
+        'Weekly telemetry pings gain a syncs_ever bucket: the lifetime count of successful syncs, reported in the same coarse buckets as all other counts. This distinguishes a healthy-but-idle instance from an install where syncing has never succeeded.',
+      ],
+    },
+  },
+  {
     version: '1.19.2',
     headline: 'Stored credentials are now encrypted at rest',
     summary:


### PR DESCRIPTION
The weekly ping's `syncs_per_week` bucket counts syncs since the last weekly ping (the window counter resets after every successful send), so an instance reporting `0` is indistinguishable from an install where syncing has never worked. Roughly half the opt-in panel reports `0` in any given week, making it the noisiest signal in the dataset, and the June fleet report flagged exactly this ambiguity.

This adds a `LifetimeSyncs` counter to the persisted telemetry state, incremented alongside the window counter on every successful sync (and rewatch) and never reset, plus a `syncs_ever` field in the payload's `buckets` object using the existing coarse buckets (`0` / `1-10` / `11-100` / `100+`). A healthy-but-idle instance now reports `syncs_per_week: "0"` with a non-zero `syncs_ever`; a never-activated install reports `"0"` on both, which is the actionable case.

No backend change needed: the ingest worker treats bucket keys as a validated passthrough (string values, capped count), so old and new plugin versions coexist. Existing configs deserialize with the new field at 0, meaning long-running instances will briefly under-report `syncs_ever` until history accumulates; that's acceptable since the bucket's job is distinguishing zero from non-zero. Privacy posture is unchanged: bucketed only, never exact counts, opt-in only, and the README's exact-payload documentation is updated to match (the settings "Preview exact JSON" modal picks the field up automatically).

Tests: window-reset test now verifies the lifetime counter survives the weekly send; a new quiet-week test pins the `"0"` week + `"1-10"` lifetime case; the sync-event counting test covers the double increment. Full suite passes locally (618 passed, 0 failed).

## Release notes

A small improvement to the opt-in anonymous telemetry: alongside the existing per-week sync bucket, the weekly ping now includes a lifetime sync bucket. Until now, an instance reporting zero syncs in a week was indistinguishable from one where syncing never worked at all; the lifetime bucket separates the two, so setup problems can be spotted and fixed. Same privacy rules as everything else: a coarse bucket only (0, 1-10, 11-100, 100+), never exact numbers, and nothing is sent unless you opted in.