### PR TITLE
fix: warn on empty send-logs bundles and make bundles self-describing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.3.0</Version>
-        <AssemblyVersion>1.19.3.0</AssemblyVersion>
-        <FileVersion>1.19.3.0</FileVersion>
+        <Version>1.19.4.0</Version>
+        <AssemblyVersion>1.19.4.0</AssemblyVersion>
+        <FileVersion>1.19.4.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.4.0</Version>
-        <AssemblyVersion>1.19.4.0</AssemblyVersion>
-        <FileVersion>1.19.4.0</FileVersion>
+        <Version>1.19.5.0</Version>
+        <AssemblyVersion>1.19.5.0</AssemblyVersion>
+        <FileVersion>1.19.5.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/SendLogsTests.cs
+++ b/LetterboxdSync.Tests/SendLogsTests.cs
@@ -43,12 +43,14 @@ public class SendLogsTests : IDisposable
 
     private static List<string> Lines() => new() { "[INF] LetterboxdSync started", "[ERR] Letterboxd login error" };
 
+    private static object TestCollector(int matched = 2) => new { files = "jellyfin.log", matched, error = "none" };
+
     [Fact]
     public async Task SendLogBundle_PostsToLogsEndpoint_WithExpectedShape()
     {
         var snapshot = TelemetryService.BuildPayload("logs", 1200);
         var built = TelemetryService.BuildLogBundleJson(
-            "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "1.17.0.0", snapshot, "diary sync broke", Lines());
+            "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "1.17.0.0", snapshot, "diary sync broke", Lines(), TestCollector());
         var code = await TelemetryService.PostLogBundleAsync(built);
 
         Assert.Equal("LBX-TEST01", code);
@@ -65,6 +67,9 @@ public class SendLogsTests : IDisposable
         Assert.Equal(2, root.GetProperty("log_lines").GetArrayLength());
         // The telemetry snapshot is embedded as structured JSON, not a string.
         Assert.Equal(JsonValueKind.Object, root.GetProperty("telemetry").ValueKind);
+        // Collector status is a structured field, not just a string inside log_lines.
+        Assert.Equal(2, root.GetProperty("collector").GetProperty("matched").GetInt32());
+        Assert.Equal("jellyfin.log", root.GetProperty("collector").GetProperty("files").GetString());
         // The preview/bundle MUST contain the actual log text, the consent bug was that
         // the preview showed only the telemetry snapshot, hiding the log lines.
         Assert.Contains("Letterboxd login error", built);
@@ -76,7 +81,7 @@ public class SendLogsTests : IDisposable
         TelemetryService.LogSenderOverride = (_, _) => Task.FromResult<string?>(null);
         var snapshot = TelemetryService.BuildPayload("logs", null);
         var json = TelemetryService.BuildLogBundleJson(
-            "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "1.17.0.0", snapshot, null, Lines());
+            "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "1.17.0.0", snapshot, null, Lines(), TestCollector());
         var code = await TelemetryService.PostLogBundleAsync(json);
         Assert.Null(code);
     }
@@ -155,6 +160,10 @@ public class SendLogsTests : IDisposable
         var (_, json) = Assert.Single(_sent);
         Assert.Contains("[meta] collector:", json);
         Assert.Contains("matched=0", json);
+        using (var doc = System.Text.Json.JsonDocument.Parse(json))
+        {
+            Assert.Equal(0, doc.RootElement.GetProperty("collector").GetProperty("matched").GetInt32());
+        }
     }
 
     [Fact]
@@ -194,7 +203,7 @@ public class SendLogsTests : IDisposable
         // supplies a one-off instance id, and the snapshot reflects disabled state.
         Assert.False(_h.Config.Telemetry.Enabled);
         var snapshot = TelemetryService.BuildPayload("logs", 100);
-        var json = TelemetryService.BuildLogBundleJson(Guid.NewGuid().ToString(), "1.17.0.0", snapshot, null, Lines());
+        var json = TelemetryService.BuildLogBundleJson(Guid.NewGuid().ToString(), "1.17.0.0", snapshot, null, Lines(), TestCollector());
         var code = await TelemetryService.PostLogBundleAsync(json);
         Assert.Equal("LBX-TEST01", code);
         Assert.Single(_sent);

--- a/LetterboxdSync.Tests/SendLogsTests.cs
+++ b/LetterboxdSync.Tests/SendLogsTests.cs
@@ -133,6 +133,60 @@ public class SendLogsTests : IDisposable
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
+    // ---- Empty-capture visibility (LBX-C1EP38: a real user's bundle arrived with
+    // log_lines = [] and nothing in it explained why; the send also reported plain
+    // success, so the user never knew their diagnostics were blank) ----
+
+    [Fact]
+    public async Task SendLogs_EmptyCapture_WarnsUser_AndBundleCarriesCollectorMeta()
+    {
+        // No log files exist in the harness log dir: the collector matches nothing.
+        var result = await _h.Controller.SendLogs(new SendLogsRequest { Note = null });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("LBX-TEST01", response);
+        // The user is told the bundle is empty instead of getting a bare success.
+        Assert.Contains("\"warning\"", response);
+        Assert.DoesNotContain("\"warning\":null", response);
+
+        // The uploaded bundle explains itself: collector status travels with it, so an
+        // empty capture is distinguishable (server-side) from a broken collector.
+        var (_, json) = Assert.Single(_sent);
+        Assert.Contains("[meta] collector:", json);
+        Assert.Contains("matched=0", json);
+    }
+
+    [Fact]
+    public async Task SendLogs_WithMatchingLines_DoesNotWarn()
+    {
+        var logFile = System.IO.Path.Combine(_h.LogDir, "log_20260614.log");
+        System.IO.File.WriteAllText(logFile,
+            "[2026-06-14 10:00:00.000 +00:00] [INF] [1] LetterboxdSync.Foo: a diagnostic line\n");
+
+        var result = await _h.Controller.SendLogs(new SendLogsRequest { Note = null });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("LBX-TEST01", response);
+        Assert.Contains("\"warning\":null", response);
+
+        var (_, json) = Assert.Single(_sent);
+        Assert.Contains("a diagnostic line", json);
+        Assert.Contains("matched=1", json);
+    }
+
+    [Fact]
+    public void PreviewLogs_EmptyCapture_ShowsCollectorMeta()
+    {
+        // The preview must show the same truth the send uploads: with nothing matched,
+        // the user sees matched=0 in the consent modal instead of a bare empty array.
+        var result = _h.Controller.PreviewLogs();
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Contains("[meta] collector:", content.Content!);
+        Assert.Contains("matched=0", content.Content!);
+    }
+
     [Fact]
     public async Task SendLogBundle_WorksWithTelemetryDisabled()
     {

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -717,6 +717,7 @@ public class LetterboxdController : ControllerBase
         // arrived as log_lines=[] with nothing saying whether the plugin was idle,
         // the log dir was missing, or the line filter matched nothing.
         lines.Insert(0, $"[meta] collector: files={source ?? "none"}; matched={matched}; error={error ?? "none"}");
+        var collector = new { files = source ?? "none", matched, error = error ?? "none" };
 
         int? libraryCount;
         try
@@ -742,7 +743,8 @@ public class LetterboxdController : ControllerBase
             Plugin.Instance?.Version?.ToString() ?? "unknown",
             telemetrySnapshot,
             note,
-            lines);
+            lines,
+            collector);
         return (json, matched);
     }
 

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -706,10 +706,17 @@ public class LetterboxdController : ControllerBase
     /// the preview and the send so they cannot diverge: what the preview shows is byte
     /// for byte what the send uploads (note aside, which the user types in either path).
     /// </summary>
-    private string BuildLogBundleJson(string? note)
+    private (string Json, int MatchedLines) BuildLogBundleJson(string? note)
     {
-        var (allLines, _, _) = ReadRecentLogLines();
+        var (allLines, source, error) = ReadRecentLogLines();
+        var matched = allLines.Count;
         var lines = allLines.Count > 500 ? allLines.GetRange(allLines.Count - 500, 500) : allLines;
+
+        // Collector status travels inside the bundle. Without it an empty capture is
+        // indistinguishable (server-side) from a broken collector: bundle LBX-C1EP38
+        // arrived as log_lines=[] with nothing saying whether the plugin was idle,
+        // the log dir was missing, or the line filter matched nothing.
+        lines.Insert(0, $"[meta] collector: files={source ?? "none"}; matched={matched}; error={error ?? "none"}");
 
         int? libraryCount;
         try
@@ -730,12 +737,13 @@ public class LetterboxdController : ControllerBase
         if (string.IsNullOrEmpty(instanceId))
             instanceId = Guid.NewGuid().ToString();
 
-        return TelemetryService.BuildLogBundleJson(
+        var json = TelemetryService.BuildLogBundleJson(
             instanceId,
             Plugin.Instance?.Version?.ToString() ?? "unknown",
             telemetrySnapshot,
             note,
             lines);
+        return (json, matched);
     }
 
     /// <summary>
@@ -748,7 +756,7 @@ public class LetterboxdController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult PreviewLogs()
     {
-        return Content(BuildLogBundleJson(null), "application/json");
+        return Content(BuildLogBundleJson(null).Json, "application/json");
     }
 
     [HttpPost("Telemetry/SendLogs")]
@@ -756,13 +764,20 @@ public class LetterboxdController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult> SendLogs([FromBody] SendLogsRequest? request)
     {
-        var json = BuildLogBundleJson(request?.Note);
+        var (json, matched) = BuildLogBundleJson(request?.Note);
         var code = await TelemetryService.PostLogBundleAsync(json).ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(code))
             return BadRequest(new { error = "Could not reach the diagnostics endpoint. Check the server's internet connection and try again." });
 
-        return Ok(new { refCode = code });
+        // Still a success (the telemetry snapshot alone can be useful), but the user
+        // must know their diagnostics were blank, otherwise they quote the ref code
+        // in a bug report and wait on logs that never arrived.
+        string? warning = matched == 0
+            ? "No LetterboxdSync entries were found in the two newest server log files, so the bundle contains no log lines. Reproduce the problem first (for example, run a sync), then send logs again."
+            : null;
+
+        return Ok(new { refCode = code, warning });
     }
 
     /// <summary>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.4.0</AssemblyVersion>
-    <FileVersion>1.19.4.0</FileVersion>
+    <AssemblyVersion>1.19.5.0</AssemblyVersion>
+    <FileVersion>1.19.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.3.0</AssemblyVersion>
-    <FileVersion>1.19.3.0</FileVersion>
+    <AssemblyVersion>1.19.4.0</AssemblyVersion>
+    <FileVersion>1.19.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Telemetry/TelemetryService.cs
+++ b/LetterboxdSync/Telemetry/TelemetryService.cs
@@ -398,7 +398,8 @@ internal static class TelemetryService
     /// sent" is literally true: the preview renders this string, the send posts it.
     /// </summary>
     public static string BuildLogBundleJson(
-        string instanceId, string pluginVersion, string telemetrySnapshotJson, string? note, List<string> logLines)
+        string instanceId, string pluginVersion, string telemetrySnapshotJson, string? note, List<string> logLines,
+        object collector)
     {
         var bundle = new
         {
@@ -407,6 +408,10 @@ internal static class TelemetryService
             jellyfin_version = JellyfinVersion ?? "unknown",
             telemetry = JsonSerializer.Deserialize<JsonElement>(telemetrySnapshotJson),
             note,
+            // Structured twin of the "[meta] collector: ..." first log line: tooling
+            // reads this field instead of parsing a string back out of log_lines; the
+            // line itself stays for humans reading the preview or grepping bundles.
+            collector,
             log_lines = logLines
         };
         return JsonSerializer.Serialize(bundle, new JsonSerializerOptions { WriteIndented = true });

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -213,6 +213,7 @@
                             <div style="font-size:0.88em;line-height:1.5;">Your reference code:
                                 <code id="sendLogsRefCode" style="font-size:1.1em;background:rgba(0,0,0,0.35);padding:0.1em 0.4em;border-radius:4px;">&mdash;</code><br>
                                 If you open a bug report on GitHub, quote this code so the developer can find your logs.</div>
+                            <div id="sendLogsWarning" style="display:none;margin-top:0.6em;padding:0.5em 0.7em;background:rgba(255,176,0,0.1);border:1px solid rgba(255,176,0,0.4);border-radius:6px;font-size:0.85em;line-height:1.5;"></div>
                             <button type="button" class="lb-btn lb-btn-secondary" id="sendLogsCopyCode" style="margin-top:0.6em;">Copy code</button>
                             <button type="button" class="lb-btn lb-btn-secondary" id="sendLogsClose" style="margin-top:0.6em;">Close</button>
                         </div>
@@ -475,6 +476,9 @@
                                 response.json().then(function (data) {
                                     status.textContent = '';
                                     document.getElementById('sendLogsRefCode').textContent = data.refCode;
+                                    var warn = document.getElementById('sendLogsWarning');
+                                    warn.textContent = data.warning || '';
+                                    warn.style.display = data.warning ? 'block' : 'none';
                                     document.getElementById('sendLogsResult').style.display = 'block';
                                 });
                             }, function (err) {

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.19.4',
+    headline: 'Send logs to developer now tells you when there is nothing to send',
+    summary:
+      'A user sent a diagnostic bundle that arrived completely empty: the plugin had not logged anything recently, so there was nothing to collect, but the dialog still reported plain success and neither side could tell why the bundle was blank. Now the send dialog warns you when no plugin log lines were found (with a hint to reproduce the problem first and try again), and every bundle carries a small status line saying which log files were read and how many lines matched, so an empty bundle explains itself.',
+    highlights: {
+      fixes: [
+        'The "Send logs to developer" dialog now shows a clear warning when the bundle contains no log lines, instead of reporting bare success on an empty send.',
+        'Diagnostic bundles now include a collector status line (files read, lines matched, any read error), so support can tell an idle plugin from a broken log reader.',
+      ],
+    },
+  },
+  {
     version: '1.19.3',
     headline: 'Telemetry can now tell a quiet week from a plugin that never worked',
     summary:


### PR DESCRIPTION
## Why

Diagnostic bundle `LBX-C1EP38` (2026-07-05, v1.19.2) arrived with `log_lines = []` and no note. Investigation showed the collection pipeline was working correctly: the sending instance's own telemetry snapshot recorded `syncs_per_week: 0` and zero error counters, i.e. the plugin was idle and its two newest Jellyfin log files genuinely contained no LetterboxdSync lines. The bug is that this case is silent on both ends: `BuildLogBundleJson` discarded the collector's `Source`/`Error` diagnostics, `SendLogs` uploaded the empty bundle anyway, and the dialog reported plain success. The user believes they sent diagnostics; the developer receives nothing and cannot tell an idle plugin from a missing log dir or a log template the line filter can't match.

## What

- `BuildLogBundleJson` now returns the matched-line count and prepends a collector status line to every bundle: `[meta] collector: files=<names>; matched=<n>; error=<err>`. Empty bundles become self-describing with zero worker/schema changes, and the consent preview shows the same line.
- `SendLogs` returns a `warning` field when zero lines matched; the send dialog displays it ("reproduce the problem first, then send again") alongside the ref code.

## Tests

633 total, 0 failures. Three new regression tests written first and confirmed failing against the unpatched code: empty capture warns + bundle carries `matched=0` meta; a matching line produces no warning and `matched=1`; preview shows the meta line on empty capture.

## Release notes

**"Send logs to developer" now tells you when there is nothing to send.** Previously, if the plugin had not logged anything recently, the send dialog reported success but the bundle arrived empty, and neither you nor the developer could tell why. The dialog now warns you when no plugin log lines were found, with a hint to reproduce the problem first and send again, and every bundle includes a small status line saying which log files were read and how many lines matched, so support requests no longer dead-end on an empty bundle.