### PR TITLE
test: fix all seven compiler and analyzer warnings in the test project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.3.0</Version>
-        <AssemblyVersion>1.19.3.0</AssemblyVersion>
-        <FileVersion>1.19.3.0</FileVersion>
+        <Version>1.19.4.0</Version>
+        <AssemblyVersion>1.19.4.0</AssemblyVersion>
+        <FileVersion>1.19.4.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/DiaryImportTaskTests.cs
+++ b/LetterboxdSync.Tests/DiaryImportTaskTests.cs
@@ -211,8 +211,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Letterboxd diary has TMDb 1233413; library has the same movie unplayed.
@@ -243,8 +245,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -274,8 +278,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -307,8 +313,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Diary has the film but no rating; library already marked as played.
@@ -339,8 +347,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Diary mentions a film, but library has nothing.
@@ -359,7 +369,7 @@ public class DiaryImportTaskTests : IDisposable
     }
 
     [Fact]
-    public async Task GetDefaultTriggers_ReturnsDailyInterval()
+    public void GetDefaultTriggers_ReturnsDailyInterval()
     {
         var triggers = _task.GetDefaultTriggers().ToList();
 
@@ -387,8 +397,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -423,8 +435,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();

--- a/LetterboxdSync.Tests/HttpClientTests.cs
+++ b/LetterboxdSync.Tests/HttpClientTests.cs
@@ -68,7 +68,7 @@ public class HttpClientTests
         http.SetRawCookies("   ");
 
         var cookies = http.CookieContainer.GetCookies(BaseUri);
-        Assert.Equal(0, cookies.Count);
+        Assert.Empty(cookies);
     }
 
     [Fact]

--- a/LetterboxdSync.Tests/LetterboxdControllerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdControllerTests.cs
@@ -397,7 +397,7 @@ public class LetterboxdControllerTests
         });
 
         var mine = h.Config.Accounts.Where(a => a.UserJellyfinId == UserId).ToList();
-        Assert.Single(mine.Where(a => a.IsPrimary));
+        Assert.Single(mine, a => a.IsPrimary);
     }
 
     [Fact]
@@ -415,7 +415,7 @@ public class LetterboxdControllerTests
         });
 
         var mine = h.Config.Accounts.Where(a => a.UserJellyfinId == UserId).ToList();
-        Assert.Single(mine.Where(a => a.IsPrimary));
+        Assert.Single(mine, a => a.IsPrimary);
     }
 
     // ----- StartSync -----

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -271,7 +271,7 @@ public class LetterboxdSyncRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task IsRunning_FalseWhenIdle()
+    public void IsRunning_FalseWhenIdle()
     {
         Assert.False(LetterboxdSyncRunner.IsRunning);
     }
@@ -405,7 +405,9 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var importedUserData = new UserItemData
         {
-            Key = "k", Played = true, LastPlayedDate = null
+            Key = "k",
+            Played = true,
+            LastPlayedDate = null
         };
         _userDataManager.GetUserData(user, movie).Returns(importedUserData);
 
@@ -449,7 +451,9 @@ public class LetterboxdSyncRunnerTests : IDisposable
 
         var playedUserData = new UserItemData
         {
-            Key = "k", Played = true, LastPlayedDate = DateTime.UtcNow
+            Key = "k",
+            Played = true,
+            LastPlayedDate = DateTime.UtcNow
         };
         _userDataManager.GetUserData(user, movie).Returns(playedUserData);
 
@@ -535,8 +539,11 @@ public class LetterboxdSyncRunnerTests : IDisposable
         for (var i = 0; i < LetterboxdSyncRunner.MaxConsecutiveSyncFailures; i++)
             SyncHistory.Record(new SyncEvent
             {
-                FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
-                Timestamp = DateTime.UtcNow.AddMinutes(-i), Status = SyncStatus.Failed
+                FilmTitle = "Sinners",
+                TmdbId = 1233413,
+                Username = "lachlan",
+                Timestamp = DateTime.UtcNow.AddMinutes(-i),
+                Status = SyncStatus.Failed
             });
 
         var factoryHit = false;
@@ -570,8 +577,11 @@ public class LetterboxdSyncRunnerTests : IDisposable
         for (var i = 0; i < LetterboxdSyncRunner.MaxConsecutiveSyncFailures - 1; i++)
             SyncHistory.Record(new SyncEvent
             {
-                FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
-                Timestamp = DateTime.UtcNow.AddMinutes(-i), Status = SyncStatus.Failed
+                FilmTitle = "Sinners",
+                TmdbId = 1233413,
+                Username = "lachlan",
+                Timestamp = DateTime.UtcNow.AddMinutes(-i),
+                Status = SyncStatus.Failed
             });
 
         var factoryHit = false;
@@ -688,14 +698,20 @@ public class LetterboxdSyncRunnerTests : IDisposable
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
         _userDataManager.GetUserData(user, movie).Returns(new UserItemData
         {
-            Key = "k", Played = true, LastPlayedDate = viewing
+            Key = "k",
+            Played = true,
+            LastPlayedDate = viewing
         });
 
         SyncHistory.Record(new SyncEvent
         {
-            FilmTitle = "Sinners", TmdbId = 1233413, Username = "lachlan",
-            Timestamp = DateTime.UtcNow, ViewingDate = viewing,
-            Status = SyncStatus.Success, Source = "test"
+            FilmTitle = "Sinners",
+            TmdbId = 1233413,
+            Username = "lachlan",
+            Timestamp = DateTime.UtcNow,
+            ViewingDate = viewing,
+            Status = SyncStatus.Success,
+            Source = "test"
         });
 
         var factoryHit = false;
@@ -723,8 +739,12 @@ public class LetterboxdSyncRunnerTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "lb-user", LetterboxdPassword = "secret",
-            Enabled = true, SkipPreviouslySynced = false, StopOnFailure = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "lb-user",
+            LetterboxdPassword = "secret",
+            Enabled = true,
+            SkipPreviouslySynced = false,
+            StopOnFailure = true
         });
 
         var m1 = MakeMovie(1233413, "Sinners");
@@ -769,15 +789,22 @@ public class LetterboxdSyncRunnerTests : IDisposable
         _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
         _userDataManager.GetUserData(user, movie).Returns(new UserItemData
         {
-            Key = "k", Played = true, LastPlayedDate = viewing
+            Key = "k",
+            Played = true,
+            LastPlayedDate = viewing
         });
 
         // Prior successful sync on the same viewing date → not a rewatch → suppress.
         SyncHistory.Record(new SyncEvent
         {
-            FilmTitle = "Sinners", FilmSlug = "sinners-2025", TmdbId = 1233413, Username = "lachlan",
-            Timestamp = DateTime.UtcNow.AddHours(-1), ViewingDate = viewing.Date,
-            Status = SyncStatus.Success, Source = "test"
+            FilmTitle = "Sinners",
+            FilmSlug = "sinners-2025",
+            TmdbId = 1233413,
+            Username = "lachlan",
+            Timestamp = DateTime.UtcNow.AddHours(-1),
+            ViewingDate = viewing.Date,
+            Status = SyncStatus.Success,
+            Source = "test"
         });
 
         var service = Substitute.For<ILetterboxdService>();

--- a/LetterboxdSync.Tests/MultiAccountContractTests.cs
+++ b/LetterboxdSync.Tests/MultiAccountContractTests.cs
@@ -59,11 +59,16 @@ public class MultiAccountContractTests
         var config = new PluginConfiguration();
         config.Accounts.Add(new Account
         {
-            UserJellyfinId = "u1", LetterboxdUsername = "secondary", Enabled = true
+            UserJellyfinId = "u1",
+            LetterboxdUsername = "secondary",
+            Enabled = true
         });
         config.Accounts.Add(new Account
         {
-            UserJellyfinId = "u1", LetterboxdUsername = "primary", Enabled = true, IsPrimary = true
+            UserJellyfinId = "u1",
+            LetterboxdUsername = "primary",
+            Enabled = true,
+            IsPrimary = true
         });
 
         var ordered = config.GetEnabledAccountsForUser("u1").ToList();
@@ -85,6 +90,6 @@ public class MultiAccountContractTests
 
         config.NormalisePrimaryFlags();
 
-        Assert.Single(config.Accounts.Where(a => a.IsPrimary));
+        Assert.Single(config.Accounts, a => a.IsPrimary);
     }
 }

--- a/LetterboxdSync.Tests/PlaybackHandlerTests2.cs
+++ b/LetterboxdSync.Tests/PlaybackHandlerTests2.cs
@@ -305,7 +305,9 @@ public class PlaybackHandlerEarlyExitTests : IDisposable
         // userData has rating=8 (Jellyfin scale) → should map to LB 4.0
         _userDataManager.GetUserData(user, movie).Returns(new UserItemData
         {
-            Key = "k", Played = true, Rating = 8.0
+            Key = "k",
+            Played = true,
+            Rating = 8.0
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -318,7 +320,8 @@ public class PlaybackHandlerEarlyExitTests : IDisposable
         double? capturedRating = null;
         service.MarkAsWatchedAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Do<double?>(r => capturedRating = r));
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Do<double?>(r => capturedRating = r))
+            .Returns(Task.CompletedTask);
 
         await _handler.HandlePlaybackStoppedAsync(new PlaybackStopEventArgs
         {

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.3.0</AssemblyVersion>
-    <FileVersion>1.19.3.0</FileVersion>
+    <AssemblyVersion>1.19.4.0</AssemblyVersion>
+    <FileVersion>1.19.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,17 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.19.4',
+    headline: 'Housekeeping: a warning-clean test build',
+    summary:
+      'No functional changes. The plugin\u2019s test suite compiled with seven compiler and analyzer warnings (a couple of async test methods that never awaited anything, one fire-and-forget mock setup, and a few assertions written the long way around). All seven are fixed, so the build is warning-clean again and future warnings stand out instead of drowning in noise. Nothing about syncing, accounts, or the dashboard changes in this release.',
+    highlights: {
+      fixes: [
+        'Cleaned up all seven compiler and analyzer warnings in the test project; every touched test was verified to still fail when its assertion is broken, so no coverage was lost.',
+      ],
+    },
+  },
+  {
     version: '1.19.3',
     headline: 'Telemetry can now tell a quiet week from a plugin that never worked',
     summary:


### PR DESCRIPTION
No linked issue.

## Release notes

No functional changes. The plugin's test suite compiled with seven compiler and analyzer warnings (a couple of async test methods that never awaited anything, one fire-and-forget mock setup, and a few assertions written the long way around). All seven are fixed, so the build is warning-clean again and future warnings stand out instead of drowning in noise. Nothing about syncing, accounts, or the dashboard changes in this release.

## What's broken

`dotnet build` of the solution emitted seven warnings from LetterboxdSync.Tests (CS1998 x2, CS4014 x1, xUnit2013 x1, xUnit2031 x3). Warning noise hides real warnings when they appear.

## Why it happens

1. Two test methods were declared `async` but never await anything, and one NSubstitute setup call discards the returned Task.
2. Three assertions use `Where(...)` + `Assert.Single(...)` / `Assert.Equal(0, Count)` where xUnit's analyzers want the dedicated overloads.

## What this PR does

Fixes each warning at its site: drops `async` from the two synchronous tests, gives the `MarkAsWatchedAsync` setup an explicit `.Returns(Task.CompletedTask)`, and switches the three assertions to `Assert.Empty` / `Assert.Single(collection, predicate)`. The pre-commit formatter also normalized whitespace in the touched files (object initializers one property per line); those lines are cosmetic. Version bumped to 1.19.4.0 with a release-notes entry.

## How to test

- `dotnet build LetterboxdSync.sln -c Release` emits zero warnings (was seven).
- `dotnet test -c Release --filter "Category!=Integration"`: 618 passed, 0 failed.
- Each touched test was individually verified to still FAIL when its core assertion is inverted, so no test went dead in the cleanup.

## Follow-ups

- Issue #89 (reverse sync does not work) is the top open bug and untouched by this PR.