### PR TITLE
fix: diary import explains why it skipped instead of finishing silently

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.19.3.0</Version>
-        <AssemblyVersion>1.19.3.0</AssemblyVersion>
-        <FileVersion>1.19.3.0</FileVersion>
+        <Version>1.19.6.0</Version>
+        <AssemblyVersion>1.19.6.0</AssemblyVersion>
+        <FileVersion>1.19.6.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/DiaryImportTaskTests.cs
+++ b/LetterboxdSync.Tests/DiaryImportTaskTests.cs
@@ -131,7 +131,7 @@ public class DiaryImportTaskTests : IDisposable
 
         await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
-        // No factory call made, no userdata saves; nothing to assert beyond not throwing.
+        // No factory call, no userdata saves; checks the runner is not left running.
         Assert.False(LetterboxdSyncRunner.IsRunning);
     }
 
@@ -204,6 +204,9 @@ public class DiaryImportTaskTests : IDisposable
 
         await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
+        // Subsumes the former ExecuteAsync_EmptyDiary_DoesNotQueryLibrary test:
+        // an empty diary must never reach the library query.
+        _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
         Assert.Contains(_logs.Entries, e =>
             e.Level == LogLevel.Information && e.Message.Contains("nothing to import"));
         // This path used to `continue` without SyncProgress.Complete(), leaving the
@@ -249,28 +252,6 @@ public class DiaryImportTaskTests : IDisposable
         var service = Substitute.For<ILetterboxdService>();
         service.GetDiaryFilmEntriesAsync(Arg.Any<string>())
             .Returns<Task<List<DiaryFilmEntry>>>(_ => throw new Exception("403"));
-        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
-
-        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
-
-        _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_EmptyDiary_DoesNotQueryLibrary()
-    {
-        var (user, userId) = MakeUser("lachlan");
-        _userManager.GetUsers().Returns(new[] { user });
-        Plugin.Instance!.Configuration.Accounts.Add(new Account
-        {
-            UserJellyfinId = userId,
-            LetterboxdUsername = "u",
-            Enabled = true,
-            EnableDiaryImport = true
-        });
-
-        var service = Substitute.For<ILetterboxdService>();
-        service.GetDiaryFilmEntriesAsync(Arg.Any<string>()).Returns(new List<DiaryFilmEntry>());
         LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
 
         await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);

--- a/LetterboxdSync.Tests/DiaryImportTaskTests.cs
+++ b/LetterboxdSync.Tests/DiaryImportTaskTests.cs
@@ -13,7 +13,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Serialization;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -54,7 +54,36 @@ public class DiaryImportTaskTests : IDisposable
         _libraryManager = Substitute.For<ILibraryManager>();
         _userDataManager = Substitute.For<IUserDataManager>();
 
-        _task = new DiaryImportTask(_userManager, NullLoggerFactory.Instance, _libraryManager, _userDataManager);
+        _logs = new ListLoggerFactory();
+        _task = new DiaryImportTask(_userManager, _logs, _libraryManager, _userDataManager);
+    }
+
+    private readonly ListLoggerFactory _logs;
+
+    /// <summary>
+    /// Captures log output in memory so tests can assert the task explains its
+    /// skip decisions (issue #89: a silent run is indistinguishable from a broken
+    /// feature). Enabled for every level so Debug lines are captured too.
+    /// </summary>
+    private sealed class ListLoggerFactory : ILoggerFactory
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new ListLogger(Entries);
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
+
+        private sealed class ListLogger : ILogger
+        {
+            private readonly List<(LogLevel, string)> _entries;
+            public ListLogger(List<(LogLevel, string)> entries) { _entries = entries; }
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                lock (_entries) { _entries.Add((logLevel, formatter(state, exception))); }
+            }
+        }
     }
 
     public void Dispose()
@@ -107,7 +136,7 @@ public class DiaryImportTaskTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_UserHasNoAccount_SkippedSilently()
+    public async Task ExecuteAsync_UserHasNoAccount_SkippedWithDebugLog()
     {
         var (user, userId) = MakeUser("lachlan");
         _userManager.GetUsers().Returns(new[] { user });
@@ -116,6 +145,10 @@ public class DiaryImportTaskTests : IDisposable
 
         // No factory override needed; we never get to it.
         _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        // Debug, not Information: a user who never set the plugin up shouldn't
+        // produce daily log noise, but the reason must still be discoverable.
+        Assert.Contains(_logs.Entries, e =>
+            e.Level == LogLevel.Debug && e.Message.Contains("no enabled Letterboxd accounts"));
     }
 
     [Fact]
@@ -134,6 +167,48 @@ public class DiaryImportTaskTests : IDisposable
         await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
         _libraryManager.DidNotReceive().GetItemList(Arg.Any<InternalItemsQuery>());
+        // Issue #89: this exact state (account exists, toggle off) used to be a
+        // silent no-op. It must now tell the user how to turn reverse sync on.
+        Assert.Contains(_logs.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("none has diary import turned on"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlwaysLogsRunSummary_EvenWithNothingToDo()
+    {
+        _userManager.GetUsers().Returns(new List<User>());
+
+        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Contains(_logs.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("Diary import task finished"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyDiary_LogsOutcomeAndCompletesProgress()
+    {
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        Plugin.Instance!.Configuration.Accounts.Add(new Account
+        {
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
+        });
+
+        var service = Substitute.For<ILetterboxdService>();
+        service.GetDiaryFilmEntriesAsync(Arg.Any<string>())
+            .Returns(new List<DiaryFilmEntry>());
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) => Task.FromResult(service);
+
+        await _task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Contains(_logs.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("nothing to import"));
+        // This path used to `continue` without SyncProgress.Complete(), leaving the
+        // dashboard progress banner running forever.
+        Assert.False(SyncProgress.IsRunning);
     }
 
     [Fact]
@@ -211,8 +286,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Letterboxd diary has TMDb 1233413; library has the same movie unplayed.
@@ -243,8 +320,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -274,8 +353,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -307,8 +388,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Diary has the film but no rating; library already marked as played.
@@ -339,8 +422,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         // Diary mentions a film, but library has nothing.
@@ -387,8 +472,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();
@@ -423,8 +510,10 @@ public class DiaryImportTaskTests : IDisposable
         _userManager.GetUsers().Returns(new[] { user });
         Plugin.Instance!.Configuration.Accounts.Add(new Account
         {
-            UserJellyfinId = userId, LetterboxdUsername = "u",
-            Enabled = true, EnableDiaryImport = true
+            UserJellyfinId = userId,
+            LetterboxdUsername = "u",
+            Enabled = true,
+            EnableDiaryImport = true
         });
 
         var service = Substitute.For<ILetterboxdService>();

--- a/LetterboxdSync/DiaryImportTask.cs
+++ b/LetterboxdSync/DiaryImportTask.cs
@@ -42,6 +42,7 @@ public class DiaryImportTask : IScheduledTask
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var users = _userManager.GetUsers().ToList();
+        var usersWithImport = 0;
 
         foreach (var user in users)
         {
@@ -50,12 +51,28 @@ public class DiaryImportTask : IScheduledTask
             // Collect entries from every enabled-with-diary-import account belonging to this
             // Jellyfin user. GetEnabledAccountsForUser returns primary first, so the merge
             // below naturally gives primary's rating priority on conflicts.
-            var accounts = Config.GetEnabledAccountsForUser(user.Id.ToString("N"))
+            var enabledAccounts = Config.GetEnabledAccountsForUser(user.Id.ToString("N")).ToList();
+            var accounts = enabledAccounts
                 .Where(a => a.EnableDiaryImport)
                 .ToList();
 
             if (accounts.Count == 0)
+            {
+                // Say WHY nothing happened: a run that exits here used to log nothing at
+                // all, which made a disabled toggle indistinguishable from a broken
+                // feature (issue #89). Users with no accounts at all stay at Debug so a
+                // multi-user server isn't nagged daily about people who never set up
+                // the plugin.
+                if (enabledAccounts.Count > 0)
+                    _logger.LogInformation(
+                        "Diary import skipped for {Username}: {AccountCount} enabled Letterboxd account(s), but none has diary import turned on. Enable 'Import Letterboxd diary as Jellyfin watched' on the account to use reverse sync.",
+                        user.Username, enabledAccounts.Count);
+                else
+                    _logger.LogDebug("Diary import skipped for {Username}: no enabled Letterboxd accounts", user.Username);
                 continue;
+            }
+
+            usersWithImport++;
 
             _logger.LogInformation("Starting diary import for {Username} ({AccountCount} account(s))",
                 user.Username, accounts.Count);
@@ -115,7 +132,16 @@ public class DiaryImportTask : IScheduledTask
             }
 
             if (diaryTmdbIds.Count == 0)
+            {
+                // Log the outcome and close the progress banner; this path used to
+                // `continue` bare, leaving SyncProgress started forever and the log
+                // silent about why nothing was imported.
+                _logger.LogInformation(
+                    "Diary import for {Username}: no films found on Letterboxd across {AccountCount} account(s) (empty diary/watched list, or every fetch failed above); nothing to import",
+                    user.Username, accounts.Count);
+                SyncProgress.Complete();
                 continue;
+            }
 
             // Pull all movies (not just unplayed) so we can also apply rating-only updates
             // to films already marked as played.
@@ -215,6 +241,12 @@ public class DiaryImportTask : IScheduledTask
                 ratingByTmdbId.Count(kv => libraryTmdbIds.Contains(kv.Key)) - ratingsApplied);
             SyncProgress.Complete();
         }
+
+        // Always leave one line per run, even when every user was skipped, so a
+        // "finished in 0 seconds" run is explainable from the log alone.
+        _logger.LogInformation(
+            "Diary import task finished: {UserCount} Jellyfin user(s) checked, {EligibleCount} with diary import enabled",
+            users.Count, usersWithImport);
 
         progress.Report(100);
     }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>1.19.3.0</AssemblyVersion>
-    <FileVersion>1.19.3.0</FileVersion>
+    <AssemblyVersion>1.19.6.0</AssemblyVersion>
+    <FileVersion>1.19.6.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '1.19.6',
+    headline: 'Reverse sync now explains itself when it has nothing to do',
+    summary:
+      'If the "Import Letterboxd diary as Jellyfin watched" task ran and did nothing, it used to finish in a second and leave no trace in the log, so a switched-off toggle looked identical to a broken feature. The task now says why it skipped each user (for example, an account exists but diary import is not turned on, with a pointer to the setting), reports when your Letterboxd returned no films, and always ends with a one-line summary of what it checked. A stuck progress banner on the dashboard for empty diaries is also fixed. If reverse sync has not been working for you, update, run the task once, and the log will now tell you exactly why.',
+    highlights: {
+      fixes: [
+        'The diary import task logs the reason whenever it skips a user, reports empty results, and always writes a completion summary, so a run that does nothing is explainable from the log alone.',
+        'Fixed the dashboard progress banner staying active forever when a diary import found no films to import.',
+      ],
+    },
+  },
+  {
     version: '1.19.3',
     headline: 'Telemetry can now tell a quiet week from a plugin that never worked',
     summary:


### PR DESCRIPTION
Closes #89.

## Release notes

If the "Import Letterboxd diary as Jellyfin watched" task ran and did nothing, it used to finish in a second and leave no trace in the log, so a switched-off toggle looked identical to a broken feature. The task now says why it skipped each user (for example, an account exists but diary import is not turned on, with a pointer to the setting), reports when your Letterboxd returned no films, and always ends with a one-line summary of what it checked. A stuck progress banner on the dashboard for empty diaries is also fixed. If reverse sync has not been working for you, update, run the task once, and the log will now tell you exactly why.

## What's broken

Issue #89: reverse sync appears dead. The scheduled task completes in 0 seconds with no log output, and the reporter (on the official API path, forward sync working) cannot tell why.

## Why it happens

1. The task silently `continue`s any Jellyfin user whose accounts don't pass the diary-import filter, with no log line, so the overwhelmingly likely state (the per-account toggle is off, it is opt-in) is invisible.
2. The empty-diary path also `continue`d bare, skipping both the outcome log and `SyncProgress.Complete()`, leaving the dashboard progress banner running forever.

The diary fetch itself is healthy: it is exercised against live letterboxd.com by the integration suite on every PR.

## What this PR does

Adds skip-reason logging (Information when an account exists but diary import is off, with the setting named; Debug for users with no accounts so multi-user servers aren't nagged), an outcome line when Letterboxd returns no films, a `SyncProgress.Complete()` on that path, and an always-emitted run summary. Tests capture log output via an in-memory logger factory and pin each new line; the redundant pre-existing empty-diary test was folded into the new one. Version 1.19.6.0 (1.19.4.0 and 1.19.5.0 are claimed by open PRs #88 and #90; merge those first).

## How to test

- `dotnet test -c Release --filter "Category!=Integration"`: 619 passed, 0 failed.
- After merge, run the task once with an account whose diary-import toggle is off: the log names the user, the reason, and the exact setting to enable; the run summary line always appears.

## Follow-ups

- Reply drafted for issue #89 asking the reporter to update and re-run so the log explains their specific case.