### PR TITLE
chore: release v2.1.0, dashboard credit line, TV telemetry, Logs tab fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>1.20.0.0</Version>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <FileVersion>2.0.0.0</FileVersion>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+        <FileVersion>2.1.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -918,8 +918,14 @@
                                     function () { st.innerHTML = '<span class="ws-red">Connection failed.</span>'; });
                         },
                         loadLogs: function () {
+                            document.getElementById('logsOutput').textContent = 'Loading…';
                             ApiClient.ajax({ url: ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/Logs', { maxLines: 400 }), type: 'GET' })
-                                .then(function (r) { r.text().then(function (t) { document.getElementById('logsOutput').textContent = t || 'No recent log lines.'; }); })
+                                .then(function (r) { r.json().then(function (d) {
+                                    var lines = d.lines || [];
+                                    document.getElementById('logsOutput').textContent = lines.length
+                                        ? lines.join('\n')
+                                        : (d.error ? 'Error: ' + d.error : 'No recent log lines.');
+                                }); })
                                 .catch(function () { document.getElementById('logsOutput').textContent = 'Could not load logs.'; });
                         },
                         sendLogs: function () {

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -11,13 +11,14 @@ export type ReleaseNotes = {
 export const releaseNotes: ReleaseNotes[] = [
   {
     version: '2.1.0',
-    headline: 'Telemetry now covers TV syncs, and the dashboard credit is back',
+    headline: 'Telemetry now covers TV syncs, the dashboard credit is back, and Logs actually refresh',
     summary:
-      'Two follow-ups to the 2.0.0 rebrand. The admin and user dashboard headers lost their "by Lachlan Young and AI" credit line during the redesign, it\'s back. And the opt-in anonymous telemetry, which only ever counted Letterboxd film syncs, now counts Serializd TV syncs and errors too, since that pipeline was never touched when TV support was built.',
+      'A few follow-ups to the 2.0.0 rebrand. The admin and user dashboard headers lost their "by Lachlan Young and AI" credit line during the redesign, it\'s back. The opt-in anonymous telemetry, which only ever counted Letterboxd film syncs, now counts Serializd TV syncs and errors too, since that pipeline was never touched when TV support was built. And the Logs tab\'s Refresh button, which had been dumping a raw JSON blob into the panel instead of readable log lines, now shows the actual logs.',
     highlights: {
       fixes: [
         'Restored the "by Lachlan Young and AI" credit line in both the admin and user dashboard headers.',
         'Opt-in anonymous telemetry now tracks Serializd (TV) syncs and errors independently from the Letterboxd (film) side, instead of only ever reporting film activity.',
+        'Fixed the Logs tab\'s Refresh button showing the raw JSON response instead of readable log lines.',
       ],
     },
   },

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '2.1.0',
+    headline: 'Telemetry now covers TV syncs, and the dashboard credit is back',
+    summary:
+      'Two follow-ups to the 2.0.0 rebrand. The admin and user dashboard headers lost their "by Lachlan Young and AI" credit line during the redesign, it\'s back. And the opt-in anonymous telemetry, which only ever counted Letterboxd film syncs, now counts Serializd TV syncs and errors too, since that pipeline was never touched when TV support was built.',
+    highlights: {
+      fixes: [
+        'Restored the "by Lachlan Young and AI" credit line in both the admin and user dashboard headers.',
+        'Opt-in anonymous telemetry now tracks Serializd (TV) syncs and errors independently from the Letterboxd (film) side, instead of only ever reporting film activity.',
+      ],
+    },
+  },
+  {
     version: '2.0.0',
     headline: 'Renamed to Jellyscribe, and TV shows now sync to Serializd',
     summary:


### PR DESCRIPTION
No linked issue.

## Release notes

A few follow-ups to the 2.0.0 rebrand. The admin and user dashboard headers lost their "by Lachlan Young and AI" credit line during the redesign, it's back. The opt-in anonymous telemetry, which only ever counted Letterboxd film syncs, now counts Serializd TV syncs and errors too, since that pipeline was never touched when TV support was built. And the Logs tab's Refresh button, which had been dumping a raw JSON blob into the panel instead of readable log lines, now shows the actual logs.

## What's broken

Three things, found while verifying the 2.0.0 rebrand live on a real server after merge:

- **The dashboard credit line disappeared.** Both the admin config page and the per-user page used to show "by Lachlan Young and AI" under the logo. The 2.0.0 redesign rebuilt both headers and dropped it.
- **Telemetry is blind to the plugin's newest feature.** Every counter, feature flag, and error category the opt-in telemetry reports (`syncs_ever`, `watchlist_sync`, error classification, all of it) only ever reflected the Letterboxd side. Nothing in the Serializd (TV) code path was ever wired in when TV support was built in the same 2.0.0 PR, so an install running entirely on TV syncs reports as if it does nothing at all.
- **The Logs tab's Refresh button shows garbage.** Clicking it replaces the panel with the raw JSON response body instead of the log lines it contains.

## Why it happens

1. The dashboard headers were rebuilt from scratch for the 2.0.0 visual redesign, and the credit line wasn't part of the new markup.
2. Serializd was built as a fully independent, parallel system (separate history, separate activity feed, separate sync gate) in the same PR that shipped it, but nobody wired its success/failure events into `TelemetryService`, which only has ever had one hook, called from the Letterboxd-only `SyncHistory.Record`.
3. The Logs tab's backend endpoint (`GetLogs`) has always returned a JSON object (`{lines, totalMatches, source}`), unchanged from before the redesign. The rebuilt Refresh handler reads the response with `r.text()` instead of `r.json()`, so it never parses out the `lines` array, it just stringifies the whole response body.

## What this PR does

- Restores the credit line in both `configPage.html` and `userPage.html` headers, styled to match the new design (gold "AI", underlined author link), with `utm_source=jellyscribe&utm_medium=plugin&utm_campaign=author-link` on the link.
- Wires Serializd into telemetry:
  - `SerializdActivity.Record` now calls a new `TelemetryService.OnTvSyncEvent`, the TV counterpart of the existing `OnSyncEvent` hook, feeding independent `WindowTvSyncs`/`LifetimeTvSyncs` counters (`tv_syncs_per_week`/`tv_syncs_ever` in the payload).
  - New `tv_*` feature flags (`tv_configured`, `tv_watchlist_sync`, `tv_diary_import`, etc.) computed from `SerializdAccounts`, mirroring the existing Letterboxd flags.
  - Direct `TelemetryService.RecordError` hooks added at the Serializd early-exit catch blocks (auth/fetch failures that never reach a `SyncEvent`), mirroring the existing Letterboxd runners.
  - `Classify()` now also recognizes Serializd's `"failed (5xx):"` error message shape (it only matched Letterboxd's `"returned 5xx"` wording before), so Serializd server errors classify correctly instead of falling into the `other` bucket.
  - Errors share the existing categories rather than adding a parallel TV set: the ingest Worker's category list is fixed and mirrored in a separate private ops repo, and every existing category (`auth_failure`, `rate_limit`, `server_error`, `jellyseerr_error`, etc.) already applies equally to either service.
- Fixes the Logs tab's `loadLogs()` to parse the response as JSON and join the `lines` array, instead of dumping the raw response text.
- Bumps `AssemblyVersion`/`FileVersion` to 2.1.0.0.

### Note on how this PR arrived

The credit-line, UTM-tagging, and telemetry-wiring commits were pushed directly to `main` earlier today rather than through this PR (an active back-and-forth fixing live issues found right after the 2.0.0 merge), so they don't show up in this PR's diff, they're already on `main`. This PR is what actually ships them as a real release: the version bump, plus the Logs tab fix found afterward. The Release notes section above describes everything landing in 2.1.0, not just this branch's diff.

## How to test

Automated: `dotnet test -c Release --filter "Category!=Integration"`, 793 tests, all passing, including new coverage in `TelemetryServiceTests.cs` for the TV counters, shared error classification, and the `Classify()` Serializd-format patterns.

Manual:
1. Open the admin and user dashboards, confirm "by Lachlan Young and AI" shows under the logo in both, and the author link carries `utm_medium=plugin`.
2. With telemetry enabled and a Serializd account configured, trigger a TV sync, confirm the next telemetry preview shows non-zero `tv_syncs_ever` and the `tv_*` feature flags reflect your actual settings.
3. Open the Logs tab, click Refresh, confirm it shows readable log lines instead of a JSON blob.

Verified live against production: deployed to a real server, confirmed via direct D1 query that a telemetry payload sent after this build shows all the new `tv_*` fields, and that the log bundle from the same run has no new errors introduced.

## Follow-ups (not in this PR)

- Flip `jellyscribe.dev` to the primary GitHub Pages domain (still deferred from 2.0.0).
- Run the one-time D1 migration and redeploy the telemetry Worker if not already done (`collector` column, repo-name URLs, both already applied live this session).
