### PR TITLE
docs: add requested to the dashboard sync statistics list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ These apply the same way whether the account is a Letterboxd (film) or Serializd
 ### Dashboard
 
 The **Dashboard** tab shows the same for both Letterboxd and Serializd accounts:
-- Sync statistics (total, synced, rewatches, skipped, failed)
+- Sync statistics (total, synced, rewatches, skipped, failed, requested)
 - Recent activity with links to each title on Letterboxd or Serializd
 - **Run Sync Now** button to trigger a sync on demand
 - **Review** buttons to write and post reviews directly to Letterboxd or Serializd


### PR DESCRIPTION
No linked issue.

## Release notes

Docs-only change, no release notes needed.

## What's broken

The README's Dashboard section listed the sync statistics tiles as "total, synced, rewatches, skipped, failed", missing the "requested" tile that PR #98 added for Seerr auto-request activity.

## Why it happens

1. PR #98 added the `Requested` stat tile to statsPage.html but the README's Dashboard bullet wasn't updated alongside it.

## What this PR does

Adds "requested" to the parenthetical list of dashboard sync statistics in README.md. Docs-only, no code or behavior change.

## How to test

Visual inspection of README.md; no automated coverage for prose accuracy.

## Follow-ups (not in this PR)

-