### PR TITLE
fix: retry sidebar registration to survive Jellyfin's startup race

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>1.20.0.0</Version>
-        <AssemblyVersion>2.1.1.0</AssemblyVersion>
-        <FileVersion>2.1.1.0</FileVersion>
+        <AssemblyVersion>2.1.2.0</AssemblyVersion>
+        <FileVersion>2.1.2.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/SidebarInjectionTests.cs
+++ b/LetterboxdSync.Tests/SidebarInjectionTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using LetterboxdSync;
 using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -12,6 +14,23 @@ namespace LetterboxdSync.Tests;
 
 public class SidebarInjectionTaskTests
 {
+    /// <summary>Captures log entries (including the passed exception) for assertions.</summary>
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (Entries) { Entries.Add((logLevel, formatter(state, exception), exception)); }
+        }
+    }
+
+    private static Func<TimeSpan, CancellationToken, Task> NoOpDelay(List<TimeSpan> recorded) =>
+        (delay, _) => { lock (recorded) recorded.Add(delay); return Task.CompletedTask; };
+
+
     [Fact]
     public void Metadata_NameKeyDescriptionCategory_AreSet()
     {
@@ -70,6 +89,102 @@ public class SidebarInjectionTaskTests
         private readonly List<T> _values = new();
         public IReadOnlyList<T> Values { get { lock (_lock) return _values.ToList(); } }
         public void Report(T value) { lock (_lock) _values.Add(value); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisterSucceedsFirstTry_DoesNotRetry()
+    {
+        var logs = new ListLogger<SidebarInjectionTask>();
+        var delays = new List<TimeSpan>();
+        var attempts = 0;
+        var task = new SidebarInjectionTask(logs)
+        {
+            RegisterAttemptOverride = () => attempts++,
+            DelayOverride = NoOpDelay(delays),
+        };
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(1, attempts);
+        Assert.Empty(delays);
+        Assert.Contains(logs.Entries, e => e.Level == LogLevel.Information
+            && e.Message.Contains("registered successfully"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisterFailsThenSucceeds_RetriesAndSucceeds()
+    {
+        var logs = new ListLogger<SidebarInjectionTask>();
+        var delays = new List<TimeSpan>();
+        var attempts = 0;
+        var task = new SidebarInjectionTask(logs)
+        {
+            RegisterAttemptOverride = () =>
+            {
+                attempts++;
+                if (attempts < SidebarInjectionTask.MaxAttempts)
+                    throw new InvalidOperationException("File Transformation not ready yet");
+            },
+            DelayOverride = NoOpDelay(delays),
+        };
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(SidebarInjectionTask.MaxAttempts, attempts);
+        Assert.Equal(SidebarInjectionTask.MaxAttempts - 1, delays.Count);
+        Assert.Contains(logs.Entries, e => e.Level == LogLevel.Information
+            && e.Message.Contains("registered successfully"));
+        Assert.DoesNotContain(logs.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisterAlwaysFails_RetriesMaxAttemptsThenLogsWarning()
+    {
+        var logs = new ListLogger<SidebarInjectionTask>();
+        var delays = new List<TimeSpan>();
+        var attempts = 0;
+        var task = new SidebarInjectionTask(logs)
+        {
+            RegisterAttemptOverride = () =>
+            {
+                attempts++;
+                throw new InvalidOperationException("File Transformation still not ready");
+            },
+            DelayOverride = NoOpDelay(delays),
+        };
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(SidebarInjectionTask.MaxAttempts, attempts);
+        Assert.Equal(SidebarInjectionTask.MaxAttempts - 1, delays.Count);
+
+        var warning = Assert.Single(logs.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains($"after {SidebarInjectionTask.MaxAttempts} attempt", warning.Message);
+        Assert.DoesNotContain(logs.Entries, e => e.Message.Contains("registered successfully"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnwrapsTargetInvocationException_LogsRealInnerException()
+    {
+        // The production failure path goes through reflection (MethodInfo.Invoke), which
+        // always wraps the real exception in a TargetInvocationException whose own .Message
+        // is a generic, useless string. This is the class of bug that made the original
+        // production failure undiagnosable without temporarily raising the log level.
+        var logs = new ListLogger<SidebarInjectionTask>();
+        var delays = new List<TimeSpan>();
+        var inner = new NullReferenceException("File Transformation's internal registry wasn't initialized yet");
+        var task = new SidebarInjectionTask(logs)
+        {
+            RegisterAttemptOverride = () => throw new TargetInvocationException(inner),
+            DelayOverride = NoOpDelay(delays),
+        };
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        var warning = Assert.Single(logs.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Same(inner, warning.Exception);
+        Assert.Contains(inner.Message, warning.Message);
+        Assert.DoesNotContain("target of an invocation", warning.Message);
     }
 }
 

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>2.1.1.0</AssemblyVersion>
-    <FileVersion>2.1.1.0</FileVersion>
+    <AssemblyVersion>2.1.2.0</AssemblyVersion>
+    <FileVersion>2.1.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/SidebarInjection.cs
+++ b/LetterboxdSync/SidebarInjection.cs
@@ -14,8 +14,24 @@ namespace LetterboxdSync;
 /// Startup task that registers with File Transformation plugin to inject
 /// the Letterboxd sidebar link into index.html for all users.
 /// </summary>
+/// <remarks>
+/// Registration races File Transformation's own startup init: both plugins fire their
+/// StartupTrigger tasks independently, and Jellyfin gives no ordering guarantee between
+/// them. When File Transformation hasn't finished initializing yet, <c>RegisterTransformation</c>
+/// throws (observed in production as an intermittent, restart-dependent failure - same code,
+/// same plugin version, works on some boots and not others). A single attempt made this a
+/// coin flip on every Jellyfin restart, including the weekly scheduled VM reboot, with no
+/// user-visible signal that it happened. <see cref="ExecuteAsync"/> retries a few times with a
+/// short delay before giving up, and unwraps <see cref="TargetInvocationException"/> so a real
+/// failure logs the actual cause instead of reflection's generic wrapper message.
+/// </remarks>
 public class SidebarInjectionTask : IScheduledTask
 {
+    /// <summary>Total attempts before giving up (1 initial + retries).</summary>
+    internal const int MaxAttempts = 3;
+
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(2);
+
     private readonly ILogger<SidebarInjectionTask> _logger;
 
     public string Name => "Jellyscribe Sidebar Registration";
@@ -31,6 +47,21 @@ public class SidebarInjectionTask : IScheduledTask
         _logger = logger;
     }
 
+    /// <summary>
+    /// Test-only override for the registration attempt. When set, the retry loop calls this
+    /// instead of the real reflection-based <see cref="RegisterWithFileTransformation"/>, so
+    /// tests can simulate N failures before success (or persistent failure) without a real
+    /// File Transformation assembly loaded. Production never assigns it.
+    /// </summary>
+    internal Action? RegisterAttemptOverride;
+
+    /// <summary>
+    /// Test-only override for the inter-attempt delay. When set, replaces the real
+    /// <see cref="Task.Delay(TimeSpan, CancellationToken)"/> wait so retry tests run instantly
+    /// instead of waiting <see cref="RetryDelay"/> in real time. Production never assigns it.
+    /// </summary>
+    internal Func<TimeSpan, CancellationToken, Task>? DelayOverride;
+
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
         return new[]
@@ -39,23 +70,44 @@ public class SidebarInjectionTask : IScheduledTask
         };
     }
 
-    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         progress.Report(10);
 
-        try
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
-            RegisterWithFileTransformation();
-            _logger.LogInformation("Letterboxd sidebar injection registered successfully");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning("Sidebar injection failed: {Error}", ex.Message);
-            _logger.LogDebug(ex, "Full sidebar injection error");
+            try
+            {
+                if (RegisterAttemptOverride != null)
+                    RegisterAttemptOverride();
+                else
+                    RegisterWithFileTransformation();
+
+                _logger.LogInformation("Letterboxd sidebar injection registered successfully");
+                break;
+            }
+            catch (Exception ex)
+            {
+                // TargetInvocationException.Message is always the generic reflection
+                // boilerplate ("Exception has been thrown by the target of an invocation.");
+                // the real cause is the InnerException.
+                var real = ex is TargetInvocationException { InnerException: { } inner } ? inner : ex;
+
+                if (attempt == MaxAttempts)
+                {
+                    _logger.LogWarning(real, "Sidebar injection failed after {Attempts} attempt(s): {Error}", attempt, real.Message);
+                    break;
+                }
+
+                _logger.LogDebug(real, "Sidebar injection attempt {Attempt}/{MaxAttempts} failed, retrying in {Delay}",
+                    attempt, MaxAttempts, RetryDelay);
+
+                var delay = DelayOverride ?? Task.Delay;
+                await delay(RetryDelay, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         progress.Report(100);
-        return Task.CompletedTask;
     }
 
     private void RegisterWithFileTransformation()

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '2.1.2',
+    headline: 'Sidebar link now reliably survives a Jellyfin restart',
+    summary:
+      'The sidebar link this plugin adds to Jellyfin\'s nav is injected by registering with the File Transformation plugin once, at Jellyfin startup. That registration was racing File Transformation\'s own startup init, so on some restarts (including scheduled ones) it silently failed and the link just never appeared, with nothing in the logs beyond a generic, undiagnosable error. Registration now retries a few times before giving up, and a real failure logs the actual cause instead of a useless wrapper message.',
+    highlights: {
+      fixes: [
+        'Sidebar link registration now retries (with a short delay) instead of giving up after a single attempt, so it no longer depends on winning a startup race against the File Transformation plugin on every Jellyfin restart.',
+        'A registration failure now logs the real underlying exception instead of reflection\'s generic "Exception has been thrown by the target of an invocation" message.',
+      ],
+    },
+  },
+  {
     version: '2.1.1',
     headline: 'Watchlist auto-requests now show up in your sync history',
     summary:


### PR DESCRIPTION
No linked issue.

## Release notes

The sidebar link this plugin adds to Jellyfin's nav is injected by registering with the File Transformation plugin once, at Jellyfin startup. That registration was racing File Transformation's own startup init, so on some restarts (including scheduled ones) it silently failed and the link just never appeared, with nothing in the logs beyond a generic, undiagnosable error. Registration now retries a few times before giving up, and a real failure logs the actual cause instead of a useless wrapper message.

## What's broken

The sidebar link (Letterboxd/Serializd nav entry) sometimes doesn't appear after a Jellyfin restart. Same plugin version, same server, works on some boots and not others. Discovered live: two consecutive restarts on 2026-07-18 both failed, a third succeeded.

## Why it happens

1. `SidebarInjectionTask` registers with the File Transformation plugin via reflection on a `StartupTrigger`, once, with no retry.
2. That registration races File Transformation's own startup init (module load, Harmony patching, DI registration) — Jellyfin gives no ordering guarantee between two plugins' independent startup tasks, so if File Transformation hasn't finished yet, `RegisterTransformation` throws. The only log output was `TargetInvocationException`'s generic message ("Exception has been thrown by the target of an invocation"), which hid the real `InnerException` and made this undiagnosable without manually raising the log level.

## What this PR does

- `SidebarInjectionTask.ExecuteAsync` now retries the registration attempt up to `MaxAttempts` (3) times, 2 seconds apart, before giving up.
- On failure, unwraps `TargetInvocationException.InnerException` so the log shows the real cause instead of reflection's boilerplate wrapper message.
- Added `RegisterAttemptOverride` / `DelayOverride` test-only injection points (mirrors the existing `SeerrClientFactoryOverride` pattern elsewhere in this codebase) so the retry loop is unit-testable without a real File Transformation assembly loaded or real `Task.Delay` waits.
- Deliberately did NOT touch `RegisterWithFileTransformation`'s actual reflection logic — the race is on File Transformation's side of the handshake, not a bug in what we're sending it, so retrying is the right fix rather than trying to out-guess its internals.

## How to test

- `dotnet test -c Release --filter "FullyQualifiedName~SidebarInjection"` — 8/8 passing, including new coverage for: succeeds first try (no retry), fails then recovers, exhausts all attempts then logs a warning, and unwraps a `TargetInvocationException` to its real inner exception.
- Full suite: `dotnet test -c Release --filter "Category!=Integration"` — 809/809 passing.
- Manual: deployed 2.1.1.0 to a real Jellyfin instance and observed the exact race this PR fixes (2 failed registrations in a row, 3rd succeeded) before writing the fix.

## Follow-ups (not in this PR)

- We never captured the actual production `InnerException` (both failures observed pre-fix only logged the generic wrapper, and the debug-level fix wasn't deployed before the race happened to resolve on its own). If it fails again post-deploy, the unwrapped exception should finally reveal what File Transformation is doing at that point in its init.
- Worth filing upstream against File Transformation if the same InnerException recurs — dependent plugins racing its startup is presumably not unique to this one.