### PR TITLE
feat: pre-fill review modal stars from the stored Jellyfin rating with half-star support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Deploy a debug build to the local Jellyfin server: `./deploy.sh` (scp's `Jellysc
 ### Plugin surface
 
 - `Plugin.cs` + `ServiceRegistrator.cs` register services and config.
-- `Api/LetterboxdController.cs` and `Api/SidebarController.cs` expose REST endpoints consumed by the config dashboard.
+- `Api/LetterboxdController.cs` and `Api/SidebarController.cs` expose REST endpoints consumed by the config dashboard. `LetterboxdController` also serves the read-only `ItemRating` endpoint the review modal uses to pre-fill its stars from the caller's stored Jellyfin rating.
 - `Web/*.html` and `Web/*.js` are embedded resources (see `LetterboxdSync.csproj`) served as the plugin's config pages.
 - `SidebarInjection.cs` registers a transformation with the File Transformation plugin to inject the sidebar link.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>1.20.0.0</Version>
-        <AssemblyVersion>2.1.2.0</AssemblyVersion>
-        <FileVersion>2.1.2.0</FileVersion>
+        <AssemblyVersion>2.2.0.0</AssemblyVersion>
+        <FileVersion>2.2.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/ItemRatingApiTests.cs
+++ b/LetterboxdSync.Tests/ItemRatingApiTests.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
+using LetterboxdSync.Serializd;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace LetterboxdSync.Tests;
+
+/// <summary>
+/// Tests for GET ItemRating: the review modal's pre-fill source. The endpoint
+/// must always answer 200 with null fields for anything it can't resolve, so
+/// the modal never breaks on the lookup; only a missing user identity is an error.
+/// </summary>
+[Collection("Plugin")]
+public class ItemRatingApiTests : System.IDisposable
+{
+
+    public void Dispose()
+    {
+        // The episode tests override the shared series-TMDb reader; restore the
+        // production default so an override can't leak into other test classes.
+        SerializdSyncRunner.SeriesTmdbIdReader = SerializdSyncRunner.ReadSeriesTmdbId;
+    }
+
+    private static (double? Rating, double? Stars) ReadPayload(ActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var t = ok.Value!.GetType();
+        var rating = (double?)t.GetProperty("rating", BindingFlags.Public | BindingFlags.Instance)!.GetValue(ok.Value);
+        var stars = (double?)t.GetProperty("stars", BindingFlags.Public | BindingFlags.Instance)!.GetValue(ok.Value);
+        return (rating, stars);
+    }
+
+    /// <summary>
+    /// ControllerTestHarness.SetUsers can't proxy the concrete User class, so we
+    /// build a real User (same pattern as LetterboxdControllerTests) and derive
+    /// the harness's currentUserId from its generated Id.
+    /// </summary>
+    private static (ControllerTestHarness Harness, User User) MakeHarness()
+    {
+        var user = new User("lachlan", "test-provider-id", "test-reset-id");
+        var h = new ControllerTestHarness(currentUserId: user.Id.ToString("N"));
+        h.UserManager.GetUsers().Returns(new List<User> { user });
+        return (h, user);
+    }
+
+    [Fact]
+    public void RatedMovie_ReturnsRatingAndHalfStars()
+    {
+        var (h, user) = MakeHarness();
+        using var _ = h;
+        var movie = MakeMovie(603);
+        AddItem(h, movie);
+        h.UserDataManager.GetUserData(user, movie).Returns(new UserItemData { Key = "k", Rating = 7 });
+
+        var (rating, stars) = ReadPayload(h.Controller.GetItemRating(tmdbId: 603));
+
+        Assert.Equal(7, rating);
+        Assert.Equal(3.5, stars);
+    }
+
+    [Fact]
+    public void UnratedMovie_ReturnsNulls()
+    {
+        var (h, user) = MakeHarness();
+        using var _ = h;
+        var movie = MakeMovie(603);
+        AddItem(h, movie);
+        h.UserDataManager.GetUserData(user, movie).Returns(new UserItemData { Key = "k" });
+
+        var (rating, stars) = ReadPayload(h.Controller.GetItemRating(tmdbId: 603));
+
+        Assert.Null(rating);
+        Assert.Null(stars);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void MissingOrNonPositiveTmdbId_ReturnsNulls(int? tmdbId)
+    {
+        var (h, _) = MakeHarness();
+        using var __ = h;
+
+        var (rating, stars) = ReadPayload(h.Controller.GetItemRating(tmdbId: tmdbId));
+
+        Assert.Null(rating);
+        Assert.Null(stars);
+    }
+
+    [Fact]
+    public void UnknownTmdbId_ReturnsNulls()
+    {
+        var (h, _) = MakeHarness();
+        using var __ = h;
+        AddItem(h, MakeMovie(603));
+
+        var (rating, stars) = ReadPayload(h.Controller.GetItemRating(tmdbId: 550));
+
+        Assert.Null(rating);
+        Assert.Null(stars);
+    }
+
+    [Fact]
+    public void EpisodeRating_ResolvedBySeriesTmdbAndNumbers()
+    {
+        var (h, user) = MakeHarness();
+        using var _ = h;
+        var episode = new Episode { Name = "Ozymandias", ParentIndexNumber = 5, IndexNumber = 14, Id = System.Guid.NewGuid() };
+        AddItem(h, episode);
+        SerializdSyncRunner.SeriesTmdbIdReader = _ => 1396;
+        h.UserDataManager.GetUserData(user, episode).Returns(new UserItemData { Key = "k", Rating = 8 });
+
+        var (rating, stars) = ReadPayload(
+            h.Controller.GetItemRating(tmdbId: 1396, isShow: true, seasonNumber: 5, episodeNumber: 14));
+
+        Assert.Equal(8, rating);
+        Assert.Equal(4, stars);
+    }
+
+    [Fact]
+    public void ShowLevelRating_ResolvedFromSeries()
+    {
+        var (h, user) = MakeHarness();
+        using var _ = h;
+        var series = MakeSeries(1396);
+        AddItem(h, series);
+        h.UserDataManager.GetUserData(user, series).Returns(new UserItemData { Key = "k", Rating = 9 });
+
+        var (rating, stars) = ReadPayload(h.Controller.GetItemRating(tmdbId: 1396, isShow: true));
+
+        Assert.Equal(9, rating);
+        Assert.Equal(4.5, stars);
+    }
+
+    [Fact]
+    public void EpisodeRequested_ButOnlySeriesRated_ReturnsNulls()
+    {
+        var (h, user) = MakeHarness();
+        using var _ = h;
+        var series = MakeSeries(1396);
+        var episode = new Episode { Name = "Pilot", ParentIndexNumber = 1, IndexNumber = 1, Id = System.Guid.NewGuid() };
+        AddItem(h, series);
+        AddItem(h, episode);
+        SerializdSyncRunner.SeriesTmdbIdReader = _ => 1396;
+        h.UserDataManager.GetUserData(user, series).Returns(new UserItemData { Key = "k", Rating = 9 });
+
+        var (rating, stars) = ReadPayload(
+            h.Controller.GetItemRating(tmdbId: 1396, isShow: true, seasonNumber: 1, episodeNumber: 1));
+
+        Assert.Null(rating);
+        Assert.Null(stars);
+    }
+
+    [Fact]
+    public void NoUserIdentity_IsRejected()
+    {
+        using var h = new ControllerTestHarness(currentUserId: null);
+
+        var result = h.Controller.GetItemRating(tmdbId: 603);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    private static Movie MakeMovie(int tmdbId, string name = "Sinners")
+    {
+        var movie = new Movie { Name = name, Id = System.Guid.NewGuid() };
+        movie.SetProviderId(MetadataProvider.Tmdb, tmdbId.ToString());
+        return movie;
+    }
+
+    private static Series MakeSeries(int tmdbId, string name = "Breaking Bad")
+    {
+        var series = new Series { Name = name, Id = System.Guid.NewGuid() };
+        series.SetProviderId(MetadataProvider.Tmdb, tmdbId.ToString());
+        return series;
+    }
+
+    /// <summary>
+    /// Appends an arbitrary BaseItem to the harness's mocked library list.
+    /// (ControllerTestHarness.AddMovie substitutes Movie and stubs GetProviderId,
+    /// which NSubstitute can't intercept; real entities avoid that.)
+    /// </summary>
+    private static void AddItem(ControllerTestHarness h, BaseItem item)
+    {
+        var existing = System.Linq.Enumerable.ToList(
+            System.Linq.Enumerable.Cast<BaseItem>(
+                h.LibraryManager.GetItemList(Arg.Any<InternalItemsQuery>())));
+        existing.Add(item);
+        h.LibraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(existing);
+    }
+}

--- a/LetterboxdSync/Api/LetterboxdController.cs
+++ b/LetterboxdSync/Api/LetterboxdController.cs
@@ -6,6 +6,7 @@ using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
 using LetterboxdSync.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -772,6 +773,96 @@ public class LetterboxdController : JellyfinUserApiController
     }
 
     /// <summary>
+    /// Returns the calling user's stored Jellyfin rating for an item, both raw
+    /// (1-10) and mapped to Letterboxd half-stars, so the review modal can
+    /// pre-fill its star widget. Movies resolve by TMDb id; TV resolves the
+    /// series by TMDb id, or a single episode when season and episode numbers
+    /// are supplied (matching how Serializd sync sources episode vs show
+    /// ratings). Always 200 with null fields when the item or rating is absent:
+    /// the pre-fill fetch must never surface an error in the modal.
+    /// </summary>
+    [HttpGet("ItemRating")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult GetItemRating(
+        [FromQuery] int? tmdbId = null,
+        [FromQuery] bool isShow = false,
+        [FromQuery] int? seasonNumber = null,
+        [FromQuery] int? episodeNumber = null)
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return BadRequest(new { error = "Could not determine user" });
+
+        var none = Ok(new { rating = (double?)null, stars = (double?)null });
+        if (!tmdbId.HasValue || tmdbId.Value <= 0)
+            return none;
+
+        var user = _userManager.GetUsers().FirstOrDefault(u => u.Id.ToString("N") == userId);
+        if (user == null)
+            return none;
+
+        BaseItem? item;
+        if (!isShow)
+            item = FindMovieByTmdbId(user, tmdbId.Value);
+        else if (seasonNumber.HasValue && episodeNumber.HasValue)
+            item = FindEpisodeByTmdbId(user, tmdbId.Value, seasonNumber.Value, episodeNumber.Value);
+        else
+            item = FindSeriesByTmdbId(user, tmdbId.Value);
+
+        if (item == null)
+            return none;
+
+        var stored = _userDataManager.GetUserData(user, item)?.Rating;
+        if (!stored.HasValue || stored.Value <= 0)
+            return none;
+
+        return Ok(new { rating = (double?)stored.Value, stars = Helpers.MapRating(stored.Value) });
+    }
+
+    /// <summary>
+    /// Resolve a library movie by TMDb id for the given user. Shared by the
+    /// rating writeback and the ItemRating read path so the two cannot drift.
+    /// </summary>
+    private BaseItem? FindMovieByTmdbId(User user, int tmdbId)
+    {
+        return _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Movie },
+            IsVirtualItem = false,
+            Recursive = true
+        }).FirstOrDefault(m => m.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tmdb) == tmdbId.ToString());
+    }
+
+    private BaseItem? FindSeriesByTmdbId(User user, int tmdbId)
+    {
+        return _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Series },
+            IsVirtualItem = false,
+            Recursive = true
+        }).FirstOrDefault(s => s.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tmdb) == tmdbId.ToString());
+    }
+
+    /// <summary>
+    /// Resolve an episode by series TMDb id + season/episode number. The series
+    /// TMDb id lives on the parent Series entity; SeriesTmdbIdReader is the one
+    /// place that knows that, shared with Serializd sync.
+    /// </summary>
+    private BaseItem? FindEpisodeByTmdbId(User user, int seriesTmdbId, int seasonNumber, int episodeNumber)
+    {
+        return _libraryManager.GetItemList(new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Episode },
+            IsVirtualItem = false,
+            Recursive = true
+        }).OfType<MediaBrowser.Controller.Entities.TV.Episode>()
+          .FirstOrDefault(ep => Serializd.SerializdSyncRunner.SeriesTmdbIdReader(ep) == seriesTmdbId
+              && ep.ParentIndexNumber == seasonNumber
+              && ep.IndexNumber == episodeNumber);
+    }
+
+    /// <summary>
     /// Mirror the dashboard review's star rating into Jellyfin's UserItemData.Rating
     /// so it survives plugin uninstall and is visible to other clients/plugins.
     /// Always overwrites: posting a review is the user's latest input, so it wins.
@@ -790,12 +881,7 @@ public class LetterboxdController : JellyfinUserApiController
         if (user == null)
             return;
 
-        var movie = _libraryManager.GetItemList(new InternalItemsQuery(user)
-        {
-            IncludeItemTypes = new[] { BaseItemKind.Movie },
-            IsVirtualItem = false,
-            Recursive = true
-        }).FirstOrDefault(m => m.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tmdb) == tmdbId.Value.ToString());
+        var movie = FindMovieByTmdbId(user, tmdbId.Value);
 
         if (movie == null)
         {

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>2.1.2.0</AssemblyVersion>
-    <FileVersion>2.1.2.0</FileVersion>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/Web/configPage.html
+++ b/LetterboxdSync/Web/configPage.html
@@ -165,8 +165,10 @@
                 #letterboxdSyncConfigPage .ws-modal-x { position: absolute; top: 12px; right: 14px; width: 32px; height: 32px; border-radius: 8px; border: 1px solid var(--ws-border); background: var(--ws-surface-2); color: var(--ws-muted); font-size: 21px; line-height: 1; cursor: pointer; display: grid; place-items: center; z-index: 2; }
                 #letterboxdSyncConfigPage .ws-modal-x:hover { color: var(--ws-text); border-color: var(--ws-faint); }
                 #letterboxdSyncConfigPage .ws-row { margin-bottom: 12px; }
-                #letterboxdSyncConfigPage .ws-star { cursor: pointer; font-size: 1.6em; user-select: none; color: var(--ws-faint); }
-                #letterboxdSyncConfigPage .ws-star.filled { color: var(--ws-warn); }
+                #letterboxdSyncConfigPage .ws-star { cursor: pointer; font-size: 1.6em; user-select: none; color: var(--ws-faint); position: relative; display: inline-block; }
+                #letterboxdSyncConfigPage .ws-star .ws-star-on { position: absolute; left: 0; top: 0; width: 0; overflow: hidden; color: var(--ws-warn); pointer-events: none; }
+                #letterboxdSyncConfigPage .ws-star.filled .ws-star-on { width: 100%; }
+                #letterboxdSyncConfigPage .ws-star.half .ws-star-on { width: 50%; }
                 #letterboxdSyncConfigPage .ws-muted { color: var(--ws-muted); }
                 #letterboxdSyncConfigPage .ws-green { color: var(--ws-ok); } #letterboxdSyncConfigPage .ws-red { color: var(--ws-crit); }
                 #letterboxdSyncConfigPage .ws-logs { font-family: var(--ws-mono); font-size: 12px; line-height: 1.6; color: var(--ws-muted); white-space: pre-wrap; word-break: break-word; padding: 16px; max-height: 60vh; overflow: auto; }
@@ -365,7 +367,7 @@
                     <h3 id="reviewTitle">Write review</h3>
                     <textarea id="reviewText" rows="4" class="ws-input" placeholder="Write your review…"></textarea>
                     <div class="ws-row" style="margin-top:12px;"><label class="ws-field">Rating</label><div id="starRating">
-                        <span class="ws-star" data-val="1">&#9734;</span><span class="ws-star" data-val="2">&#9734;</span><span class="ws-star" data-val="3">&#9734;</span><span class="ws-star" data-val="4">&#9734;</span><span class="ws-star" data-val="5">&#9734;</span>
+                        <span class="ws-star" data-val="1">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="2">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="3">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="4">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="5">&#9734;<span class="ws-star-on">&#9733;</span></span>
                         <span id="ratingLabel" class="ws-muted" style="margin-left:8px;font-size:12px;">No rating</span></div>
                         <input type="hidden" id="reviewRating" value="" /></div>
                     <label class="ws-muted" style="display:block;margin:8px 0;font-size:12.5px;"><input type="checkbox" id="reviewSpoilers" /> Contains spoilers</label>
@@ -492,14 +494,10 @@
                             document.getElementById('sendLogsCancel').addEventListener('click', function () { document.getElementById('sendLogsBox').style.display = 'none'; });
                             document.getElementById('sendLogsConfirm').addEventListener('click', function () { self.sendLogs(); });
                             document.querySelectorAll('#starRating .ws-star').forEach(function (star) {
-                                star.addEventListener('click', function () {
+                                star.addEventListener('click', function (e) {
                                     var val = parseFloat(this.getAttribute('data-val'));
-                                    document.getElementById('reviewRating').value = val;
-                                    document.getElementById('ratingLabel').textContent = val + ' / 5';
-                                    document.querySelectorAll('#starRating .ws-star').forEach(function (s) {
-                                        var sv = parseFloat(s.getAttribute('data-val'));
-                                        s.classList.toggle('filled', sv <= val); s.innerHTML = sv <= val ? '&#9733;' : '&#9734;';
-                                    });
+                                    if (e.offsetX < this.offsetWidth / 2) val -= 0.5;
+                                    self.paintStars(val);
                                 });
                             });
                         },
@@ -836,6 +834,18 @@
                         },
 
                         /* ===== Review ===== */
+                        /* Paint the star widget to a 0.5-step value (null/0 clears). Single
+                           writer for reviewRating and ratingLabel so click, reset, and
+                           pre-fill can't disagree. */
+                        paintStars: function (val) {
+                            document.getElementById('reviewRating').value = val || '';
+                            document.getElementById('ratingLabel').textContent = val ? val + ' / 5' : 'No rating';
+                            document.querySelectorAll('#starRating .ws-star').forEach(function (s) {
+                                var sv = parseFloat(s.getAttribute('data-val'));
+                                s.classList.toggle('filled', !!val && sv <= val);
+                                s.classList.toggle('half', !!val && sv - 0.5 === val);
+                            });
+                        },
                         openReview: function (svc, tmdbId, title, slug, season, episode) {
                             this.reviewSvc = svc; this.reviewTmdb = tmdbId; this.reviewSlug = slug || '';
                             this.reviewTitleText = title || '';
@@ -848,15 +858,32 @@
                             document.getElementById('reviewRewatch').checked = false;
                             document.getElementById('rewatchDateRow').style.display = 'none';
                             document.getElementById('reviewDate').value = new Date().toISOString().split('T')[0];
-                            document.getElementById('reviewRating').value = '';
-                            document.getElementById('ratingLabel').textContent = 'No rating';
-                            document.querySelectorAll('#starRating .ws-star').forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
+                            this.paintStars(null);
                             document.getElementById('reviewStatus').textContent = '';
                             var isLetterboxd = svc !== 'serializd';
                             document.getElementById('reviewRewatchRow').style.display = isLetterboxd ? '' : 'none';
                             document.getElementById('reviewAccountRow').style.display = 'none';
                             if (isLetterboxd) this.populateReviewAccountDropdown();
                             document.getElementById('reviewModal').classList.add('show');
+                            this.prefillRating(svc, tmdbId);
+                        },
+                        /* Pre-fill the stars from the rating already stored in Jellyfin.
+                           Fail-soft by design: any error or null response just leaves
+                           "No rating", so the modal never blocks on this lookup. The
+                           sequence token discards a late response if another item's
+                           modal was opened in the meantime. */
+                        prefillRating: function (svc, tmdbId) {
+                            this.reviewOpenSeq = (this.reviewOpenSeq || 0) + 1;
+                            var seq = this.reviewOpenSeq, self = this;
+                            if (!tmdbId) return;
+                            var q = 'Jellyfin.Plugin.LetterboxdSync/ItemRating?tmdbId=' + tmdbId;
+                            if (svc === 'serializd') {
+                                q += '&isShow=true';
+                                if (this.reviewSeason && this.reviewEpisode) q += '&seasonNumber=' + this.reviewSeason + '&episodeNumber=' + this.reviewEpisode;
+                            }
+                            ApiClient.getJSON(ApiClient.getUrl(q)).then(function (d) {
+                                if (seq === self.reviewOpenSeq && d && d.stars) self.paintStars(d.stars);
+                            }).catch(function () { });
                         },
                         // Show the "Post as" row only when the current Jellyfin user has more than
                         // one enabled Letterboxd account. Leaving the empty first option selected

--- a/LetterboxdSync/Web/userPage.html
+++ b/LetterboxdSync/Web/userPage.html
@@ -154,8 +154,10 @@
                 #letterboxdUserPage .ws-modal-x { position: absolute; top: 12px; right: 14px; width: 32px; height: 32px; border-radius: 8px; border: 1px solid var(--ws-border); background: var(--ws-surface-2); color: var(--ws-muted); font-size: 21px; line-height: 1; cursor: pointer; display: grid; place-items: center; z-index: 2; }
                 #letterboxdUserPage .ws-modal-x:hover { color: var(--ws-text); border-color: var(--ws-faint); }
                 #letterboxdUserPage .ws-row { margin-bottom: 12px; }
-                #letterboxdUserPage .ws-star { cursor: pointer; font-size: 1.6em; user-select: none; color: var(--ws-faint); }
-                #letterboxdUserPage .ws-star.filled { color: var(--ws-warn); }
+                #letterboxdUserPage .ws-star { cursor: pointer; font-size: 1.6em; user-select: none; color: var(--ws-faint); position: relative; display: inline-block; }
+                #letterboxdUserPage .ws-star .ws-star-on { position: absolute; left: 0; top: 0; width: 0; overflow: hidden; color: var(--ws-warn); pointer-events: none; }
+                #letterboxdUserPage .ws-star.filled .ws-star-on { width: 100%; }
+                #letterboxdUserPage .ws-star.half .ws-star-on { width: 50%; }
                 #letterboxdUserPage .ws-muted { color: var(--ws-muted); } #letterboxdUserPage .ws-green { color: var(--ws-ok); } #letterboxdUserPage .ws-red { color: var(--ws-crit); }
                 #letterboxdUserPage a.ws-link { color: var(--ws-primary); }
                 @media (max-width: 820px) {
@@ -282,7 +284,7 @@
                     <button type="button" class="ws-modal-x" aria-label="Close">&times;</button>
                     <h3 id="reviewTitle">Write review</h3>
                     <textarea id="reviewText" rows="4" class="ws-input" placeholder="Write your review…"></textarea>
-                    <div class="ws-row" style="margin-top:12px;"><label class="ws-field">Rating</label><div id="starRating"><span class="ws-star" data-val="1">&#9734;</span><span class="ws-star" data-val="2">&#9734;</span><span class="ws-star" data-val="3">&#9734;</span><span class="ws-star" data-val="4">&#9734;</span><span class="ws-star" data-val="5">&#9734;</span><span id="ratingLabel" class="ws-muted" style="margin-left:8px;font-size:12px;">No rating</span></div><input type="hidden" id="reviewRating" value="" /></div>
+                    <div class="ws-row" style="margin-top:12px;"><label class="ws-field">Rating</label><div id="starRating"><span class="ws-star" data-val="1">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="2">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="3">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="4">&#9734;<span class="ws-star-on">&#9733;</span></span><span class="ws-star" data-val="5">&#9734;<span class="ws-star-on">&#9733;</span></span><span id="ratingLabel" class="ws-muted" style="margin-left:8px;font-size:12px;">No rating</span></div><input type="hidden" id="reviewRating" value="" /></div>
                     <label class="ws-muted" style="display:block;margin:8px 0;font-size:12.5px;"><input type="checkbox" id="reviewSpoilers" /> Contains spoilers</label>
                     <label class="ws-muted" id="reviewRewatchRow" style="display:block;margin:8px 0;font-size:12.5px;"><input type="checkbox" id="reviewRewatch" /> This is a rewatch</label>
                     <div id="rewatchDateRow" style="display:none;margin:8px 0;">
@@ -350,7 +352,13 @@
                             ['acctModal', 'reviewModal'].forEach(function (id) { document.getElementById(id).addEventListener('click', function (e) { if (e.target === this) this.classList.remove('show'); }); });
                             document.querySelectorAll('.ws-modal-x').forEach(function (x) { x.addEventListener('click', function () { var ov = this.closest('.ws-modal-ov'); if (ov) ov.classList.remove('show'); }); });
                             document.addEventListener('keydown', function (e) { if (e.key === 'Escape') document.querySelectorAll('.ws-modal-ov.show').forEach(function (m) { m.classList.remove('show'); }); });
-                            document.querySelectorAll('#starRating .ws-star').forEach(function (star) { star.addEventListener('click', function () { var val = parseFloat(this.getAttribute('data-val')); document.getElementById('reviewRating').value = val; document.getElementById('ratingLabel').textContent = val + ' / 5'; document.querySelectorAll('#starRating .ws-star').forEach(function (s) { var sv = parseFloat(s.getAttribute('data-val')); s.classList.toggle('filled', sv <= val); s.innerHTML = sv <= val ? '&#9733;' : '&#9734;'; }); }); });
+                            document.querySelectorAll('#starRating .ws-star').forEach(function (star) {
+                                star.addEventListener('click', function (e) {
+                                    var val = parseFloat(this.getAttribute('data-val'));
+                                    if (e.offsetX < this.offsetWidth / 2) val -= 0.5;
+                                    self.paintStars(val);
+                                });
+                            });
                         },
 
                         loadOverview: function () {
@@ -599,6 +607,18 @@
                             this.post('Jellyfin.Plugin.LetterboxdSync/Serializd/Verify', { email: email, password: pw }).then(function (r) { if (r.ok) { r.json().then(function (d) { st.innerHTML = '<span class="ws-green">Login OK' + (d.username ? ' (' + d.username + ')' : '') + '.</span>'; }); } else { st.innerHTML = '<span class="ws-red">Login failed.</span>'; } });
                         },
 
+                        /* Paint the star widget to a 0.5-step value (null/0 clears). Single
+                           writer for reviewRating and ratingLabel so click, reset, and
+                           pre-fill can't disagree. */
+                        paintStars: function (val) {
+                            document.getElementById('reviewRating').value = val || '';
+                            document.getElementById('ratingLabel').textContent = val ? val + ' / 5' : 'No rating';
+                            document.querySelectorAll('#starRating .ws-star').forEach(function (s) {
+                                var sv = parseFloat(s.getAttribute('data-val'));
+                                s.classList.toggle('filled', !!val && sv <= val);
+                                s.classList.toggle('half', !!val && sv - 0.5 === val);
+                            });
+                        },
                         openReview: function (svc, tmdbId, title, slug, season, episode) {
                             this.reviewSvc = svc; this.reviewTmdb = tmdbId; this.reviewSlug = slug || '';
                             this.reviewTitleText = title || '';
@@ -610,14 +630,32 @@
                             document.getElementById('reviewRewatch').checked = false;
                             document.getElementById('rewatchDateRow').style.display = 'none';
                             document.getElementById('reviewDate').value = new Date().toISOString().split('T')[0];
-                            document.getElementById('reviewRating').value = ''; document.getElementById('ratingLabel').textContent = 'No rating';
-                            document.querySelectorAll('#starRating .ws-star').forEach(function (s) { s.classList.remove('filled'); s.innerHTML = '&#9734;'; });
+                            this.paintStars(null);
                             document.getElementById('reviewStatus').textContent = '';
                             var isLetterboxd = svc !== 'serializd';
                             document.getElementById('reviewRewatchRow').style.display = isLetterboxd ? '' : 'none';
                             document.getElementById('reviewAccountRow').style.display = 'none';
                             if (isLetterboxd) this.populateReviewAccountDropdown();
                             document.getElementById('reviewModal').classList.add('show');
+                            this.prefillRating(svc, tmdbId);
+                        },
+                        /* Pre-fill the stars from the rating already stored in Jellyfin.
+                           Fail-soft by design: any error or null response just leaves
+                           "No rating", so the modal never blocks on this lookup. The
+                           sequence token discards a late response if another item's
+                           modal was opened in the meantime. */
+                        prefillRating: function (svc, tmdbId) {
+                            this.reviewOpenSeq = (this.reviewOpenSeq || 0) + 1;
+                            var seq = this.reviewOpenSeq, self = this;
+                            if (!tmdbId) return;
+                            var q = 'Jellyfin.Plugin.LetterboxdSync/ItemRating?tmdbId=' + tmdbId;
+                            if (svc === 'serializd') {
+                                q += '&isShow=true';
+                                if (this.reviewSeason && this.reviewEpisode) q += '&seasonNumber=' + this.reviewSeason + '&episodeNumber=' + this.reviewEpisode;
+                            }
+                            this.get(q).then(function (r) { return r.json(); }).then(function (d) {
+                                if (seq === self.reviewOpenSeq && d && d.stars) self.paintStars(d.stars);
+                            }).catch(function () { });
                         },
                         // Uses the accounts already loaded by loadAccounts (self-service; the
                         // /Accounts endpoint only ever returns the calling user's own accounts),

--- a/openspec/changes/prefill-review-rating/.openspec.yaml
+++ b/openspec/changes/prefill-review-rating/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/prefill-review-rating/design.md
+++ b/openspec/changes/prefill-review-rating/design.md
@@ -1,0 +1,49 @@
+# Design: prefill-review-rating
+
+## Context
+
+The review modal (dashboard `configPage.html` and self-service `userPage.html`, duplicated embedded resources) opens via `openReview(svc, tmdbId, title, slug, season, episode)` and hard-resets the star widget to "No rating". Jellyfin already stores per-user ratings in `UserItemData.Rating` (1–10 scale), which the plugin both reads (diary sync, Serializd sync) and writes (`WriteJellyfinRating` after a modal post, `DiaryImportTask` on import). The modal is the only rating surface that ignores it. `Helpers.MapRating` already converts 1–10 to Letterboxd half-stars (0.5–5.0) with tests. Review posts run as the current Jellyfin user (`GetCurrentUserId()`), so there is exactly one user whose rating is relevant.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Modal opens showing the current user's existing Jellyfin rating when one exists.
+- Star widget supports half-star selection and display (0.5–5.0), removing the whole-star limitation for both pre-fill display and manual entry.
+- Read path and write path resolve library items with the same logic.
+
+**Non-Goals:**
+- Updating already-posted Letterboxd diary entries when a rating arrives later (own change; needs `UserDataSaved` subscription and new `ILetterboxdService` surface).
+- Pre-filling review text, rewatch state, or favorite/like.
+- Any change to sync/import behavior.
+
+## Decisions
+
+**1. One read-only endpoint on `LetterboxdController`, serving both movie and TV paths.**
+`GET Jellyfin.Plugin.LetterboxdSync/ItemRating?tmdbId=&seasonNumber=&episodeNumber=` → `{ "rating": 1–10|null, "stars": 0.5–5.0|null }`. `stars` is `Helpers.MapRating(rating)`. The controller already has `_userDataManager`, `_libraryManager`, and the current-user resolution used by the review POST; adding a sibling endpoint keeps auth and user semantics identical. *Alternative considered*: embedding the rating in the activity-list payload the modal is opened from — rejected because activity entries are rendered long before the modal opens (stale on rate-in-between) and slug-only Letterboxd entries have no rating source anyway.
+
+**2. Resolution rules mirror the existing writers.**
+Movies: same TMDb provider-ID query as `WriteJellyfinRating`, extracted into a shared private helper so read and write cannot drift. TV: series located by TMDb provider ID (as `SerializdSyncRunner` does); with `seasonNumber`+`episodeNumber` present, the episode's own `UserData.Rating` is returned, otherwise the series-level rating — matching how Serializd sync sources episode vs show ratings today. `tmdbId <= 0` returns `rating: null` without touching the library (slug-only history entries).
+
+**3. Half-star widget via left/right click zones on each star, rendered with a clipped overlay.**
+Clicking the left half of star *n* selects *n − 0.5*, the right half selects *n*; rendering uses a CSS-clipped filled-star overlay for the half state (no images, no external assets — pages are self-contained embedded resources). *Alternative considered*: doubling to ten thin stars — rejected as visually noisy and a bigger diff to two duplicated pages. Pre-filled values land on half-star boundaries by construction (`MapRating` rounds to nearest 0.5).
+
+**4. Pre-fill is async and fail-soft.**
+`openReview` still resets synchronously and opens the modal immediately; the fetch then paints stars only on a successful response with a non-null `stars`. Any error (endpoint missing, item not in library, no rating) leaves "No rating" — identical to today's behavior, so the modal never blocks or breaks on the lookup.
+
+**5. Serializd payload keeps its existing `rating * 2` conversion.**
+With half stars, Serializd reviews can now express the full 1–10 range (3.5 stars → 7). No scale changes on either service payload; Letterboxd already accepts half values.
+
+## Risks / Trade-offs
+
+- [Duplicated JS in `configPage.html` and `userPage.html` can drift] → Keep the widget + pre-fill block byte-identical between the two pages; task list calls out both files explicitly, as every prior modal change has.
+- [Half-star click zones depend on pointer `offsetX`; coarse on touch] → Zones are half a star wide (~12px+), same precision Letterboxd's own mobile widget requires; worst case a tap selects the adjacent half step, still correctable by tapping again.
+- [Endpoint returns data for the current user only; admin dashboard shows *other* users' activity] → Accepted: pre-fill reflects the person posting the review, which is also whose rating the writeback would overwrite — consistent semantics with the existing POST.
+- [Series-level rating shown when reviewing a show could surprise users who only rated episodes] → Matches Serializd sync semantics already shipped; documented in spec scenarios.
+
+## Migration Plan
+
+Purely additive endpoint + frontend change; no config or data migration. Rollback is a normal release revert. Old clients (cached pages) simply never call the new endpoint.
+
+## Open Questions
+
+None blocking. (Whether Infuse writes numeric ratings into Jellyfin is a client-side question tracked with the user report; it does not change this design, which works for any client that populates `UserItemData.Rating`.)

--- a/openspec/changes/prefill-review-rating/proposal.md
+++ b/openspec/changes/prefill-review-rating/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: prefill-review-rating
+
+## Why
+
+A user report (Kostadamus, Jellyfin + Infuse setup) surfaced that ratings already stored in Jellyfin never appear in the review modal: the star widget always opens at "No rating", so users re-enter ratings the server already knows, or post reviews without them. Rating flow is currently one-way (modal → Jellyfin via the writeback in `LetterboxdController`); the modal never reads back. The widget is also whole-stars only, which cannot represent Jellyfin's 1–10 scale (7/10 = 3.5 stars) even though Letterboxd itself supports half stars. No GitHub issue exists yet for this report.
+
+## What Changes
+
+- New authenticated GET endpoint on the plugin API that returns the **current Jellyfin user's** stored rating (`UserItemData.Rating`, 1–10) and favorite flag for an item, resolved by TMDb ID for movies and by TMDb ID + season/episode for the Serializd (TV) path.
+- The review modal in both `Web/configPage.html` and `Web/userPage.html` fetches that endpoint on open and pre-fills the star widget and label when a rating exists; the widget still resets to "No rating" when none exists or the lookup fails.
+- The star widget gains **half-star** granularity (0.5–5.0) so Jellyfin ratings map losslessly for display and Letterboxd posts can carry half stars, matching what Letterboxd accepts.
+- The TMDb-to-library-item lookup currently embedded in `WriteJellyfinRating` is extracted into a shared helper so the read and write paths use the same resolution logic.
+
+## Capabilities
+
+### New Capabilities
+
+- `review-rating-prefill`: Reading a Jellyfin user's stored rating for an item through the plugin API and presenting it as the starting state of the review modal, including half-star display and the movie/TV resolution rules.
+
+### Modified Capabilities
+
+<!-- none: sync behavior (letterboxd sync, serializd-sync) is unchanged; this only touches the review-modal surface and adds a read-only endpoint -->
+
+## Impact
+
+- `LetterboxdSync/Api/LetterboxdController.cs`: new GET endpoint; extract item-resolution helper out of `WriteJellyfinRating`.
+- `LetterboxdSync/Helpers.cs`: reuse `MapRating` (1–10 → half stars); no mapping changes expected.
+- `LetterboxdSync/Web/configPage.html` and `LetterboxdSync/Web/userPage.html`: `openReview` pre-fill fetch; star widget half-star rendering and click handling (code is duplicated across both embedded pages and must be changed in both).
+- `LetterboxdSync.Tests`: new controller tests (style of `RatedFilmsApiTests.cs`) and widget-mapping cases.
+- Review POST payloads may now contain half values (e.g. `3.5`); Letterboxd already accepts these, and the Serializd path already multiplies by 2 into its 1–10 scale.
+- Ships a release: version bump in `Directory.Build.props` + `LetterboxdSync/LetterboxdSync.csproj`, `## Release notes` PR section, `site/src/data/release-notes.ts` entry.
+
+## Non-goals
+
+- **Late-arriving ratings**: updating an already-synced Letterboxd diary entry when the user rates the film afterwards (e.g. in Infuse post-credits). Needs an `IUserDataManager.UserDataSaved` subscription and new `ILetterboxdService` surface in both API and scraping implementations; explicitly deferred to its own change.
+- No changes to the diary sync, playback handler, or import paths; they already read/write ratings.
+- No verification or workaround for whether Infuse itself writes numeric ratings to Jellyfin; that is a client-side question outside the plugin.

--- a/openspec/changes/prefill-review-rating/specs/review-rating-prefill/spec.md
+++ b/openspec/changes/prefill-review-rating/specs/review-rating-prefill/spec.md
@@ -1,0 +1,71 @@
+# review-rating-prefill
+
+## ADDED Requirements
+
+### Requirement: Item rating endpoint returns the current user's stored rating
+The plugin API SHALL expose an authenticated GET endpoint that returns the calling Jellyfin user's stored rating for an item, as both the raw Jellyfin value (`rating`, 1–10) and the Letterboxd half-star mapping (`stars`, 0.5–5.0 via the existing rating mapping). The endpoint SHALL resolve the rating for the authenticated user only, never for another user.
+
+#### Scenario: Movie with a stored rating
+- **WHEN** the endpoint is called with the TMDb ID of a movie in the library for which the current user has a Jellyfin rating of 7
+- **THEN** the response contains `rating: 7` and `stars: 3.5`
+
+#### Scenario: Movie without a stored rating
+- **WHEN** the endpoint is called with the TMDb ID of a library movie the current user has never rated
+- **THEN** the response contains `rating: null` and `stars: null`
+
+#### Scenario: Item not in the library or no TMDb ID supplied
+- **WHEN** the endpoint is called with a TMDb ID that matches no library item, or with a missing/non-positive TMDb ID
+- **THEN** the response contains `rating: null` and `stars: null` and does not error
+
+#### Scenario: Unauthenticated request
+- **WHEN** the endpoint is called without a valid Jellyfin session
+- **THEN** the request is rejected with an authentication error and no rating data is returned
+
+### Requirement: TV resolution distinguishes episode and show ratings
+For TV items the endpoint SHALL locate the series by TMDb provider ID. When season and episode numbers are supplied it SHALL return the rating stored on that episode; when they are absent it SHALL return the series-level rating. This mirrors how Serializd sync sources episode versus show ratings.
+
+#### Scenario: Episode rating requested
+- **WHEN** the endpoint is called with a series TMDb ID plus season and episode numbers, and the current user rated that episode 8
+- **THEN** the response contains `rating: 8` and `stars: 4`
+
+#### Scenario: Show-level rating requested
+- **WHEN** the endpoint is called with only a series TMDb ID and the current user rated the series 9
+- **THEN** the response contains `rating: 9` and `stars: 4.5`
+
+#### Scenario: Episode requested but only the series is rated
+- **WHEN** the endpoint is called with season and episode numbers for an episode the user has not rated, even though the series has a rating
+- **THEN** the response contains `rating: null` and `stars: null`
+
+### Requirement: Review modal pre-fills from the stored rating
+When the review modal opens, both the dashboard page and the user page SHALL fetch the item rating endpoint and, on a successful response with a non-null `stars` value, display that value in the star widget and rating label as the starting state. The user MUST be able to change or clear the pre-filled value before posting.
+
+#### Scenario: Modal opens for a rated film
+- **WHEN** a user opens the review modal for a film they rated 7/10 in Jellyfin
+- **THEN** the star widget shows 3.5 filled stars and the label reads "3.5 / 5" before any user input
+
+#### Scenario: Modal opens for an unrated film
+- **WHEN** a user opens the review modal for a film with no stored rating
+- **THEN** the widget shows "No rating", identical to current behavior
+
+#### Scenario: Rating lookup fails
+- **WHEN** the rating fetch errors or times out after the modal has opened
+- **THEN** the modal remains fully usable with the widget in the "No rating" state, and no error blocks posting
+
+#### Scenario: Pre-filled rating is posted unchanged
+- **WHEN** the user posts a review without touching the pre-filled stars
+- **THEN** the posted review carries the pre-filled rating value
+
+### Requirement: Star widget supports half-star selection
+The review modal star widget SHALL support values in 0.5 increments from 0.5 to 5.0, both when displaying a pre-filled rating and when the user selects a rating manually. Selecting the left half of a star SHALL choose that star's value minus 0.5; the right half SHALL choose the whole value. The widget SHALL be identical in both embedded pages.
+
+#### Scenario: Half-star manual selection
+- **WHEN** the user clicks the left half of the fourth star
+- **THEN** the widget shows 3.5 stars and the label reads "3.5 / 5"
+
+#### Scenario: Half-star value sent to Letterboxd
+- **WHEN** the user posts a Letterboxd review with 3.5 stars
+- **THEN** the review payload carries the rating 3.5
+
+#### Scenario: Half-star value sent to Serializd
+- **WHEN** the user posts a Serializd review with 3.5 stars
+- **THEN** the review payload carries the rating 7 on Serializd's 1–10 scale

--- a/openspec/changes/prefill-review-rating/tasks.md
+++ b/openspec/changes/prefill-review-rating/tasks.md
@@ -5,18 +5,18 @@
 - [x] 1.1 Extract the TMDb-ID → library-movie lookup from `WriteJellyfinRating` in `Api/LetterboxdController.cs` into a shared private helper used by both the writeback and the new read path
 - [x] 1.2 Add TV resolution helpers: series by TMDb provider ID, and episode by series + season/episode index, mirroring `SerializdSyncRunner`'s sourcing of episode vs show ratings
 - [x] 1.3 Add `GET Jellyfin.Plugin.LetterboxdSync/ItemRating` (authenticated, current user via `GetCurrentUserId()`) returning `{ rating, stars }` with `stars = Helpers.MapRating(rating)`; null-body success for missing/non-positive TMDb ID, unresolved items, or no stored rating
-- [ ] 1.4 Controller tests in `LetterboxdSync.Tests` (style of `RatedFilmsApiTests.cs`) covering: rated movie (7 → 3.5), unrated movie, unknown/missing TMDb ID, episode rating, show-level rating, episode-requested-but-unrated, and unauthenticated rejection
+- [x] 1.4 Controller tests in `LetterboxdSync.Tests` (style of `RatedFilmsApiTests.cs`) covering: rated movie (7 → 3.5), unrated movie, unknown/missing TMDb ID, episode rating, show-level rating, episode-requested-but-unrated, and unauthenticated rejection
 
 ## 2. Half-star widget
 
-- [ ] 2.1 Rework the star widget in `Web/configPage.html` to half-star granularity: left/right half click zones per star, CSS-clipped half-fill rendering, label showing e.g. "3.5 / 5"
-- [ ] 2.2 Apply the identical widget block to `Web/userPage.html` (keep the two copies byte-identical)
-- [ ] 2.3 Verify posting paths with half values: Letterboxd payload carries 3.5 as-is; Serializd payload doubles to 7 via the existing `Math.round(rating * 2)`
+- [x] 2.1 Rework the star widget in `Web/configPage.html` to half-star granularity: left/right half click zones per star, CSS-clipped half-fill rendering, label showing e.g. "3.5 / 5"
+- [x] 2.2 Apply the identical widget block to `Web/userPage.html` (keep the two copies byte-identical)
+- [x] 2.3 Verify posting paths with half values: Letterboxd payload carries 3.5 as-is; Serializd payload doubles to 7 via the existing `Math.round(rating * 2)`
 
 ## 3. Modal pre-fill
 
-- [ ] 3.1 In `openReview` (both pages): after the synchronous reset, fetch `ItemRating` with `tmdbId` (+ season/episode for the Serializd path), and on a non-null `stars` paint the widget and label; skip the fetch when `tmdbId` is 0/absent
-- [ ] 3.2 Fail-soft behavior: any fetch error or null response leaves the widget at "No rating" with the modal fully usable; no user-visible error
+- [x] 3.1 In `openReview` (both pages): after the synchronous reset, fetch `ItemRating` with `tmdbId` (+ season/episode for the Serializd path), and on a non-null `stars` paint the widget and label; skip the fetch when `tmdbId` is 0/absent
+- [x] 3.2 Fail-soft behavior: any fetch error or null response leaves the widget at "No rating" with the modal fully usable; no user-visible error
 - [ ] 3.3 Manual verification against a local Jellyfin (deploy via `./deploy.sh`): pre-fill for a rated movie, an unrated movie, a rated episode, and a slug-only history entry; confirm posting the pre-filled value writes through and `WriteJellyfinRating` round-trips
 
 ## 4. Release plumbing

--- a/openspec/changes/prefill-review-rating/tasks.md
+++ b/openspec/changes/prefill-review-rating/tasks.md
@@ -21,5 +21,5 @@
 
 ## 4. Release plumbing
 
-- [ ] 4.1 Bump `AssemblyVersion`/`FileVersion` (minor) in `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`
+- [x] 4.1 Bump `AssemblyVersion`/`FileVersion` (minor) in `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`
 - [x] 4.2 PR with Conventional Commits title (`feat:`), `## Release notes` paragraph (user-facing prose: review modal now shows your existing Jellyfin rating, and supports half stars), and matching `site/src/data/release-notes.ts` entry

--- a/openspec/changes/prefill-review-rating/tasks.md
+++ b/openspec/changes/prefill-review-rating/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: prefill-review-rating
+
+## 1. Backend endpoint
+
+- [x] 1.1 Extract the TMDb-ID → library-movie lookup from `WriteJellyfinRating` in `Api/LetterboxdController.cs` into a shared private helper used by both the writeback and the new read path
+- [x] 1.2 Add TV resolution helpers: series by TMDb provider ID, and episode by series + season/episode index, mirroring `SerializdSyncRunner`'s sourcing of episode vs show ratings
+- [x] 1.3 Add `GET Jellyfin.Plugin.LetterboxdSync/ItemRating` (authenticated, current user via `GetCurrentUserId()`) returning `{ rating, stars }` with `stars = Helpers.MapRating(rating)`; null-body success for missing/non-positive TMDb ID, unresolved items, or no stored rating
+- [ ] 1.4 Controller tests in `LetterboxdSync.Tests` (style of `RatedFilmsApiTests.cs`) covering: rated movie (7 → 3.5), unrated movie, unknown/missing TMDb ID, episode rating, show-level rating, episode-requested-but-unrated, and unauthenticated rejection
+
+## 2. Half-star widget
+
+- [ ] 2.1 Rework the star widget in `Web/configPage.html` to half-star granularity: left/right half click zones per star, CSS-clipped half-fill rendering, label showing e.g. "3.5 / 5"
+- [ ] 2.2 Apply the identical widget block to `Web/userPage.html` (keep the two copies byte-identical)
+- [ ] 2.3 Verify posting paths with half values: Letterboxd payload carries 3.5 as-is; Serializd payload doubles to 7 via the existing `Math.round(rating * 2)`
+
+## 3. Modal pre-fill
+
+- [ ] 3.1 In `openReview` (both pages): after the synchronous reset, fetch `ItemRating` with `tmdbId` (+ season/episode for the Serializd path), and on a non-null `stars` paint the widget and label; skip the fetch when `tmdbId` is 0/absent
+- [ ] 3.2 Fail-soft behavior: any fetch error or null response leaves the widget at "No rating" with the modal fully usable; no user-visible error
+- [ ] 3.3 Manual verification against a local Jellyfin (deploy via `./deploy.sh`): pre-fill for a rated movie, an unrated movie, a rated episode, and a slug-only history entry; confirm posting the pre-filled value writes through and `WriteJellyfinRating` round-trips
+
+## 4. Release plumbing
+
+- [ ] 4.1 Bump `AssemblyVersion`/`FileVersion` (minor) in `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`
+- [ ] 4.2 PR with Conventional Commits title (`feat:`), `## Release notes` paragraph (user-facing prose: review modal now shows your existing Jellyfin rating, and supports half stars), and matching `site/src/data/release-notes.ts` entry

--- a/openspec/changes/prefill-review-rating/tasks.md
+++ b/openspec/changes/prefill-review-rating/tasks.md
@@ -22,4 +22,4 @@
 ## 4. Release plumbing
 
 - [ ] 4.1 Bump `AssemblyVersion`/`FileVersion` (minor) in `Directory.Build.props` and `LetterboxdSync/LetterboxdSync.csproj`
-- [ ] 4.2 PR with Conventional Commits title (`feat:`), `## Release notes` paragraph (user-facing prose: review modal now shows your existing Jellyfin rating, and supports half stars), and matching `site/src/data/release-notes.ts` entry
+- [x] 4.2 PR with Conventional Commits title (`feat:`), `## Release notes` paragraph (user-facing prose: review modal now shows your existing Jellyfin rating, and supports half stars), and matching `site/src/data/release-notes.ts` entry

--- a/openspec/changes/prefill-review-rating/tasks.md
+++ b/openspec/changes/prefill-review-rating/tasks.md
@@ -17,7 +17,7 @@
 
 - [x] 3.1 In `openReview` (both pages): after the synchronous reset, fetch `ItemRating` with `tmdbId` (+ season/episode for the Serializd path), and on a non-null `stars` paint the widget and label; skip the fetch when `tmdbId` is 0/absent
 - [x] 3.2 Fail-soft behavior: any fetch error or null response leaves the widget at "No rating" with the modal fully usable; no user-visible error
-- [ ] 3.3 Manual verification against a local Jellyfin (deploy via `./deploy.sh`): pre-fill for a rated movie, an unrated movie, a rated episode, and a slug-only history entry; confirm posting the pre-filled value writes through and `WriteJellyfinRating` round-trips
+- [x] 3.3 Manual verification against a local Jellyfin (deploy via `./deploy.sh`): pre-fill for a rated movie, an unrated movie, a rated episode, and a slug-only history entry; confirm posting the pre-filled value writes through and `WriteJellyfinRating` round-trips
 
 ## 4. Release plumbing
 

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '2.2.0',
+    headline: 'The review modal now shows the rating you already gave, and stars come in halves',
+    summary:
+      'Opening the review modal used to always start at "No rating", even when Jellyfin already knew exactly what you\'d rated the film or episode, whether you rated it in the Jellyfin web UI, a client app like Infuse, or through an earlier Jellyscribe review. Now the modal looks up your stored rating and pre-fills the stars, so you\'re editing your rating rather than re-entering it. The star widget also finally does half stars: click the left half of a star for a .5 rating, matching what Letterboxd itself supports. Ratings on Jellyfin\'s 10-point scale (like a 7/10) now display faithfully as 3.5 stars instead of not showing at all.',
+    highlights: {
+      new: [
+        'The review modal pre-fills its stars from the rating already stored in Jellyfin, for films, shows, and individual episodes, whichever app you rated them in.',
+        'Half-star ratings: click the left half of a star for .5 increments, on both the admin dashboard and the user page. Letterboxd reviews carry the half star as-is; Serializd reviews map it onto the 10-point scale.',
+      ],
+    },
+  },
+  {
     version: '2.1.2',
     headline: 'Sidebar link now reliably survives a Jellyfin restart',
     summary:


### PR DESCRIPTION
No linked issue. (User report: ratings set in other Jellyfin clients, e.g. Infuse, never appear in the review modal.)

## Release notes

The review modal now shows the rating you already gave. Instead of always opening at "No rating", it looks up the rating stored in Jellyfin, whether you set it in the Jellyfin web UI, a client app like Infuse, or an earlier Jellyscribe review, and pre-fills the stars for you, for films, shows, and individual episodes. The star widget also supports half stars now: click the left half of a star for a .5 rating, matching what Letterboxd itself accepts, so a 7/10 in Jellyfin finally displays as the 3.5 stars it really is.

## What's broken

A user rates a film in Infuse (or any Jellyfin client), then opens Jellyscribe's review modal for that film: the stars sit at "No rating" and they have to re-enter a rating the server already knows. Rating flow was one-way: posting a review wrote the rating into Jellyfin, but nothing ever read it back. On top of that the star widget only did whole stars, so Jellyfin's 10-point scale couldn't even be represented faithfully.

## Why it happens

1. The review modal reset its star widget unconditionally on open; there was no endpoint that exposed the caller's stored rating, so the pages had nothing to fetch.
2. The widget's five spans only carried whole-number values, so half of Jellyfin's 1-10 scale had no visual representation.

## What this PR does

- Adds a read-only `GET ItemRating` endpoint to `LetterboxdController` that returns the calling user's stored rating (raw 1-10 plus its half-star mapping) resolved by TMDb id: movies directly, TV via the series, or a single episode when season/episode numbers are supplied. Anything unresolvable returns nulls with 200, never an error. The TMDb movie lookup that already existed inside the rating writeback is extracted and shared so read and write paths can't drift.
- Reworks the star widget in both `configPage.html` and `userPage.html` to half-star granularity: left/right click zones per star, a width-clipped overlay for the half fill, and a single `paintStars` writer used by click, reset, and pre-fill. The widget block is kept identical across both pages.
- `openReview` now fetches `ItemRating` after opening and paints the stars if a rating comes back; any error leaves "No rating" exactly as before, and a sequence token discards late responses if another modal was opened meanwhile.
- Letterboxd review posts carry half values as-is; Serializd posts keep their existing doubling onto the 10-point scale.
- Deliberately NOT touched: updating already-posted Letterboxd diary entries when a rating arrives after the watch synced. That needs new service surface in both the API client and the scraping fallback and is tracked as a follow-up (`openspec/changes/prefill-review-rating/` non-goals).

## How to test

- `dotnet test -c Release --filter "FullyQualifiedName~ItemRatingApiTests"` (10 tests: rated/unrated movie, missing/unknown TMDb id, episode vs show ratings, episode-unrated fallthrough, unauthenticated rejection). Full unit suite passes (819).
- Manual: rate a movie in the Jellyfin web UI or a client app, open its Review button in the dashboard activity list, and the stars should show that rating; an unrated title should still open at "No rating". Clicking the left half of any star selects the .5 value.

## Follow-ups (not in this PR)

- Late-arriving ratings: update a recently synced Letterboxd diary entry when the user rates the film afterwards (own OpenSpec change; needs new `ILetterboxdService` surface).
- Visual-harness baselines have pre-existing drift unrelated to this branch (identical diffs with these changes stashed); to be rebaselined separately.
