### PR TITLE
fix: skip syncing manually-watched items with an epoch LastPlayedDate

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>1.20.0.0</Version>
-        <AssemblyVersion>2.3.0.0</AssemblyVersion>
-        <FileVersion>2.3.0.0</FileVersion>
+        <AssemblyVersion>2.3.1.0</AssemblyVersion>
+        <FileVersion>2.3.1.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/LetterboxdSync.Tests/HelpersAdditionalTests.cs
+++ b/LetterboxdSync.Tests/HelpersAdditionalTests.cs
@@ -91,6 +91,28 @@ public class HelpersAdditionalTests
     }
 
     [Fact]
+    public void HasPlausibleWatchDate_Null_False()
+    {
+        Assert.False(Helpers.HasPlausibleWatchDate(null));
+    }
+
+    [Fact]
+    public void HasPlausibleWatchDate_UnixEpoch_False()
+    {
+        // issue #106: manually marking watched can leave LastPlayedDate at an
+        // epoch-adjacent value instead of null.
+        Assert.False(Helpers.HasPlausibleWatchDate(new DateTime(1970, 1, 1)));
+        Assert.False(Helpers.HasPlausibleWatchDate(DateTime.UnixEpoch));
+    }
+
+    [Fact]
+    public void HasPlausibleWatchDate_RealWatchDate_True()
+    {
+        Assert.True(Helpers.HasPlausibleWatchDate(DateTime.Today));
+        Assert.True(Helpers.HasPlausibleWatchDate(new DateTime(1971, 1, 1)));
+    }
+
+    [Fact]
     public void ParseDiaryDates_EmptyHtml_ReturnsEmpty()
     {
         Assert.Empty(Helpers.ParseDiaryDates("<html></html>"));

--- a/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
+++ b/LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs
@@ -436,6 +436,45 @@ public class LetterboxdSyncRunnerTests : IDisposable
         Assert.False(factoryHit);
     }
 
+    // ----- Epoch LastPlayedDate suppression (issue #106) -----
+
+    [Fact]
+    public async Task TryRunForUserAsync_ManuallyMarkedPlayedWithEpochLastPlayedDate_DoesNotExportToLetterboxd()
+    {
+        // The bug: marking a film watched via the Jellyfin checkmark (rather than real
+        // playback) can leave LastPlayedDate set to an epoch-adjacent value like 1970-01-01
+        // instead of null, which slips past a plain HasValue check and gets logged to
+        // Letterboxd as "seen on 1970-01-01".
+        var (user, userId) = MakeUser("lachlan");
+        _userManager.GetUsers().Returns(new[] { user });
+        AddAccount(userId);
+
+        var movie = MakeMovie(1233413);
+        _libraryManager.GetItemList(Arg.Any<InternalItemsQuery>()).Returns(new List<BaseItem> { movie });
+
+        var manuallyMarkedUserData = new UserItemData
+        {
+            Key = "k",
+            Played = true,
+            LastPlayedDate = new DateTime(1970, 1, 1)
+        };
+        _userDataManager.GetUserData(user, movie).Returns(manuallyMarkedUserData);
+
+        var factoryHit = false;
+        LetterboxdServiceFactory.OverrideForTesting = (_, _, _, _, _) =>
+        {
+            factoryHit = true;
+            return Task.FromResult(Substitute.For<ILetterboxdService>());
+        };
+
+        var ok = await _runner.TryRunForUserAsync(userId, "scheduled",
+            new Progress<double>(), CancellationToken.None);
+
+        Assert.True(ok);
+        // Filter eliminated the only candidate, so the runner exits before authenticating.
+        Assert.False(factoryHit);
+    }
+
     [Fact]
     public async Task TryRunForUserAsync_DiaryImportedFilmThenActuallyPlayed_StillExportsToLetterboxd()
     {

--- a/LetterboxdSync.Tests/Serializd/SerializdSyncRunnerCatchUpTests.cs
+++ b/LetterboxdSync.Tests/Serializd/SerializdSyncRunnerCatchUpTests.cs
@@ -142,6 +142,26 @@ public class SerializdSyncRunnerCatchUpTests : IDisposable
     }
 
     [Fact]
+    public async Task Run_EpisodePlayedWithEpochLastPlayedDate_NeverLogged()
+    {
+        // A manual checkmark can leave LastPlayedDate at an epoch-adjacent value like
+        // 1970-01-01 instead of null (issue #106). That's non-null, so it must not slip
+        // past the guard that also catches the null case above.
+        var (user, idHex) = AddUserWithAccount();
+        var ep = MakeEpisode(1, 3);
+        LibraryHas(ep);
+        _userDataManager.GetUserData(user, ep).Returns(MakeUserData(new DateTime(1970, 1, 1)));
+        var service = FakeService(out var logged);
+
+        await _runner.RunForAllAsync(new Progress<double>(), "test", CancellationToken.None);
+
+        Assert.Empty(logged);
+        await service.DidNotReceive().CreateEpisodeLogAsync(
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<DateTime>(), Arg.Any<int?>(), Arg.Any<bool>());
+        Assert.False(SerializdSyncHistory.Has(idHex, "user@example.com", ShowTmdbId, 1, 3, SerializdSyncHistory.KindLog));
+    }
+
+    [Fact]
     public async Task Run_EpisodePlayedWithLastPlayedDate_LoggedOnce()
     {
         var (user, idHex) = AddUserWithAccount();

--- a/LetterboxdSync/Helpers.cs
+++ b/LetterboxdSync/Helpers.cs
@@ -104,4 +104,19 @@ public static class Helpers
 
         return lastDiaryDate.Value.Date == viewingDate.Date;
     }
+
+    // Some clients send an explicit but bogus datePlayed (e.g. an uninitialized JS Date
+    // defaulting to epoch) when marking an item watched manually without a real timestamp.
+    // That leaves LastPlayedDate non-null, so it slips past a plain HasValue check. No real
+    // Jellyfin server predates this floor, so anything at or before it isn't a genuine watch.
+    private static readonly DateTime EpochFloor = new(1971, 1, 1);
+
+    /// <summary>
+    /// Whether a Jellyfin LastPlayedDate looks like a genuine watch instant rather than a
+    /// missing or degenerate one (null, or epoch-adjacent e.g. 1970-01-01, see issue #106).
+    /// </summary>
+    public static bool HasPlausibleWatchDate(DateTime? lastPlayedDate)
+    {
+        return lastPlayedDate.HasValue && lastPlayedDate.Value >= EpochFloor;
+    }
 }

--- a/LetterboxdSync/LetterboxdSync.csproj
+++ b/LetterboxdSync/LetterboxdSync.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <AssemblyVersion>2.3.1.0</AssemblyVersion>
+    <FileVersion>2.3.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LetterboxdSync/LetterboxdSyncRunner.cs
+++ b/LetterboxdSync/LetterboxdSyncRunner.cs
@@ -192,24 +192,27 @@ public class LetterboxdSyncRunner
             return;
         }
 
-        // Skip films marked played on Jellyfin that have no LastPlayedDate. There's no real
-        // watch date to log: viewingDate would otherwise fall back to DateTime.Now (today),
-        // which drifts forward on every run and slips past every same-date duplicate check,
-        // posting a phantom rewatch to Letterboxd roughly every other day. Wait until Jellyfin
-        // records an actual play date. This also closes the import-then-export loop from
-        // issue #32, DiaryImportTask marks films played without a LastPlayedDate.
+        // Skip films marked played on Jellyfin with no plausible LastPlayedDate: either
+        // missing entirely, or an epoch-adjacent value (e.g. 1970-01-01) some clients send
+        // when marking an item watched manually without a real timestamp (issue #106). In
+        // either case there's no real watch date to log: viewingDate would otherwise fall
+        // back to DateTime.Now (today) or literally 1970, which drifts forward on every run
+        // and slips past every same-date duplicate check, posting a phantom rewatch to
+        // Letterboxd roughly every other day. Wait until Jellyfin records an actual play
+        // date. This also closes the import-then-export loop from issue #32, DiaryImportTask
+        // marks films played without a LastPlayedDate.
         var skippedNoPlayDate = 0;
         movies = movies.Where(m =>
         {
             var ud = _userDataManager.GetUserData(user, m);
-            if (ud?.LastPlayedDate.HasValue == true) return true;
+            if (Helpers.HasPlausibleWatchDate(ud?.LastPlayedDate)) return true;
             skippedNoPlayDate++;
             return false;
         }).ToList();
 
         if (skippedNoPlayDate > 0)
             _logger.LogInformation(
-                "Skipping {Count} films for {Username}: marked played but no LastPlayedDate (no real watch date to log)",
+                "Skipping {Count} films for {Username}: marked played but no plausible LastPlayedDate (no real watch date to log)",
                 skippedNoPlayDate, user.Username);
 
         if (movies.Count == 0)

--- a/LetterboxdSync/Serializd/SerializdSyncRunner.cs
+++ b/LetterboxdSync/Serializd/SerializdSyncRunner.cs
@@ -181,12 +181,15 @@ public class SerializdSyncRunner
 
             var ud = _userDataManager.GetUserData(user, ep);
 
-            // Skip episodes marked played on Jellyfin with no LastPlayedDate. There's no real
-            // watch date to log: watchedAt would otherwise fall back to DateTime.UtcNow (today),
-            // which drifts forward on every run and re-logs the same episode every catch-up.
-            // This is also the import-then-export loop guard: SerializdDiaryImportRunner marks
-            // episodes played without a LastPlayedDate specifically so they land here.
-            if (ud?.LastPlayedDate.HasValue != true)
+            // Skip episodes marked played on Jellyfin with no plausible LastPlayedDate: either
+            // missing entirely, or an epoch-adjacent value (e.g. 1970-01-01) some clients send
+            // when marking an item watched manually without a real timestamp (issue #106).
+            // There's no real watch date to log: watchedAt would otherwise fall back to
+            // DateTime.UtcNow (today) or literally 1970, which drifts forward on every run and
+            // re-logs the same episode every catch-up. This is also the import-then-export loop
+            // guard: SerializdDiaryImportRunner marks episodes played without a LastPlayedDate
+            // specifically so they land here.
+            if (ud is null || !Helpers.HasPlausibleWatchDate(ud.LastPlayedDate))
             {
                 skippedNoPlayDate++;
                 continue;
@@ -205,7 +208,7 @@ public class SerializdSyncRunner
 
         if (skippedNoPlayDate > 0)
             _logger.LogInformation(
-                "Serializd catch-up: skipping {Count} episodes for {Username}: marked played but no LastPlayedDate (no real watch date to log)",
+                "Serializd catch-up: skipping {Count} episodes for {Username}: marked played but no plausible LastPlayedDate (no real watch date to log)",
                 skippedNoPlayDate, user.Username);
 
         // Date filter: limit the catch-up to episodes watched within the look-back window.

--- a/site/src/data/release-notes.ts
+++ b/site/src/data/release-notes.ts
@@ -10,6 +10,18 @@ export type ReleaseNotes = {
 
 export const releaseNotes: ReleaseNotes[] = [
   {
+    version: '2.3.1',
+    headline: 'Manually marking something watched no longer logs it to 1970',
+    summary:
+      'Films and episodes that Jellyfin marks watched through real playback have always synced with the correct date. But checking a title watched by hand, using the checkmark rather than actually playing it, could leave Jellyfin\'s own watched-date field set to January 1st 1970 instead of a real date, and the plugin trusted that value as-is. The fix treats an epoch-adjacent watched date the same way it already treats a missing one: there\'s no real watch date to log yet, so the sync waits rather than posting a bogus entry to Letterboxd or Serializd. Once Jellyfin records an actual playback date for the title, it syncs normally.',
+    highlights: {
+      fixes: [
+        'Manually marking a film or episode watched no longer risks logging it to Letterboxd or Serializd with a "seen on 1970-01-01" date.',
+        'Titles affected by this are simply skipped (not synced with a fabricated date) until Jellyfin records a real watch date, matching how the plugin already handles a missing watched date.',
+      ],
+    },
+  },
+  {
     version: '2.3.0',
     headline: 'Broken Letterboxd logins now pause themselves and tell you about it',
     summary:


### PR DESCRIPTION
Closes #106.

## Release notes

Films and episodes that Jellyfin marks watched through real playback have always synced with the correct date. But checking a title watched by hand, using the checkmark rather than actually playing it, could leave Jellyfin's own watched-date field set to January 1st 1970 instead of a real date, and the plugin trusted that value as-is. The fix treats an epoch-adjacent watched date the same way it already treats a missing one: there's no real watch date to log yet, so the sync waits rather than posting a bogus entry to Letterboxd or Serializd. Once Jellyfin records an actual playback date for the title, it syncs normally.

## What's broken

Reported in #106: marking a movie watched automatically (playback reaching the end) syncs to Letterboxd with the right date. Marking it watched manually with the checkmark icon instead logs it to Letterboxd as seen on 1970-01-01.

## Why it happens

1. Jellyfin's own `LastPlayedDate` field is what the plugin reads as the watch date. A real playback completion always sets it to a sensible timestamp.
2. Marking an item watched by hand (no playback involved) can leave `LastPlayedDate` set to an epoch-adjacent value (1970-01-01) rather than left empty. The plugin already had a guard from issues #32/#55 that skips syncing when this field is *missing* entirely (to avoid inventing a watch date and creating phantom rewatch entries), but that guard only checked "is there a value at all", not "is the value plausible". An epoch timestamp has a value, so it sailed straight through and got logged as a real watch date.

## What this PR does

- Adds `Helpers.HasPlausibleWatchDate(DateTime?)`: true only when the date is present *and* not at or before an epoch floor (1971-01-01, with a little slack for timezone conversion).
- `LetterboxdSyncRunner` and `SerializdSyncRunner` now use this helper in the existing "no real watch date, skip and log" guard, instead of a plain `HasValue` check.
- Deliberately does **not** default to today's date (the fix the issue reporter suggested) — that was the exact bug #32/#55 already fixed: a "default to now" fallback drifts forward on every scheduled run and creates phantom rewatch entries every time it runs for the same title. Skipping and waiting for a real date is consistent with how the plugin already handles the missing-date case.

## How to test

- `LetterboxdSync.Tests/HelpersAdditionalTests.cs`: `HasPlausibleWatchDate_*` unit tests, run with `dotnet test --filter "FullyQualifiedName~HasPlausibleWatchDate"`.
- `LetterboxdSync.Tests/LetterboxdSyncRunnerTests.cs`: `TryRunForUserAsync_ManuallyMarkedPlayedWithEpochLastPlayedDate_DoesNotExportToLetterboxd`.
- `LetterboxdSync.Tests/Serializd/SerializdSyncRunnerCatchUpTests.cs`: `Run_EpisodePlayedWithEpochLastPlayedDate_NeverLogged`.
- Manual check: mark a never-played movie watched via the Jellyfin checkmark (not playback), run the scheduled sync, confirm it's skipped with a log line rather than appearing on Letterboxd with a 1970 date; then actually play it to completion and confirm it syncs with today's date.

## Follow-ups (not in this PR)

- None identified; this closes the gap left by #32/#55 for the specific epoch-value case.
